### PR TITLE
feat: implement 999+ notification count display

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -35,6 +35,7 @@ import {
 import { useSearch, SearchableItem } from '@/lib/hooks/useSearch';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import MasumiLogo from '@/components/MasumiLogo';
+import { formatCount } from '@/lib/utils';
 interface MainLayoutProps {
   children: React.ReactNode;
 }
@@ -123,7 +124,7 @@ export function MainLayout({ children }: MainLayoutProps) {
       href: '/transactions',
       name: 'Transactions',
       icon: FileText,
-      badge: newTransactionsCount || null,
+      badge: formatCount(newTransactionsCount),
     },
     {
       href: '/payment-sources',
@@ -295,12 +296,12 @@ export function MainLayout({ children }: MainLayoutProps) {
               <item.icon className="h-4 w-4" />
               {!collapsed && <span>{item.name}</span>}
               {!collapsed && item.badge && (
-                <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                <span className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1 text-xs font-normal text-white">
                   {item.badge}
                 </span>
               )}
               {collapsed && item.badge && (
-                <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-xs font-normal text-white">
                   {item.badge}
                 </span>
               )}
@@ -408,7 +409,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                   onClick={handleOpenNotifications}
                 >
                   <Bell className="h-4 w-4" />
-                  {newTransactionsCount ? newTransactionsCount : null}
+                  {formatCount(newTransactionsCount)}
                 </Button>
               </div>
             </div>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -34,3 +34,23 @@ export function parseError(error: any): string {
   }
   return 'An error occurred';
 }
+
+/**
+ * Formats count for display
+ * Shows exact count up to maxValue, shows "maxValue+" for counts > maxValue
+ *
+ * @param count - The count to format
+ * @param maxValue - The maximum value to display before showing "maxValue+" (default: 999)
+ * @returns Formatted count string
+ */
+export function formatCount(count: number, maxValue: number = 999): string {
+  if (count <= 0) {
+    return '';
+  }
+
+  if (count > maxValue) {
+    return `${maxValue}+`;
+  }
+
+  return count.toString();
+}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
- Add formatCount utility function to utils.ts with configurable maxValue
- Update notification bell in header to show 999+ for counts > 999
- Update Transactions sidebar button to show 999+ for counts > 999
- Improve badge styling with fixed height and flexible width
- Add proper padding and normal font weight for badge text
- Maintain square appearance for small numbers while expanding for 999+
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
Closes DEV-600
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
