### PR TITLE
fix: change RefundWithdrawn status color to blue for better distinction

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -350,8 +350,9 @@ export default function Transactions() {
       case 'resultsubmitted':
         return 'text-green-500';
       case 'refundrequested':
-      case 'refundwithdrawn':
         return 'text-orange-500';
+      case 'refundwithdrawn':
+        return 'text-blue-500';
       case 'disputed':
       case 'disputedwithdrawn':
         return 'text-red-500';


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
Resolve transaction status color confusion in UI
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
Closes DEV-504
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
