### PR TITLE
feat(swap): unlock after Blockfrost confirmation threshold

### DIFF
--- a/src/routes/api/swap/index.ts
+++ b/src/routes/api/swap/index.ts
@@ -317,13 +317,13 @@ export const getSwapConfirmEndpointGet = adminAuthenticatedEndpointFactory.build
 				const confirmations = block.confirmations ?? 0;
 
 				const awaitingConfirmationDepth =
-					swapTx &&
+					swapTx != null &&
 					confirmations < CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD &&
 					(swapTx.status === TransactionStatus.Pending ||
 						currentSwapStatus === SwapStatus.OrderPending ||
 						currentSwapStatus === SwapStatus.CancelPending);
 
-				if (awaitingConfirmationDepth) {
+				if (awaitingConfirmationDepth && swapTx != null) {
 					try {
 						await prisma.swapTransaction.update({
 							where: { id: swapTx.id },

--- a/src/routes/api/swap/index.ts
+++ b/src/routes/api/swap/index.ts
@@ -1,7 +1,15 @@
 import { adminAuthenticatedEndpointFactory } from '@/utils/security/auth/admin-authenticated';
 import { z } from '@/utils/zod-openapi';
 import createHttpError from 'http-errors';
-import { swapTokens, getPoolEstimate, Token, cancelSwapOrder, findOrderOutputIndex } from '@/services/integrations';
+import {
+	swapTokens,
+	getPoolEstimate,
+	Token,
+	cancelSwapOrder,
+	findOrderOutputIndex,
+	SWAP_CHAIN_SUBMIT_TIMEOUT_MS,
+} from '@/services/integrations';
+import { CONFIG } from '@/utils/config';
 import { recordBusinessEndpointError } from '@/utils/metrics';
 import { AuthContext, checkIsAllowedNetworkOrThrowUnauthorized } from '@/utils/middleware/auth-middleware';
 import { Network, TransactionStatus, SwapStatus } from '@/generated/prisma/client';
@@ -41,9 +49,6 @@ export {
 	acknowledgeSwapTimeoutSchemaInput,
 	acknowledgeSwapTimeoutSchemaOutput,
 };
-
-/** How long a pending tx can sit before we consider it timed out (15 minutes). */
-const SWAP_TX_TIMEOUT_MS = 15 * 60 * 1000;
 
 export const swapTokensEndpointPost = adminAuthenticatedEndpointFactory.build({
 	method: 'post',
@@ -309,6 +314,34 @@ export const getSwapConfirmEndpointGet = adminAuthenticatedEndpointFactory.build
 					};
 				}
 				const block = await blockfrost.blocks(tx.block);
+				const confirmations = block.confirmations ?? 0;
+
+				const awaitingConfirmationDepth =
+					swapTx &&
+					confirmations < CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD &&
+					(swapTx.status === TransactionStatus.Pending ||
+						currentSwapStatus === SwapStatus.OrderPending ||
+						currentSwapStatus === SwapStatus.CancelPending);
+
+				if (awaitingConfirmationDepth) {
+					try {
+						await prisma.swapTransaction.update({
+							where: { id: swapTx.id },
+							data: { confirmations, lastCheckedAt: new Date() },
+						});
+					} catch (updateError) {
+						logger.error('Failed to persist swap confirmation depth while below threshold', {
+							swapTransactionId: swapTx.id,
+							error: updateError instanceof Error ? updateError.message : String(updateError),
+						});
+					}
+					return {
+						status: 'Pending' as const,
+						swapStatus: currentSwapStatus ?? undefined,
+						swapTransactionId: swapTx.id,
+						confirmations,
+					};
+				}
 
 				if (currentSwapStatus === SwapStatus.CancelPending && swapTx) {
 					// Cancel tx confirmed → transition to CancelConfirmed
@@ -472,7 +505,7 @@ export const getSwapConfirmEndpointGet = adminAuthenticatedEndpointFactory.build
 						const isPendingState =
 							currentSwapStatus === SwapStatus.OrderPending || currentSwapStatus === SwapStatus.CancelPending;
 
-						if (isPendingState && elapsed > SWAP_TX_TIMEOUT_MS) {
+						if (isPendingState && elapsed > SWAP_CHAIN_SUBMIT_TIMEOUT_MS) {
 							const timeoutStatus =
 								currentSwapStatus === SwapStatus.OrderPending
 									? SwapStatus.OrderSubmitTimeout

--- a/src/services/integrations/index.ts
+++ b/src/services/integrations/index.ts
@@ -1,6 +1,9 @@
 export { fetchAssetInWalletAndMetadata } from './asset-metadata';
 export { handlePurchaseCreditInit } from './token-credit/service';
 export { cancelSwapOrder, findOrderOutputIndex, getPoolEstimate, swapTokens } from './swap/service';
+export { getSwapTxInclusion } from './swap/blockfrost-confirmations';
+export type { SwapTxInclusion } from './swap/blockfrost-confirmations';
+export { SWAP_BACKGROUND_POLL_MIN_INTERVAL_MS, SWAP_CHAIN_SUBMIT_TIMEOUT_MS } from './swap/constants';
 export type {
 	CancelSwapParams,
 	PoolEstimateParams,

--- a/src/services/integrations/swap/blockfrost-confirmations.ts
+++ b/src/services/integrations/swap/blockfrost-confirmations.ts
@@ -1,0 +1,26 @@
+import type { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+
+export type SwapTxInclusion =
+	| { kind: 'not_found' }
+	| { kind: 'unconfirmed' }
+	| { kind: 'included'; confirmations: number };
+
+/**
+ * Whether a swap-related tx is visible on-chain and how deep it is (Blockfrost block confirmations).
+ */
+export async function getSwapTxInclusion(blockfrost: BlockFrostAPI, txHash: string): Promise<SwapTxInclusion> {
+	try {
+		const tx = await blockfrost.txs(txHash);
+		if (!tx.block) {
+			return { kind: 'unconfirmed' };
+		}
+		const block = await blockfrost.blocks(tx.block);
+		return { kind: 'included', confirmations: block.confirmations ?? 0 };
+	} catch (error: unknown) {
+		const msg = error instanceof Error ? error.message : String(error);
+		if (msg.includes('404') || msg.toLowerCase().includes('not found')) {
+			return { kind: 'not_found' };
+		}
+		throw error;
+	}
+}

--- a/src/services/integrations/swap/constants.ts
+++ b/src/services/integrations/swap/constants.ts
@@ -1,0 +1,5 @@
+/** Match swap HTTP handlers: if submit tx never appears on-chain within this window → timeout states. */
+export const SWAP_CHAIN_SUBMIT_TIMEOUT_MS = 15 * 60 * 1000;
+
+/** Min gap between background polls per pending swap (wallet-timeout job may run more often). */
+export const SWAP_BACKGROUND_POLL_MIN_INTERVAL_MS = 10_000;

--- a/src/services/transactions/wallet-timeouts/service.ts
+++ b/src/services/transactions/wallet-timeouts/service.ts
@@ -616,57 +616,56 @@ export async function updateWalletTransactionHash() {
 								} else {
 									await persistSwapRow({});
 								}
-								return;
-							}
-
-							if (inclusion.kind === 'unconfirmed') {
+								if (!shouldUnlock) {
+									return;
+								}
+							} else if (inclusion.kind === 'unconfirmed') {
 								await persistSwapRow({});
 								return;
-							}
+							} else {
+								const confirmations = inclusion.confirmations;
+								if (confirmations < CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD) {
+									await persistSwapRow({ confirmations });
+									return;
+								}
 
-							const confirmations = inclusion.confirmations;
-							if (confirmations < CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD) {
-								await persistSwapRow({ confirmations });
-								return;
-							}
+								if (swapStatus === SwapStatus.CancelPending) {
+									finalSwapStatus = SwapStatus.CancelConfirmed;
+									finalStatus = TransactionStatus.Confirmed;
+									shouldUnlock = true;
+									await persistSwapRow({
+										status: finalStatus,
+										swapStatus: finalSwapStatus,
+										confirmations,
+									});
+								} else {
+									let orderOutputIndex: number | null = null;
+									try {
+										orderOutputIndex = await findOrderOutputIndex(txHashToCheck, blockfrost, wallet.walletAddress);
+									} catch (outputError) {
+										logger.error('Failed to find order output index during swap poll', {
+											txHash: txHashToCheck,
+											walletId: wallet.id,
+											error: outputError instanceof Error ? outputError.message : String(outputError),
+										});
+									}
 
-							if (swapStatus === SwapStatus.CancelPending) {
-								finalSwapStatus = SwapStatus.CancelConfirmed;
-								finalStatus = TransactionStatus.Confirmed;
-								shouldUnlock = true;
-								await persistSwapRow({
-									status: finalStatus,
-									swapStatus: finalSwapStatus,
-									confirmations,
-								});
-								return;
-							}
+									if (orderOutputIndex == null) {
+										await persistSwapRow({ confirmations });
+										return;
+									}
 
-							let orderOutputIndex: number | null = null;
-							try {
-								orderOutputIndex = await findOrderOutputIndex(txHashToCheck, blockfrost, wallet.walletAddress);
-							} catch (outputError) {
-								logger.error('Failed to find order output index during swap poll', {
-									txHash: txHashToCheck,
-									walletId: wallet.id,
-									error: outputError instanceof Error ? outputError.message : String(outputError),
-								});
+									finalSwapStatus = SwapStatus.OrderConfirmed;
+									finalStatus = TransactionStatus.Confirmed;
+									shouldUnlock = true;
+									await persistSwapRow({
+										status: finalStatus,
+										swapStatus: finalSwapStatus,
+										confirmations,
+										orderOutputIndex,
+									});
+								}
 							}
-
-							if (orderOutputIndex == null) {
-								await persistSwapRow({ confirmations });
-								return;
-							}
-
-							finalSwapStatus = SwapStatus.OrderConfirmed;
-							finalStatus = TransactionStatus.Confirmed;
-							shouldUnlock = true;
-							await persistSwapRow({
-								status: finalStatus,
-								swapStatus: finalSwapStatus,
-								confirmations,
-								orderOutputIndex,
-							});
 						} catch (pollError) {
 							logger.error(`Swap poll Blockfrost error for wallet ${wallet.id}: ${errorToString(pollError)}`);
 							if (isTimedOutByWalletLock) {

--- a/src/services/transactions/wallet-timeouts/service.ts
+++ b/src/services/transactions/wallet-timeouts/service.ts
@@ -1,11 +1,12 @@
 import {
 	HotWalletType,
+	RegistrationState,
+	SwapStatus,
 	TransactionStatus,
 	PaymentAction,
 	PaymentErrorType,
 	PurchasingAction,
 	PurchaseErrorType,
-	RegistrationState,
 } from '@/generated/prisma/client';
 import { prisma } from '@/utils/db';
 import { logger } from '@/utils/logger';
@@ -16,6 +17,13 @@ import { registerInboxAgentV1, deRegisterInboxAgentV1 } from '@/services/registr
 import { CONFIG, DEFAULTS } from '@/utils/config';
 import { errorToString } from '@/utils/converter/error-string-convert';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
+import {
+	findOrderOutputIndex,
+	getSwapTxInclusion,
+	SWAP_BACKGROUND_POLL_MIN_INTERVAL_MS,
+	SWAP_CHAIN_SUBMIT_TIMEOUT_MS,
+} from '@/services/integrations';
+import { getBlockfrostInstance } from '@/utils/blockfrost';
 import {
 	connectPreviousAction,
 	createMeshProvider,
@@ -504,7 +512,14 @@ export async function updateWalletTransactionHash() {
 		const swapLockedWallets = await prisma.hotWallet.findMany({
 			where: {
 				PendingSwapTransaction: {
-					OR: [{ lastCheckedAt: { lte: new Date(Date.now() - 1000 * 60 * 1) } }, { lastCheckedAt: null }],
+					OR: [
+						{
+							lastCheckedAt: {
+								lte: new Date(Date.now() - SWAP_BACKGROUND_POLL_MIN_INTERVAL_MS),
+							},
+						},
+						{ lastCheckedAt: null },
+					],
 				},
 				deletedAt: null,
 			},
@@ -519,57 +534,192 @@ export async function updateWalletTransactionHash() {
 		await Promise.allSettled(
 			swapLockedWallets.map(async (wallet) => {
 				try {
-					if (wallet.PendingSwapTransaction == null) {
+					const swapTx = wallet.PendingSwapTransaction;
+					if (swapTx == null) {
 						logger.error(`Wallet ${wallet.id} has no pending swap transaction when expected. Skipping...`);
 						return;
 					}
-					const swapTxId = wallet.PendingSwapTransaction.id;
-					const txHash = wallet.PendingSwapTransaction.txHash;
-					const isTimedOut =
-						wallet.lockedAt && new Date(wallet.lockedAt) < new Date(Date.now() - CONFIG.WALLET_LOCK_TIMEOUT_INTERVAL);
+					const swapTxId = swapTx.id;
+					const txHash = swapTx.txHash;
+					const swapStatus = swapTx.swapStatus;
+					const network = wallet.PaymentSource.network;
+					const blockfrostKey = wallet.PaymentSource.PaymentSourceConfig.rpcProviderApiKey;
+					const now = new Date();
 
-					// Determine swap tx final status
+					const isTimedOutByWalletLock =
+						wallet.lockedAt != null &&
+						new Date(wallet.lockedAt).getTime() < Date.now() - CONFIG.WALLET_LOCK_TIMEOUT_INTERVAL;
+					const elapsedSinceSwapCreated = Date.now() - swapTx.createdAt.getTime();
+
 					let finalStatus: TransactionStatus | null = null;
+					let finalSwapStatus: SwapStatus | null = null;
 					let shouldUnlock = false;
+
+					const persistSwapRow = async (extra: {
+						status?: TransactionStatus;
+						swapStatus?: SwapStatus;
+						confirmations?: number | null;
+						orderOutputIndex?: number;
+					}) => {
+						try {
+							await prisma.swapTransaction.update({
+								where: { id: swapTxId },
+								data: {
+									...(extra.status != null ? { status: extra.status } : {}),
+									...(extra.swapStatus != null ? { swapStatus: extra.swapStatus } : {}),
+									...(extra.confirmations !== undefined ? { confirmations: extra.confirmations } : {}),
+									...(extra.orderOutputIndex !== undefined ? { orderOutputIndex: extra.orderOutputIndex } : {}),
+									lastCheckedAt: now,
+								},
+							});
+						} catch (swapTxError) {
+							logger.error(`Failed to update swap transaction ${swapTxId}: ${errorToString(swapTxError)}`);
+						}
+					};
 
 					if (txHash == null) {
 						finalStatus = TransactionStatus.FailedViaTimeout;
+						finalSwapStatus =
+							swapStatus === SwapStatus.CancelPending ? SwapStatus.CancelSubmitTimeout : SwapStatus.OrderSubmitTimeout;
 						shouldUnlock = true;
-					} else {
-						const blockfrostKey = wallet.PaymentSource.PaymentSourceConfig.rpcProviderApiKey;
-						const provider = createMeshProvider(blockfrostKey);
+						await persistSwapRow({ status: finalStatus, swapStatus: finalSwapStatus });
+					} else if (!blockfrostKey) {
+						logger.error(`Wallet ${wallet.id} swap poll missing Blockfrost API key`);
+						await persistSwapRow({});
+					} else if (
+						swapStatus === SwapStatus.OrderSubmitTimeout ||
+						swapStatus === SwapStatus.CancelSubmitTimeout ||
+						swapStatus === SwapStatus.Completed ||
+						swapStatus === SwapStatus.CancelConfirmed
+					) {
+						shouldUnlock = true;
+						await persistSwapRow({});
+					} else if (swapStatus === SwapStatus.CancelPending || swapStatus === SwapStatus.OrderPending) {
+						const blockfrost = getBlockfrostInstance(network, blockfrostKey);
+						const txHashToCheck =
+							swapStatus === SwapStatus.CancelPending && swapTx.cancelTxHash ? swapTx.cancelTxHash : txHash;
+
 						try {
-							const txInfo = await provider.fetchTxInfo(txHash);
-							if (txInfo) {
+							const inclusion = await getSwapTxInclusion(blockfrost, txHashToCheck);
+
+							if (inclusion.kind === 'not_found') {
+								const lifecyclePending =
+									swapStatus === SwapStatus.OrderPending || swapStatus === SwapStatus.CancelPending;
+								if (lifecyclePending && elapsedSinceSwapCreated > SWAP_CHAIN_SUBMIT_TIMEOUT_MS) {
+									finalSwapStatus =
+										swapStatus === SwapStatus.CancelPending
+											? SwapStatus.CancelSubmitTimeout
+											: SwapStatus.OrderSubmitTimeout;
+									finalStatus = TransactionStatus.FailedViaTimeout;
+									shouldUnlock = true;
+									await persistSwapRow({ status: finalStatus, swapStatus: finalSwapStatus });
+								} else {
+									await persistSwapRow({});
+								}
+								return;
+							}
+
+							if (inclusion.kind === 'unconfirmed') {
+								await persistSwapRow({});
+								return;
+							}
+
+							const confirmations = inclusion.confirmations;
+							if (confirmations < CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD) {
+								await persistSwapRow({ confirmations });
+								return;
+							}
+
+							if (swapStatus === SwapStatus.CancelPending) {
+								finalSwapStatus = SwapStatus.CancelConfirmed;
 								finalStatus = TransactionStatus.Confirmed;
 								shouldUnlock = true;
-							} else if (isTimedOut) {
-								finalStatus = TransactionStatus.FailedViaTimeout;
-								shouldUnlock = true;
+								await persistSwapRow({
+									status: finalStatus,
+									swapStatus: finalSwapStatus,
+									confirmations,
+								});
+								return;
 							}
-						} catch {
-							// Blockfrost error (e.g. 404) — tx not found on-chain yet
-							if (isTimedOut) {
+
+							let orderOutputIndex: number | null = null;
+							try {
+								orderOutputIndex = await findOrderOutputIndex(txHashToCheck, blockfrost, wallet.walletAddress);
+							} catch (outputError) {
+								logger.error('Failed to find order output index during swap poll', {
+									txHash: txHashToCheck,
+									walletId: wallet.id,
+									error: outputError instanceof Error ? outputError.message : String(outputError),
+								});
+							}
+
+							if (orderOutputIndex == null) {
+								await persistSwapRow({ confirmations });
+								return;
+							}
+
+							finalSwapStatus = SwapStatus.OrderConfirmed;
+							finalStatus = TransactionStatus.Confirmed;
+							shouldUnlock = true;
+							await persistSwapRow({
+								status: finalStatus,
+								swapStatus: finalSwapStatus,
+								confirmations,
+								orderOutputIndex,
+							});
+						} catch (pollError) {
+							logger.error(`Swap poll Blockfrost error for wallet ${wallet.id}: ${errorToString(pollError)}`);
+							if (isTimedOutByWalletLock) {
+								finalStatus = TransactionStatus.FailedViaTimeout;
+								finalSwapStatus =
+									swapStatus === SwapStatus.CancelPending
+										? SwapStatus.CancelSubmitTimeout
+										: SwapStatus.OrderSubmitTimeout;
+								shouldUnlock = true;
+								await persistSwapRow({ status: finalStatus, swapStatus: finalSwapStatus });
+							} else {
+								await persistSwapRow({});
+							}
+						}
+					} else if (swapStatus === SwapStatus.OrderConfirmed) {
+						shouldUnlock = true;
+						await persistSwapRow({});
+					} else {
+						const blockfrost = getBlockfrostInstance(network, blockfrostKey);
+						try {
+							const inclusion = await getSwapTxInclusion(blockfrost, txHash);
+							if (inclusion.kind === 'included') {
+								if (inclusion.confirmations >= CONFIG.BLOCK_CONFIRMATIONS_THRESHOLD) {
+									finalStatus = TransactionStatus.Confirmed;
+									finalSwapStatus = SwapStatus.Completed;
+									shouldUnlock = true;
+									await persistSwapRow({
+										status: finalStatus,
+										swapStatus: finalSwapStatus,
+										confirmations: inclusion.confirmations,
+									});
+								} else {
+									await persistSwapRow({ confirmations: inclusion.confirmations });
+								}
+							} else if (isTimedOutByWalletLock) {
 								finalStatus = TransactionStatus.FailedViaTimeout;
 								shouldUnlock = true;
+								await persistSwapRow({ status: finalStatus });
+							} else {
+								await persistSwapRow({});
+							}
+						} catch (pollError) {
+							logger.error(`Legacy swap poll error for wallet ${wallet.id}: ${errorToString(pollError)}`);
+							if (isTimedOutByWalletLock) {
+								finalStatus = TransactionStatus.FailedViaTimeout;
+								shouldUnlock = true;
+								await persistSwapRow({ status: finalStatus });
+							} else {
+								await persistSwapRow({});
 							}
 						}
 					}
 
-					// Update swap transaction status (best effort)
-					try {
-						await prisma.swapTransaction.update({
-							where: { id: swapTxId },
-							data: {
-								...(finalStatus ? { status: finalStatus } : {}),
-								lastCheckedAt: new Date(),
-							},
-						});
-					} catch (swapTxError) {
-						logger.error(`Failed to update swap transaction ${swapTxId}: ${errorToString(swapTxError)}`);
-					}
-
-					// Always unlock the wallet if needed — even if swap tx update failed
 					if (shouldUnlock) {
 						await prisma.hotWallet.update({
 							where: { id: wallet.id, deletedAt: null },


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
Poll pending swaps via Blockfrost inclusion depth; reuse BLOCK_CONFIRMATIONS_THRESHOLD. Align GET /swap/confirm with same gate; tighten swap poll interval (10s).
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
