### PR TITLE
Fix/api key creation bug

### DIFF
--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 import { useState, useEffect } from 'react';
 import { useAppContext } from '@/lib/contexts/AppContext';
-import { postApiKey } from '@/lib/api/generated';
+import { postApiKey, getApiKeyStatus } from '@/lib/api/generated';
 import { toast } from 'react-toastify';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useForm, Controller } from 'react-hook-form';
@@ -65,6 +65,7 @@ export function AddApiKeyDialog({
   onSuccess,
 }: AddApiKeyDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
+  const [currentUserPermission, setCurrentUserPermission] = useState<'Read' | 'ReadAndPay' | 'Admin' | null>(null);
   const { apiClient } = useAppContext();
 
   const {
@@ -88,6 +89,38 @@ export function AddApiKeyDialog({
   const permission = watch('permission');
   const usageLimited = watch('usageLimited');
 
+  // Fetch current user's permission when dialog opens
+  useEffect(() => {
+    if (open) {
+      const fetchUserPermission = async () => {
+        try {
+          const response = await getApiKeyStatus({ client: apiClient });
+          if (response.data?.data?.permission) {
+            setCurrentUserPermission(response.data.data.permission);
+          }
+        } catch (error) {
+          console.error('Failed to fetch user permission:', error);
+          // Default to Read if we can't fetch permission
+          setCurrentUserPermission('Read');
+        }
+      };
+      fetchUserPermission();
+    }
+  }, [open, apiClient]);
+
+  // Adjust selected permission if user doesn't have required permissions
+  useEffect(() => {
+    if (currentUserPermission && permission) {
+      if (currentUserPermission === 'Read' && permission !== 'Read') {
+        setValue('permission', 'Read');
+        toast.warning('Your permission level only allows creating Read API keys');
+      } else if (currentUserPermission === 'ReadAndPay' && permission === 'Admin') {
+        setValue('permission', 'ReadAndPay');
+        toast.warning('Your permission level only allows creating Read and ReadAndPay API keys');
+      }
+    }
+  }, [currentUserPermission, permission, setValue]);
+
   useEffect(() => {
     if (permission === 'Admin') {
       setValue('usageLimited', false);
@@ -97,6 +130,16 @@ export function AddApiKeyDialog({
   }, [permission, setValue]);
 
   const onSubmit = async (data: ApiKeyFormValues) => {
+    // Additional permission validation before submission
+    if (currentUserPermission === 'Read' && data.permission !== 'Read') {
+      toast.error('You can only create Read API keys with your current permission level');
+      return;
+    }
+    if (currentUserPermission === 'ReadAndPay' && data.permission === 'Admin') {
+      toast.error('You can only create Read and ReadAndPay API keys with your current permission level');
+      return;
+    }
+
     try {
       setIsLoading(true);
       const isReadOnly = data.permission === 'Read';
@@ -162,6 +205,15 @@ export function AddApiKeyDialog({
         </DialogHeader>
 
         <div className="space-y-4">
+          {currentUserPermission && currentUserPermission !== 'Admin' && (
+            <div className="p-3 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+              <p className="text-sm text-blue-700 dark:text-blue-300">
+                <strong>Permission Notice:</strong> Your current permission level ({currentUserPermission}) limits the types of API keys you can create.
+                {currentUserPermission === 'Read' && ' You can only create Read API keys.'}
+                {currentUserPermission === 'ReadAndPay' && ' You can create Read and ReadAndPay API keys.'}
+              </p>
+            </div>
+          )}
           <div className="space-y-2">
             <label className="text-sm font-medium">Permission</label>
             <Controller
@@ -174,8 +226,18 @@ export function AddApiKeyDialog({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="Read">Read</SelectItem>
-                    <SelectItem value="ReadAndPay">Read and Pay</SelectItem>
-                    <SelectItem value="Admin">Admin</SelectItem>
+                    <SelectItem 
+                      value="ReadAndPay" 
+                      disabled={currentUserPermission === 'Read'}
+                    >
+                      Read and Pay
+                    </SelectItem>
+                    <SelectItem 
+                      value="Admin" 
+                      disabled={currentUserPermission !== 'Admin'}
+                    >
+                      Admin
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               )}

--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -65,7 +65,9 @@ export function AddApiKeyDialog({
   onSuccess,
 }: AddApiKeyDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
-  const [currentUserPermission, setCurrentUserPermission] = useState<'Read' | 'ReadAndPay' | 'Admin' | null>(null);
+  const [currentUserPermission, setCurrentUserPermission] = useState<
+    'Read' | 'ReadAndPay' | 'Admin' | null
+  >(null);
   const { apiClient } = useAppContext();
 
   const {
@@ -113,10 +115,17 @@ export function AddApiKeyDialog({
     if (currentUserPermission && permission) {
       if (currentUserPermission === 'Read' && permission !== 'Read') {
         setValue('permission', 'Read');
-        toast.warning('Your permission level only allows creating Read API keys');
-      } else if (currentUserPermission === 'ReadAndPay' && permission === 'Admin') {
+        toast.warning(
+          'Your permission level only allows creating Read API keys',
+        );
+      } else if (
+        currentUserPermission === 'ReadAndPay' &&
+        permission === 'Admin'
+      ) {
         setValue('permission', 'ReadAndPay');
-        toast.warning('Your permission level only allows creating Read and ReadAndPay API keys');
+        toast.warning(
+          'Your permission level only allows creating Read and ReadAndPay API keys',
+        );
       }
     }
   }, [currentUserPermission, permission, setValue]);
@@ -132,11 +141,15 @@ export function AddApiKeyDialog({
   const onSubmit = async (data: ApiKeyFormValues) => {
     // Additional permission validation before submission
     if (currentUserPermission === 'Read' && data.permission !== 'Read') {
-      toast.error('You can only create Read API keys with your current permission level');
+      toast.error(
+        'You can only create Read API keys with your current permission level',
+      );
       return;
     }
     if (currentUserPermission === 'ReadAndPay' && data.permission === 'Admin') {
-      toast.error('You can only create Read and ReadAndPay API keys with your current permission level');
+      toast.error(
+        'You can only create Read and ReadAndPay API keys with your current permission level',
+      );
       return;
     }
 
@@ -208,9 +221,13 @@ export function AddApiKeyDialog({
           {currentUserPermission && currentUserPermission !== 'Admin' && (
             <div className="p-3 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg">
               <p className="text-sm text-blue-700 dark:text-blue-300">
-                <strong>Permission Notice:</strong> Your current permission level ({currentUserPermission}) limits the types of API keys you can create.
-                {currentUserPermission === 'Read' && ' You can only create Read API keys.'}
-                {currentUserPermission === 'ReadAndPay' && ' You can create Read and ReadAndPay API keys.'}
+                <strong>Permission Notice:</strong> Your current permission
+                level ({currentUserPermission}) limits the types of API keys you
+                can create.
+                {currentUserPermission === 'Read' &&
+                  ' You can only create Read API keys.'}
+                {currentUserPermission === 'ReadAndPay' &&
+                  ' You can create Read and ReadAndPay API keys.'}
               </p>
             </div>
           )}
@@ -226,14 +243,14 @@ export function AddApiKeyDialog({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="Read">Read</SelectItem>
-                    <SelectItem 
-                      value="ReadAndPay" 
+                    <SelectItem
+                      value="ReadAndPay"
                       disabled={currentUserPermission === 'Read'}
                     >
                       Read and Pay
                     </SelectItem>
-                    <SelectItem 
-                      value="Admin" 
+                    <SelectItem
+                      value="Admin"
                       disabled={currentUserPermission !== 'Admin'}
                     >
                       Admin

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -40,7 +40,7 @@ export default function Settings() {
   }, [state.apiKey, apiClient]);
 
   const getPermissionDisplayText = (
-    permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
+    _permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
   ) => {
     return 'API Key';
   };

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -48,7 +48,16 @@ export default function Settings() {
   const getPermissionDescription = (
     permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
   ) => {
-    return 'Your API key for accessing the Masumi Node';
+    switch (permission) {
+      case 'Read':
+        return 'Your read-only API key for accessing the Masumi Node';
+      case 'ReadAndPay':
+        return 'Your read and payment API key for accessing the Masumi Node';
+      case 'Admin':
+        return 'Your admin API key for accessing the Masumi Node';
+      default:
+        return 'Your API key for accessing the Masumi Node';
+    }
   };
 
   const signOut = () => {

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -16,7 +16,9 @@ export default function Settings() {
   const { dispatch, state, apiClient } = useAppContext();
   const { preference, setThemePreference } = useTheme();
   const [showApiKey, setShowApiKey] = useState(false);
-  const [currentUserPermission, setCurrentUserPermission] = useState<'Read' | 'ReadAndPay' | 'Admin' | null>(null);
+  const [currentUserPermission, setCurrentUserPermission] = useState<
+    'Read' | 'ReadAndPay' | 'Admin' | null
+  >(null);
 
   const adminApiKey = state.apiKey || '';
 
@@ -37,30 +39,16 @@ export default function Settings() {
     fetchUserPermission();
   }, [state.apiKey, apiClient]);
 
-  const getPermissionDisplayText = (permission: 'Read' | 'ReadAndPay' | 'Admin' | null) => {
-    switch (permission) {
-      case 'Read':
-        return 'Read API Key';
-      case 'ReadAndPay':
-        return 'Read & Pay API Key';
-      case 'Admin':
-        return 'Admin API Key';
-      default:
-        return 'API Key';
-    }
+  const getPermissionDisplayText = (
+    permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
+  ) => {
+    return 'API Key';
   };
 
-  const getPermissionDescription = (permission: 'Read' | 'ReadAndPay' | 'Admin' | null) => {
-    switch (permission) {
-      case 'Read':
-        return 'Your read-only API key for accessing the Masumi Node';
-      case 'ReadAndPay':
-        return 'Your read and payment API key for accessing the Masumi Node';
-      case 'Admin':
-        return 'Your admin API key for accessing the Masumi Node';
-      default:
-        return 'Your API key for accessing the Masumi Node';
-    }
+  const getPermissionDescription = (
+    permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
+  ) => {
+    return 'Your API key for accessing the Masumi Node';
   };
 
   const signOut = () => {
@@ -88,7 +76,9 @@ export default function Settings() {
           {/* API Key */}
           <div className="space-y-4">
             <div>
-              <h2 className="text-sm font-medium">{getPermissionDisplayText(currentUserPermission)}</h2>
+              <h2 className="text-sm font-medium">
+                {getPermissionDisplayText(currentUserPermission)}
+              </h2>
               <p className="text-sm text-muted-foreground">
                 {getPermissionDescription(currentUserPermission)}
               </p>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -39,9 +39,7 @@ export default function Settings() {
     fetchUserPermission();
   }, [state.apiKey, apiClient]);
 
-  const getPermissionDisplayText = (
-    _permission: 'Read' | 'ReadAndPay' | 'Admin' | null,
-  ) => {
+  const getPermissionDisplayText = () => {
     return 'API Key';
   };
 
@@ -86,7 +84,7 @@ export default function Settings() {
           <div className="space-y-4">
             <div>
               <h2 className="text-sm font-medium">
-                {getPermissionDisplayText(currentUserPermission)}
+                {getPermissionDisplayText()}
               </h2>
               <p className="text-sm text-muted-foreground">
                 {getPermissionDescription(currentUserPermission)}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**
Restrict a Read or Read&Pay session from creating admin api keys
<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
only admin session should be able to create admin api keys
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
Closes DEV-379
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
