### PR TITLE
feat: add Docker Quick Start Guide and docker-compose configuration

### DIFF
--- a/DOCKER-QUICKSTART.md
+++ b/DOCKER-QUICKSTART.md
@@ -1,0 +1,102 @@
+# Docker Quick Start Guide for Masumi Payment Service
+
+This guide will help you quickly deploy Masumi Payment Service using Docker Compose.
+
+## Prerequisites
+
+- Docker and Docker Compose installed on your machine
+- [Blockfrost.io](https://blockfrost.io) account for Cardano blockchain API access
+- Basic understanding of command line operations
+
+## Quick Start
+
+1. **Configure Environment Variables**
+
+   Copy the included `.env` file and update the required values:
+
+   ```
+   # At minimum, update these values
+   POSTGRES_PASSWORD=your_secure_postgres_password
+   ENCRYPTION_KEY=your_secure_32_character_encryption_key (must be at least 32 chars)
+   ADMIN_KEY=your_secure_admin_key
+   BLOCKFROST_API_KEY_PREPROD=your_blockfrost_preprod_api_key
+   ```
+
+2. **Start the Services**
+
+   Run the following command in the same directory as your `docker-compose.yml`:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+3. **Access the Service**
+
+   Once running, access:
+   - Admin Dashboard: http://localhost:3001/admin
+   - API Documentation: http://localhost:3001/docs
+
+4. **Set Up Your Wallets**
+
+   The system will generate new wallets on first run if none are provided in your environment variables.
+   Make sure to back up the generated wallet mnemonics from the admin interface!
+
+## Data Persistence
+
+The Docker setup includes three persistent volumes:
+
+- `postgres_data`: Stores PostgreSQL database files
+- `masumi_logs`: Stores application logs
+- `masumi_wallets`: Stores wallet-related information
+
+These volumes ensure your data persists across container restarts.
+
+## Common Operations
+
+- **Viewing logs**:
+  ```bash
+  docker-compose logs -f payment-service
+  ```
+
+- **Restart services**:
+  ```bash
+  docker-compose restart
+  ```
+
+- **Stop services**:
+  ```bash
+  docker-compose down
+  ```
+
+- **Complete teardown** (including volumes):
+  ```bash
+  docker-compose down -v
+  ```
+  Warning: This will delete all data, including database records and wallets.
+
+## Troubleshooting
+
+1. **Database connection issues**:
+   - Check `POSTGRES_PASSWORD` in `.env` file matches what's in the Docker configuration
+   - Ensure PostgreSQL container is running: `docker ps | grep postgres`
+
+2. **API Errors**:
+   - Verify your Blockfrost API key is valid for the selected network
+   - Check logs for specific error messages: `docker-compose logs payment-service`
+
+3. **Wallet issues**:
+   - For testing on Preprod, ensure your wallets have test ADA (use faucets)
+   - If using custom wallet mnemonics, ensure they are correctly formatted
+
+## Getting Test ADA
+
+For Preprod, get free test ADA from [Cardano Testnet Faucet](https://docs.cardano.org/cardano-testnets/tools/faucet).
+
+## Next Steps
+
+1. Review the security of your wallets and funds
+2. Connect your CrewAI or other agent framework to the Masumi payment infrastructure
+3. Consider registering your agent on the Masumi network
+
+For more detailed instructions, refer to the [official Masumi documentation](https://docs.masumi.network/).
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,101 @@
+services:
+  # PostgreSQL database service
+  postgres:
+    image: postgres:15-alpine
+    container_name: masumi-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: masumi_payment
+      POSTGRES_USER: masumi
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-masumi_secure_password}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U masumi -d masumi_payment"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - masumi-network
+
+  # Masumi Payment Service
+  payment-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: masumi-payment-service
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      # Database configuration
+      DATABASE_URL: postgresql://masumi:${POSTGRES_PASSWORD:-masumi_secure_password}@postgres:5432/masumi_payment?schema=public
+      SHADOW_DATABASE_URL: postgresql://masumi:${POSTGRES_PASSWORD:-masumi_secure_password}@postgres:5432/masumi_payment_shadow?schema=public
+      
+      # Port
+      PORT: 3001
+      
+      # Security keys - use .env file to override these
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change_this_to_a_secure_32_character_string}
+      ADMIN_KEY: ${ADMIN_KEY:-change_this_to_a_secure_string}
+      
+      # Blockfrost API keys
+      BLOCKFROST_API_KEY_PREPROD: ${BLOCKFROST_API_KEY_PREPROD}
+      BLOCKFROST_API_KEY_MAINNET: ${BLOCKFROST_API_KEY_MAINNET:-}
+      
+      # Environment settings
+      NODE_ENV: ${NODE_ENV:-production}
+      
+      # Default network setting (PREPROD or MAINNET)
+      DEFAULT_NETWORK: ${DEFAULT_NETWORK:-PREPROD}
+      
+      # Job intervals (in seconds)
+      BATCH_PAYMENT_INTERVAL: ${BATCH_PAYMENT_INTERVAL:-240}
+      CHECK_COLLECTION_INTERVAL: ${CHECK_COLLECTION_INTERVAL:-300}
+      CHECK_TX_INTERVAL: ${CHECK_TX_INTERVAL:-180}
+      CHECK_COLLECT_REFUND_INTERVAL: ${CHECK_COLLECT_REFUND_INTERVAL:-300}
+      CHECK_SET_REFUND_INTERVAL: ${CHECK_SET_REFUND_INTERVAL:-300}
+      CHECK_UNSET_REFUND_INTERVAL: ${CHECK_UNSET_REFUND_INTERVAL:-300}
+      CHECK_AUTHORIZE_REFUND_INTERVAL: ${CHECK_AUTHORIZE_REFUND_INTERVAL:-300}
+      CHECK_SUBMIT_RESULT_INTERVAL: ${CHECK_SUBMIT_RESULT_INTERVAL:-300}
+      CHECK_WALLET_TRANSACTION_HASH_INTERVAL: ${CHECK_WALLET_TRANSACTION_HASH_INTERVAL:-60}
+      REGISTER_AGENT_INTERVAL: ${REGISTER_AGENT_INTERVAL:-300}
+      DEREGISTER_AGENT_INTERVAL: ${DEREGISTER_AGENT_INTERVAL:-300}
+      
+      # Optional wallet configuration
+      PURCHASE_WALLET_PREPROD_MNEMONIC: ${PURCHASE_WALLET_PREPROD_MNEMONIC:-}
+      SELLING_WALLET_PREPROD_MNEMONIC: ${SELLING_WALLET_PREPROD_MNEMONIC:-}
+      COLLECTION_WALLET_PREPROD_ADDRESS: ${COLLECTION_WALLET_PREPROD_ADDRESS:-}
+      PURCHASE_WALLET_MAINNET_MNEMONIC: ${PURCHASE_WALLET_MAINNET_MNEMONIC:-}
+      SELLING_WALLET_MAINNET_MNEMONIC: ${SELLING_WALLET_MAINNET_MNEMONIC:-}
+      COLLECTION_WALLET_MAINNET_ADDRESS: ${COLLECTION_WALLET_MAINNET_ADDRESS:-}
+      
+    ports:
+      - "3001:3001"
+    volumes:
+      - masumi_logs:/usr/src/app/logs
+      - masumi_wallets:/usr/src/app/wallets
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - masumi-network
+    command: >
+      sh -c "npm run prisma:migrate && 
+             NODE_ENV=production node ./dist/index.js"
+
+networks:
+  masumi-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+    driver: local
+  masumi_logs:
+    driver: local
+  masumi_wallets:
+    driver: local
+


### PR DESCRIPTION
Purpose of this Pull Request -
[X] New feature

Overview of Changes -
This PR adds Docker Compose support to simplify deployment of the Masumi Payment Service. The changes include:

Added a comprehensive docker-compose.yml file that orchestrates both the PostgreSQL database and the payment service
Created a simplified .env template specifically for Docker deployments
Added a new DOCKER-QUICKSTART.md guide to help users get started with Docker

These changes make it significantly easier for developers to deploy and test the Masumi Payment Service by removing the manual setup steps for PostgreSQL, resolving environment configuration issues, and ensuring consistent deployment across different development environments.

Issue Addressed -
Addresses the need for streamlined local deployment as discussed in community feedback.
Checklist

-  I have used lint and format to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (added DOCKER-QUICKSTART.md).

Focus for Reviewers -
Please focus on:
The database connection configuration between the PostgreSQL and payment service containers
The proper ordering of commands in the payment service startup (migrations before application start)
Volume configuration for data persistence
Environment variable handling, particularly security-sensitive values
Any potential security concerns with the Docker setup

Note: The PR intentionally skips the database seeding step that was causing errors due to missing encryption module dependencies, instead relying on migrations to set up the schema.