### PR TITLE
Fix:  add DefaultAdminKey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,6 @@ AUTO_WITHDRAW_PAYMENTS="true" #should payments be automatically withdrawn after 
 AUTO_WITHDRAW_REFUNDS="true" #should refunds be automatically withdrawn. If not set to false. Defaults to true
 
 #The following data is only needed while seeding
-DEFAULT_ADMIN_KEY="DefaultAdminKey"  #This is the Default Admin Key.
 ADMIN_KEY="abcdef_this_should_be_very_secure" #The key of the admin user, this key will have all permissions, like doing payments, changing configurations and can also be used to create new (more limited) api_keys
 SEED_ONLY_IF_EMPTY=True #***Optionally*** Will skip seeding if there are entries in the db
 

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ AUTO_WITHDRAW_PAYMENTS="true" #should payments be automatically withdrawn after 
 AUTO_WITHDRAW_REFUNDS="true" #should refunds be automatically withdrawn. If not set to false. Defaults to true
 
 #The following data is only needed while seeding
+DEFAULT_ADMIN_KEY="DefaultAdminKey"  #This is the Default Admin Key.
 ADMIN_KEY="abcdef_this_should_be_very_secure" #The key of the admin user, this key will have all permissions, like doing payments, changing configurations and can also be used to create new (more limited) api_keys
 SEED_ONLY_IF_EMPTY=True #***Optionally*** Will skip seeding if there are entries in the db
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -27,6 +27,9 @@ dotenv.config();
 const prisma = new PrismaClient();
 export const seed = async (prisma: PrismaClient) => {
   const seedOnlyIfEmpty = process.env.SEED_ONLY_IF_EMPTY;
+  console.warn(
+    'WARNING: If no ADMIN_KEY is set, a default insecure key will be used.',
+  );
   if (seedOnlyIfEmpty?.toLowerCase() === 'true') {
     const adminKey = await prisma.apiKey.findFirst({});
     if (adminKey) {
@@ -38,7 +41,7 @@ export const seed = async (prisma: PrismaClient) => {
   let usedDefaultAdminKey = false;
 
   if (!adminKey) {
-    adminKey = process.env.DEFAULT_ADMIN_KEY;
+    adminKey = 'DefaultUnsecureAdminKey';
     usedDefaultAdminKey = true;
 
     console.warn('****************************************************');

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -27,9 +27,7 @@ dotenv.config();
 const prisma = new PrismaClient();
 export const seed = async (prisma: PrismaClient) => {
   const seedOnlyIfEmpty = process.env.SEED_ONLY_IF_EMPTY;
-  console.warn(
-    'WARNING: If no ADMIN_KEY is set, a default insecure key will be used.',
-  );
+
   if (seedOnlyIfEmpty?.toLowerCase() === 'true') {
     const adminKey = await prisma.apiKey.findFirst({});
     if (adminKey) {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -34,34 +34,44 @@ export const seed = async (prisma: PrismaClient) => {
       return;
     }
   }
-  const adminKey = process.env.ADMIN_KEY;
-  if (adminKey != null) {
-    if (adminKey.length < 15) {
-      console.error(
-        'ADMIN_KEY is insecure, ensure it is at least 15 characters long',
-      );
-      throw Error('API-KEY is insecure');
-    }
+  let adminKey = process.env.ADMIN_KEY;
+  let usedDefaultAdminKey = false;
 
-    await prisma.apiKey.upsert({
-      create: {
-        token: adminKey,
-        tokenHash: generateHash(adminKey),
-        permission: Permission.Admin,
-        status: ApiKeyStatus.Active,
-      },
-      update: {
-        token: adminKey,
-        tokenHash: generateHash(adminKey),
-        permission: Permission.Admin,
-        status: ApiKeyStatus.Active,
-      },
-      where: { token: adminKey },
-    });
+  if (!adminKey) {
+    adminKey = process.env.DEFAULT_ADMIN_KEY;
+    usedDefaultAdminKey = true;
 
-    console.log('ADMIN_KEY seeded');
+    console.warn('****************************************************');
+    console.warn('**  WARNING: Using DEFAULT ADMIN_KEY for seeding!  **');
+    console.warn('**  This is INSECURE. Set ADMIN_KEY in your .env!  **');
+    console.warn('****************************************************');
+  }
+  if (!adminKey || adminKey.length < 15) {
+    console.error(
+      'ADMIN_KEY is insecure, ensure it is at least 15 characters long',
+    );
+    throw Error('API-KEY is insecure');
+  }
+
+  await prisma.apiKey.upsert({
+    create: {
+      token: adminKey,
+      tokenHash: generateHash(adminKey),
+      permission: Permission.Admin,
+      status: ApiKeyStatus.Active,
+    },
+    update: {
+      token: adminKey,
+      tokenHash: generateHash(adminKey),
+      permission: Permission.Admin,
+      status: ApiKeyStatus.Active,
+    },
+    where: { token: adminKey },
+  });
+  if (usedDefaultAdminKey) {
+    console.log('Seeded with DEFAULT_ADMIN_KEY');
   } else {
-    console.log('ADMIN_KEY is not seeded. Provide ADMIN_KEY in .env');
+    console.log('ADMIN_KEY seeded successfully');
   }
 
   let collectionWalletPreprodAddress: string | null | undefined =

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -41,7 +41,7 @@ export const seed = async (prisma: PrismaClient) => {
   let usedDefaultAdminKey = false;
 
   if (!adminKey) {
-    adminKey = 'DefaultUnsecureAdminKey';
+    adminKey = DEFAULTS.DEFAULT_ADMIN_KEY;
     usedDefaultAdminKey = true;
 
     console.warn('****************************************************');

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const __dirname = path.resolve();
 
 async function initialize() {
   await initDB();
-  const defaultKey = await prisma.apiKey.findFirst({
+  const defaultKey = await prisma.apiKey.findUnique({
     where: {
       token: DEFAULTS.DEFAULT_ADMIN_KEY,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,30 @@ import fs from 'fs';
 const __dirname = path.resolve();
 
 async function initialize() {
+  //Checking for default AdminKey if not than log warning
+  let adminKey = process.env.ADMIN_KEY;
+  if (!adminKey) {
+    adminKey = 'DefaultUnsecureAdminKey';
+    logger.warn(
+      '*****************************************************************',
+    );
+    logger.warn(
+      '*                                                               *',
+    );
+    logger.warn('*  WARNING:  Missing, or DEFAULT ADMIN_KEY detected.   *');
+    logger.warn(
+      '*  For production, generate a secure, random key and set it     *',
+    );
+    logger.warn(
+      '*  as the ADMIN_KEY in your .env file.                          *',
+    );
+    logger.warn(
+      '*                                                               *',
+    );
+    logger.warn(
+      '*****************************************************************',
+    );
+  }
   await initDB();
   await initJobs();
   logger.info('Initialized all services');

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import ui, { JsonObject } from 'swagger-ui-express';
 import { generateOpenAPI } from '@/utils/generator/swagger-generator';
 import { cleanupDB, initDB, prisma } from '@/utils/db';
 import path from 'path';
+import { DEFAULTS } from './../src/utils/config';
 import { requestLogger } from '@/utils/middleware/request-logger';
 import fs from 'fs';
 
@@ -16,13 +17,12 @@ const __dirname = path.resolve();
 
 async function initialize() {
   await initDB();
-  const DEFAULT_ADMIN_KEY = 'DefaultUnsecureAdminKey';
-  const defaultkey = await prisma.apiKey.findFirst({
+  const defaultKey = await prisma.apiKey.findFirst({
     where: {
-      token: DEFAULT_ADMIN_KEY,
+      token: DEFAULTS.DEFAULT_ADMIN_KEY,
     },
   });
-  if (defaultkey) {
+  if (defaultKey) {
     logger.warn(
       '*****************************************************************',
     );
@@ -33,7 +33,7 @@ async function initialize() {
       '*  This is a security risk. For production environments, please *',
     );
     logger.warn(
-      '*  set a secure ADMIN_KEY in .env and re-seed the database.     *',
+      '*  set a secure ADMIN_KEY in .env and Please change it in the admin tool   *',
     );
     logger.warn(
       '*****************************************************************',

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,15 @@ async function initialize() {
       '*****************************************************************',
     );
     logger.warn(
-      '*  WARNING: The default insecure ADMIN_KEY is in use.           *',
+      '*  WARNING: The default insecure ADMIN_KEY "' +
+        DEFAULTS.DEFAULT_ADMIN_KEY +
+        '" is in use.           *',
     );
     logger.warn(
       '*  This is a security risk. For production environments, please *',
     );
     logger.warn(
-      '*  set a secure ADMIN_KEY in .env and Please change it in the admin tool   *',
+      '*  set a secure ADMIN_KEY in .env before seeding or change it in the admin tool now   *',
     );
     logger.warn(
       '*****************************************************************',

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -111,6 +111,7 @@ export const CONFIG = {
 };
 
 export const DEFAULTS = {
+  DEFAULT_ADMIN_KEY: 'DefaultUnsecureAdminKey',
   TX_TIMEOUT_INTERVAL: 1000 * 60 * 7, // 7 minutes in seconds
   LOCK_TIMEOUT_INTERVAL: 1000 * 60 * 3, // 3 minutes in seconds
   DEFAULT_METADATA_VERSION: 1,


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[] New feature  
[X] Other: Improvement -  Add Default_Admin_Key  =>  Add a default admin api key if none is set while seeding and also a big warning on startup if the default admin key is used

## **Overview of Changes**

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

Add a default admin api key if none is set while seeding and also a big warning on startup if the default admin key is used

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

check the file 
- env.example
- seed.ts      --> added Default_Admin_Key if none is set while seeding and also a big warning on startup if the default admin key is used


Linear issue  = https://linear.app/nmkr/issue/DEV-174/add-default-admin-key
