### PR TITLE
feat: add 250 char limit to agent description

### DIFF
--- a/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
+++ b/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
@@ -69,7 +69,10 @@ const agentSchema = z.object({
       message: 'API URL must start with http:// or https://',
     }),
   name: z.string().min(1, 'Name is required'),
-  description: z.string().min(1, 'Description is required'),
+  description: z
+    .string()
+    .min(1, 'Description is required')
+    .max(250, 'Description must be less than 250 characters'),
   selectedWallet: z.string().min(1, 'Wallet is required'),
   prices: z.array(priceSchema).min(1, 'At least one price is required'),
   tags: z.array(z.string().min(1)).min(1, 'At least one tag is required'),
@@ -261,9 +264,9 @@ export function RegisterAIAgentDialog({
         const capability =
           data.capabilityName && data.capabilityVersion
             ? {
-              name: data.capabilityName,
-              version: data.capabilityVersion,
-            }
+                name: data.capabilityName,
+                version: data.capabilityVersion,
+              }
             : { name: 'Custom Agent', version: '1.0.0' };
 
         const response = await postRegistry({
@@ -377,12 +380,18 @@ export function RegisterAIAgentDialog({
             <label className="text-sm font-medium">
               Description <span className="text-red-500">*</span>
             </label>
-            <Textarea
-              {...register('description')}
-              placeholder="Describe what your agent does"
-              rows={3}
-              className={errors.description ? 'border-red-500' : ''}
-            />
+            <div className="relative">
+              <Textarea
+                {...register('description')}
+                placeholder="Describe what your agent does"
+                rows={3}
+                className={errors.description ? 'border-red-500' : ''}
+                maxLength={250}
+              />
+              <div className="absolute bottom-2 right-2 text-xs text-muted-foreground">
+                {watch('description')?.length || 0}/250
+              </div>
+            </div>
             {errors.description && (
               <p className="text-sm text-red-500">
                 {errors.description.message}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**

Added a 250 character limit to the description field in the Register AI Agent dialog to prevent users from entering overly long descriptions. This includes:

- Added 250 character limit validation in the Zod schema for the description field
- Implemented real-time character counter (X/250) displayed in the bottom-right corner of the textarea
- Added `maxLength` attribute to prevent users from typing beyond 250 characters
- Enhanced user experience with visual feedback on character count

## **Issue Addressed**
Closes DEV-320
Fixes the requirement to limit description entry to 250 characters in the AI Agent registration form.

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- [X] I have used `lint` and `format` to follow the code formatting
- [X] I have tested my changes locally and all of them pass
- [X] I have updated documentation (if applicable).

## **Focus for Reviewers**

Please review the character counter implementation and ensure the 250 character limit is appropriate for the description field. The validation is enforced both at the UI level (maxLength attribute) and at the schema level (Zod validation).