### PR TITLE
feat: agent verifications + v2 metadata schema alignment

### DIFF
--- a/frontend/openapi-docs.json
+++ b/frontend/openapi-docs.json
@@ -2091,6 +2091,135 @@
                                 "minItems": 1,
                                 "maxItems": 25,
                                 "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
+                            },
+                            "verifications": {
+                                "type": "array",
+                                "nullable": true,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "method": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 40,
+                                            "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                        },
+                                        "schemaVersion": {
+                                            "type": "string",
+                                            "maxLength": 16,
+                                            "description": "Version of this verification block"
+                                        },
+                                        "issuer": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential issuer identity"
+                                        },
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential schema SAID (ACDC sad.s)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential schema — the ACDC structure definition"
+                                        },
+                                        "credential": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential SAID (ACDC sad.d)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                },
+                                                "registry": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "The verifiable credential (ACDC)"
+                                        },
+                                        "holder": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the holder KEL"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential holder/issuee identity"
+                                        },
+                                        "baseUrl": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                        }
+                                    },
+                                    "required": [
+                                        "method",
+                                        "issuer",
+                                        "schema",
+                                        "credential",
+                                        "holder"
+                                    ]
+                                },
+                                "maxItems": 10,
+                                "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
                             }
                         },
                         "required": [
@@ -2102,7 +2231,8 @@
                             "AgentPricing",
                             "image",
                             "metadataVersion",
-                            "supportedPaymentSources"
+                            "supportedPaymentSources",
+                            "verifications"
                         ],
                         "description": "On-chain metadata for the agent"
                     }
@@ -2478,6 +2608,135 @@
                                 "minItems": 1,
                                 "maxItems": 25,
                                 "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
+                            },
+                            "verifications": {
+                                "type": "array",
+                                "nullable": true,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "method": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 40,
+                                            "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                        },
+                                        "schemaVersion": {
+                                            "type": "string",
+                                            "maxLength": 16,
+                                            "description": "Version of this verification block"
+                                        },
+                                        "issuer": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential issuer identity"
+                                        },
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential schema SAID (ACDC sad.s)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential schema — the ACDC structure definition"
+                                        },
+                                        "credential": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential SAID (ACDC sad.d)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                },
+                                                "registry": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "The verifiable credential (ACDC)"
+                                        },
+                                        "holder": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the holder KEL"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential holder/issuee identity"
+                                        },
+                                        "baseUrl": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                        }
+                                    },
+                                    "required": [
+                                        "method",
+                                        "issuer",
+                                        "schema",
+                                        "credential",
+                                        "holder"
+                                    ]
+                                },
+                                "maxItems": 10,
+                                "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
                             }
                         },
                         "required": [
@@ -2489,7 +2748,8 @@
                             "AgentPricing",
                             "image",
                             "metadataVersion",
-                            "supportedPaymentSources"
+                            "supportedPaymentSources",
+                            "verifications"
                         ],
                         "description": "On-chain metadata for the agent"
                     }
@@ -2892,6 +3152,135 @@
                         "maxItems": 25,
                         "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
                     },
+                    "verifications": {
+                        "type": "array",
+                        "nullable": true,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "method": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 40,
+                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                },
+                                "schemaVersion": {
+                                    "type": "string",
+                                    "maxLength": 16,
+                                    "description": "Version of this verification block"
+                                },
+                                "issuer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "aid": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                        }
+                                    },
+                                    "required": [
+                                        "aid",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential issuer identity"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "said": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                        }
+                                    },
+                                    "required": [
+                                        "said",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential schema — the ACDC structure definition"
+                                },
+                                "credential": {
+                                    "type": "object",
+                                    "properties": {
+                                        "said": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential SAID (ACDC sad.d)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                        },
+                                        "registry": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                        }
+                                    },
+                                    "required": [
+                                        "said",
+                                        "oobi"
+                                    ],
+                                    "description": "The verifiable credential (ACDC)"
+                                },
+                                "holder": {
+                                    "type": "object",
+                                    "properties": {
+                                        "aid": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the holder KEL"
+                                        }
+                                    },
+                                    "required": [
+                                        "aid",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential holder/issuee identity"
+                                },
+                                "baseUrl": {
+                                    "type": "string",
+                                    "maxLength": 500,
+                                    "format": "uri",
+                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                }
+                            },
+                            "required": [
+                                "method",
+                                "issuer",
+                                "schema",
+                                "credential",
+                                "holder"
+                            ]
+                        },
+                        "maxItems": 10,
+                        "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
+                    },
                     "SmartContractWallet": {
                         "type": "object",
                         "properties": {
@@ -2999,6 +3388,7 @@
                     "AgentPricing",
                     "sendFundingLovelace",
                     "supportedPaymentSources",
+                    "verifications",
                     "SmartContractWallet",
                     "RecipientWallet",
                     "CurrentTransaction"
@@ -17367,6 +17757,134 @@
                                         "maxItems": 25,
                                         "description": "Payment sources to persist for this registry request. If omitted, mint metadata advertises the active payment source."
                                     },
+                                    "verifications": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 40,
+                                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                                },
+                                                "schemaVersion": {
+                                                    "type": "string",
+                                                    "maxLength": 16,
+                                                    "description": "Version of this verification block"
+                                                },
+                                                "issuer": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential issuer identity"
+                                                },
+                                                "schema": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential schema — the ACDC structure definition"
+                                                },
+                                                "credential": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential SAID (ACDC sad.d)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                        },
+                                                        "registry": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "The verifiable credential (ACDC)"
+                                                },
+                                                "holder": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the holder KEL"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential holder/issuee identity"
+                                                },
+                                                "baseUrl": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                                }
+                                            },
+                                            "required": [
+                                                "method",
+                                                "issuer",
+                                                "schema",
+                                                "credential",
+                                                "holder"
+                                            ]
+                                        },
+                                        "maxItems": 10,
+                                        "description": "Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only."
+                                    },
                                     "ExampleOutputs": {
                                         "type": "array",
                                         "items": {
@@ -17706,6 +18224,30 @@
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
                                                 }
                                             ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
+                                                }
+                                            ],
                                             "SmartContractWallet": {
                                                 "walletVkey": "wallet_vkey",
                                                 "walletAddress": "wallet_address"
@@ -17828,6 +18370,30 @@
                                                     "network": "Preprod",
                                                     "paymentSourceType": "Web3CardanoV2",
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
+                                                }
+                                            ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
                                                 }
                                             ],
                                             "SmartContractWallet": {
@@ -18199,6 +18765,30 @@
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
                                                 }
                                             ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
+                                                }
+                                            ],
                                             "SmartContractWallet": {
                                                 "walletVkey": "wallet_vkey",
                                                 "walletAddress": "wallet_address"
@@ -18383,6 +18973,134 @@
                                         },
                                         "maxItems": 25,
                                         "description": "Payment sources to replace on this registry request. Provide an empty array to clear them."
+                                    },
+                                    "verifications": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 40,
+                                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                                },
+                                                "schemaVersion": {
+                                                    "type": "string",
+                                                    "maxLength": 16,
+                                                    "description": "Version of this verification block"
+                                                },
+                                                "issuer": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential issuer identity"
+                                                },
+                                                "schema": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential schema — the ACDC structure definition"
+                                                },
+                                                "credential": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential SAID (ACDC sad.d)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                        },
+                                                        "registry": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "The verifiable credential (ACDC)"
+                                                },
+                                                "holder": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the holder KEL"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential holder/issuee identity"
+                                                },
+                                                "baseUrl": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                                }
+                                            },
+                                            "required": [
+                                                "method",
+                                                "issuer",
+                                                "schema",
+                                                "credential",
+                                                "holder"
+                                            ]
+                                        },
+                                        "maxItems": 10,
+                                        "description": "Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only."
                                     },
                                     "ExampleOutputs": {
                                         "type": "array",
@@ -18718,6 +19436,30 @@
                                                     "network": "Preprod",
                                                     "paymentSourceType": "Web3CardanoV2",
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
+                                                }
+                                            ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
                                                 }
                                             ],
                                             "SmartContractWallet": {

--- a/frontend/src/components/ai-agents/AIAgentDetailsDialog.tsx
+++ b/frontend/src/components/ai-agents/AIAgentDetailsDialog.tsx
@@ -24,6 +24,8 @@ import { lookupWalletByVkey } from '@/lib/wallet-lookup';
 import { useMemo } from 'react';
 import { VerifyAndPublishAgentDialog } from './VerifyAndPublishAgentDialog';
 import { AgentX402Options } from './AgentX402Options';
+import { AgentCardanoSources } from './AgentCardanoSources';
+import { AgentVerifications } from './AgentVerifications';
 
 type AIAgent = RegistryEntry;
 
@@ -370,7 +372,11 @@ export function AIAgentDetailsDialog({
                       </CardContent>
                     </Card>
 
+                    <AgentCardanoSources sources={agent.supportedPaymentSources} />
+
                     <AgentX402Options sources={agent.supportedPaymentSources} />
+
+                    <AgentVerifications verifications={agent.verifications} />
 
                     <div className="flex items-center gap-4 pt-2">
                       <Separator className="flex-1" />

--- a/frontend/src/components/ai-agents/AgentCardanoSources.tsx
+++ b/frontend/src/components/ai-agents/AgentCardanoSources.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CopyButton } from '@/components/ui/copy-button';
+import { cn, shortenAddress } from '@/lib/utils';
+import { RegistryEntry } from '@/lib/api/generated';
+
+type SupportedPaymentSource = NonNullable<RegistryEntry['supportedPaymentSources']>[number];
+type CardanoPaymentSource = Extract<SupportedPaymentSource, { chain: 'Cardano' }>;
+
+export function agentHasCardanoSources(sources: RegistryEntry['supportedPaymentSources']): boolean {
+  return (sources ?? []).some((source) => source.chain === 'Cardano');
+}
+
+export function AgentCardanoSources({
+  sources,
+}: {
+  sources: RegistryEntry['supportedPaymentSources'];
+}) {
+  const cardanoSources = (sources ?? []).filter(
+    (source): source is CardanoPaymentSource => source.chain === 'Cardano',
+  );
+  if (cardanoSources.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Cardano Payment Sources</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 p-2 bg-muted/40 border rounded-md">
+          {cardanoSources.map((source, index, arr) => (
+            <div
+              key={`${source.network}-${source.address}`}
+              className={cn('flex flex-col gap-1 py-2', index < arr.length - 1 && 'border-b')}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">{source.network}</span>
+                <Badge variant="outline">{source.paymentSourceType}</Badge>
+              </div>
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>Escrow contract</span>
+                <span className="font-mono flex items-center gap-1">
+                  {shortenAddress(source.address, 8)}
+                  <CopyButton value={source.address} />
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ai-agents/AgentVerifications.tsx
+++ b/frontend/src/components/ai-agents/AgentVerifications.tsx
@@ -1,0 +1,99 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CopyButton } from '@/components/ui/copy-button';
+import { shortenAddress } from '@/lib/utils';
+import { RegistryEntry } from '@/lib/api/generated';
+
+type Verification = NonNullable<RegistryEntry['verifications']>[number];
+
+export function agentHasVerifications(verifications: RegistryEntry['verifications']): boolean {
+  return (verifications ?? []).length > 0;
+}
+
+// A KERI/Veridian anchor: the AID/SAID (shortened, copyable) plus the OOBI it
+// resolves from. OOBIs are untrusted fetch points — shown as plain text, not links.
+function AnchorRow({ label, id, oobi }: { label: string; id: string; oobi?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 py-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-mono flex items-center gap-1">
+          {shortenAddress(id, 6)}
+          <CopyButton value={id} />
+        </span>
+      </div>
+      {oobi && (
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>OOBI</span>
+          <span className="font-mono truncate max-w-[220px]" title={oobi}>
+            {oobi}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AgentVerifications({
+  verifications,
+}: {
+  verifications: RegistryEntry['verifications'];
+}) {
+  const entries: Verification[] = verifications ?? [];
+  if (entries.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Verifications</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {entries.map((verification, index) => (
+            <div key={index} className="space-y-1 p-2 bg-muted/40 border rounded-md">
+              <div className="flex items-center justify-between pb-1">
+                <Badge variant="secondary">{verification.method}</Badge>
+                {verification.schemaVersion && (
+                  <span className="text-xs text-muted-foreground">
+                    schema v{verification.schemaVersion}
+                  </span>
+                )}
+              </div>
+              <AnchorRow
+                label="Issuer AID"
+                id={verification.issuer.aid}
+                oobi={verification.issuer.oobi}
+              />
+              <AnchorRow
+                label="Schema SAID"
+                id={verification.schema.said}
+                oobi={verification.schema.oobi}
+              />
+              <AnchorRow
+                label="Credential SAID"
+                id={verification.credential.said}
+                oobi={verification.credential.oobi}
+              />
+              {verification.credential.registry && (
+                <AnchorRow label="Registry (TEL)" id={verification.credential.registry} />
+              )}
+              <AnchorRow
+                label="Holder AID"
+                id={verification.holder.aid}
+                oobi={verification.holder.oobi}
+              />
+              {verification.baseUrl && (
+                <div className="flex items-center justify-between text-xs text-muted-foreground pt-1">
+                  <span>Resolver base</span>
+                  <span className="font-mono truncate max-w-[220px]" title={verification.baseUrl}>
+                    {verification.baseUrl}
+                  </span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
+++ b/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
@@ -32,6 +32,13 @@ import {
   validateX402Options,
   type X402OptionDraft,
 } from './X402OptionsSection';
+import {
+  VerificationsSection,
+  validateVerifications,
+  verificationsFromApi,
+  verificationsToApi,
+  type VerificationDraft,
+} from './VerificationsSection';
 
 interface RegisterAIAgentDialogProps {
   open: boolean;
@@ -374,11 +381,15 @@ export function RegisterAIAgentDialog({
           })),
       );
       setX402Error(null);
+      setVerifications(verificationsFromApi(editingAgent.verifications));
+      setVerificationsError(null);
       return;
     }
     reset();
     setX402Options([]);
     setX402Error(null);
+    setVerifications([]);
+    setVerificationsError(null);
   }, [open, reset, isUpdateMode, editingAgent, network, stablecoinUnit]);
 
   const selectedWallet = useMemo(
@@ -399,6 +410,8 @@ export function RegisterAIAgentDialog({
   const { networks: x402Networks } = useX402Networks({ silentErrors: true });
   const [x402Options, setX402Options] = useState<X402OptionDraft[]>([]);
   const [x402Error, setX402Error] = useState<string | null>(null);
+  const [verifications, setVerifications] = useState<VerificationDraft[]>([]);
+  const [verificationsError, setVerificationsError] = useState<string | null>(null);
   // x402 supported payment sources are a V2-only capability; update always targets V2.
   const isV2Target = isUpdateMode
     ? true
@@ -528,6 +541,15 @@ export function RegisterAIAgentDialog({
           }
         }
         setX402Error(null);
+        if (isV2Target && verifications.length > 0) {
+          const verificationsValidationError = validateVerifications(verifications);
+          if (verificationsValidationError) {
+            setVerificationsError(verificationsValidationError);
+            toast.error(verificationsValidationError);
+            return;
+          }
+        }
+        setVerificationsError(null);
 
         if (isUpdateMode && editingAgent) {
           if (!editingAgent.agentIdentifier) {
@@ -543,6 +565,7 @@ export function RegisterAIAgentDialog({
           );
           const hadEvmSources =
             (editingAgent.supportedPaymentSources ?? []).length > existingNonEvmSources.length;
+          const hadVerifications = (editingAgent.verifications ?? []).length > 0;
           const updateResponse = await postRegistryUpdate({
             client: apiClient,
             body: {
@@ -564,6 +587,9 @@ export function RegisterAIAgentDialog({
                 ? {
                     supportedPaymentSources: [...existingNonEvmSources, ...evmSupportedSources],
                   }
+                : {}),
+              ...(verifications.length > 0 || hadVerifications
+                ? { verifications: verificationsToApi(verifications) }
                 : {}),
             },
           });
@@ -598,6 +624,9 @@ export function RegisterAIAgentDialog({
             ...(isV2Target && evmSupportedSources.length > 0
               ? { supportedPaymentSources: evmSupportedSources }
               : {}),
+            ...(isV2Target && verifications.length > 0
+              ? { verifications: verificationsToApi(verifications) }
+              : {}),
           },
         });
 
@@ -629,6 +658,7 @@ export function RegisterAIAgentDialog({
       editingAgent,
       editingAgentSmartContractAddress,
       x402Options,
+      verifications,
       isV2Target,
     ],
   );
@@ -1016,6 +1046,14 @@ export function RegisterAIAgentDialog({
               networks={x402Networks}
               onChange={setX402Options}
               error={x402Error}
+            />
+          )}
+
+          {isV2Target && (
+            <VerificationsSection
+              verifications={verifications}
+              onChange={setVerifications}
+              error={verificationsError}
             />
           )}
 

--- a/frontend/src/components/ai-agents/VerificationsSection.tsx
+++ b/frontend/src/components/ai-agents/VerificationsSection.tsx
@@ -1,0 +1,301 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+// Flat form draft for one KERI/Veridian verification claim. Mapped to/from the
+// nested API shape (issuer/schema/credential/holder) by the helpers below.
+export type VerificationDraft = {
+  method: string;
+  schemaVersion: string;
+  issuerAid: string;
+  issuerOobi: string;
+  schemaSaid: string;
+  schemaOobi: string;
+  credentialSaid: string;
+  credentialOobi: string;
+  credentialRegistry: string;
+  holderAid: string;
+  holderOobi: string;
+  baseUrl: string;
+};
+
+export const emptyVerification: VerificationDraft = {
+  method: 'KERI-ACDC',
+  schemaVersion: '1',
+  issuerAid: '',
+  issuerOobi: '',
+  schemaSaid: '',
+  schemaOobi: '',
+  credentialSaid: '',
+  credentialOobi: '',
+  credentialRegistry: '',
+  holderAid: '',
+  holderOobi: '',
+  baseUrl: '',
+};
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+// Mirrors the backend Zod constraints (AIDs/SAIDs 1–128 chars; OOBIs http(s)
+// URLs ≤500). Returns the first error message, or null when all entries are valid.
+export function validateVerifications(verifications: VerificationDraft[]): string | null {
+  for (let i = 0; i < verifications.length; i++) {
+    const v = verifications[i];
+    const n = i + 1;
+    const requireId = (label: string, value: string) =>
+      !value.trim() || value.trim().length > 128
+        ? `Verification ${n}: ${label} is required (max 128 chars)`
+        : null;
+    const requireOobi = (label: string, value: string) =>
+      !isHttpUrl(value.trim()) || value.trim().length > 500
+        ? `Verification ${n}: ${label} must be an http(s) URL`
+        : null;
+
+    if (!v.method.trim() || v.method.trim().length > 40)
+      return `Verification ${n}: method is required`;
+    const errors = [
+      requireId('issuer AID', v.issuerAid),
+      requireOobi('issuer OOBI', v.issuerOobi),
+      requireId('schema SAID', v.schemaSaid),
+      requireOobi('schema OOBI', v.schemaOobi),
+      requireId('credential SAID', v.credentialSaid),
+      requireOobi('credential OOBI', v.credentialOobi),
+      requireId('holder AID', v.holderAid),
+      requireOobi('holder OOBI', v.holderOobi),
+    ];
+    for (const error of errors) {
+      if (error) return error;
+    }
+    if (v.credentialRegistry.trim() && v.credentialRegistry.trim().length > 128) {
+      return `Verification ${n}: registry SAID is too long (max 128 chars)`;
+    }
+    if (v.baseUrl.trim() && !isHttpUrl(v.baseUrl.trim())) {
+      return `Verification ${n}: base URL must be an http(s) URL`;
+    }
+  }
+  return null;
+}
+
+export type VerificationApi = {
+  method: string;
+  schemaVersion?: string;
+  issuer: { aid: string; oobi: string };
+  schema: { said: string; oobi: string };
+  credential: { said: string; oobi: string; registry?: string };
+  holder: { aid: string; oobi: string };
+  baseUrl?: string;
+};
+
+export function verificationsToApi(verifications: VerificationDraft[]): VerificationApi[] {
+  return verifications.map((v) => ({
+    method: v.method.trim(),
+    ...(v.schemaVersion.trim() ? { schemaVersion: v.schemaVersion.trim() } : {}),
+    issuer: { aid: v.issuerAid.trim(), oobi: v.issuerOobi.trim() },
+    schema: { said: v.schemaSaid.trim(), oobi: v.schemaOobi.trim() },
+    credential: {
+      said: v.credentialSaid.trim(),
+      oobi: v.credentialOobi.trim(),
+      ...(v.credentialRegistry.trim() ? { registry: v.credentialRegistry.trim() } : {}),
+    },
+    holder: { aid: v.holderAid.trim(), oobi: v.holderOobi.trim() },
+    ...(v.baseUrl.trim() ? { baseUrl: v.baseUrl.trim() } : {}),
+  }));
+}
+
+export function verificationsFromApi(
+  entries: VerificationApi[] | null | undefined,
+): VerificationDraft[] {
+  if (!entries) return [];
+  return entries.map((v) => ({
+    method: v.method ?? 'KERI-ACDC',
+    schemaVersion: v.schemaVersion ?? '',
+    issuerAid: v.issuer?.aid ?? '',
+    issuerOobi: v.issuer?.oobi ?? '',
+    schemaSaid: v.schema?.said ?? '',
+    schemaOobi: v.schema?.oobi ?? '',
+    credentialSaid: v.credential?.said ?? '',
+    credentialOobi: v.credential?.oobi ?? '',
+    credentialRegistry: v.credential?.registry ?? '',
+    holderAid: v.holder?.aid ?? '',
+    holderOobi: v.holder?.oobi ?? '',
+    baseUrl: v.baseUrl ?? '',
+  }));
+}
+
+function Field({
+  label,
+  placeholder,
+  value,
+  onChange,
+}: {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs text-muted-foreground">{label}</label>
+      <Input
+        className="font-mono"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+export function VerificationsSection({
+  verifications,
+  onChange,
+  error,
+}: {
+  verifications: VerificationDraft[];
+  onChange: (next: VerificationDraft[]) => void;
+  error: string | null;
+}) {
+  const update = (index: number, patch: Partial<VerificationDraft>) =>
+    onChange(verifications.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)));
+  const remove = (index: number) => onChange(verifications.filter((_, i) => i !== index));
+  const add = () => onChange([...verifications, { ...emptyVerification }]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">Verifications (optional)</h3>
+          <p className="text-xs text-muted-foreground">
+            Advertise KERI/Veridian credential anchors so anyone can verify this agent
+            independently. OOBIs are untrusted fetch points; integrity comes from the on-chain
+            AIDs/SAIDs.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={add}
+          className="flex items-center gap-1"
+        >
+          <Plus className="h-4 w-4" />
+          Add
+        </Button>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {verifications.map((entry, index) => (
+        <div key={index} className="rounded-lg border p-3 space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground">
+              Verification {index + 1}
+            </span>
+            <Button type="button" variant="ghost" size="sm" onClick={() => remove(index)}>
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <Field
+              label="Method"
+              placeholder="KERI-ACDC"
+              value={entry.method}
+              onChange={(value) => update(index, { method: value })}
+            />
+            <Field
+              label="Schema version (optional)"
+              placeholder="1"
+              value={entry.schemaVersion}
+              onChange={(value) => update(index, { schemaVersion: value })}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <p className="col-span-2 text-xs font-medium">Issuer</p>
+            <Field
+              label="AID (sad.i)"
+              placeholder="E…"
+              value={entry.issuerAid}
+              onChange={(value) => update(index, { issuerAid: value })}
+            />
+            <Field
+              label="OOBI"
+              placeholder="https://witness…/oobi/E…"
+              value={entry.issuerOobi}
+              onChange={(value) => update(index, { issuerOobi: value })}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <p className="col-span-2 text-xs font-medium">Credential schema</p>
+            <Field
+              label="SAID (sad.s)"
+              placeholder="E…"
+              value={entry.schemaSaid}
+              onChange={(value) => update(index, { schemaSaid: value })}
+            />
+            <Field
+              label="OOBI"
+              placeholder="https://schema…/oobi/E…"
+              value={entry.schemaOobi}
+              onChange={(value) => update(index, { schemaOobi: value })}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <p className="col-span-2 text-xs font-medium">Credential</p>
+            <Field
+              label="SAID (sad.d)"
+              placeholder="E…"
+              value={entry.credentialSaid}
+              onChange={(value) => update(index, { credentialSaid: value })}
+            />
+            <Field
+              label="OOBI"
+              placeholder="https://cred…/oobi/E…"
+              value={entry.credentialOobi}
+              onChange={(value) => update(index, { credentialOobi: value })}
+            />
+            <Field
+              label="Registry / TEL SAID (sad.ri, optional)"
+              placeholder="E… (revocation registry)"
+              value={entry.credentialRegistry}
+              onChange={(value) => update(index, { credentialRegistry: value })}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <p className="col-span-2 text-xs font-medium">Holder</p>
+            <Field
+              label="AID (sad.a.i)"
+              placeholder="E…"
+              value={entry.holderAid}
+              onChange={(value) => update(index, { holderAid: value })}
+            />
+            <Field
+              label="OOBI"
+              placeholder="https://keria…/oobi/E…"
+              value={entry.holderOobi}
+              onChange={(value) => update(index, { holderOobi: value })}
+            />
+          </div>
+
+          <Field
+            label="Resolver base URL (optional)"
+            placeholder="https://verify… (witness/KERIA root)"
+            value={entry.baseUrl}
+            onChange={(value) => update(index, { baseUrl: value })}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ai-agents/VerificationsSection.tsx
+++ b/frontend/src/components/ai-agents/VerificationsSection.tsx
@@ -2,6 +2,10 @@ import { Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
+// Mirrors the backend `verificationsSchema.max(10)` cap so the form rejects
+// over-limit lists before they reach the API.
+const MAX_VERIFICATIONS = 10;
+
 // Flat form draft for one KERI/Veridian verification claim. Mapped to/from the
 // nested API shape (issuer/schema/credential/holder) by the helpers below.
 export type VerificationDraft = {
@@ -46,6 +50,9 @@ function isHttpUrl(value: string): boolean {
 // Mirrors the backend Zod constraints (AIDs/SAIDs 1–128 chars; OOBIs http(s)
 // URLs ≤500). Returns the first error message, or null when all entries are valid.
 export function validateVerifications(verifications: VerificationDraft[]): string | null {
+  if (verifications.length > MAX_VERIFICATIONS) {
+    return `At most ${MAX_VERIFICATIONS} verifications are allowed`;
+  }
   for (let i = 0; i < verifications.length; i++) {
     const v = verifications[i];
     const n = i + 1;
@@ -60,6 +67,8 @@ export function validateVerifications(verifications: VerificationDraft[]): strin
 
     if (!v.method.trim() || v.method.trim().length > 40)
       return `Verification ${n}: method is required`;
+    if (v.schemaVersion.trim() && v.schemaVersion.trim().length > 16)
+      return `Verification ${n}: schema version is too long (max 16 chars)`;
     const errors = [
       requireId('issuer AID', v.issuerAid),
       requireOobi('issuer OOBI', v.issuerOobi),
@@ -76,8 +85,8 @@ export function validateVerifications(verifications: VerificationDraft[]): strin
     if (v.credentialRegistry.trim() && v.credentialRegistry.trim().length > 128) {
       return `Verification ${n}: registry SAID is too long (max 128 chars)`;
     }
-    if (v.baseUrl.trim() && !isHttpUrl(v.baseUrl.trim())) {
-      return `Verification ${n}: base URL must be an http(s) URL`;
+    if (v.baseUrl.trim() && (!isHttpUrl(v.baseUrl.trim()) || v.baseUrl.trim().length > 500)) {
+      return `Verification ${n}: base URL must be an http(s) URL (max 500 chars)`;
     }
   }
   return null;
@@ -165,7 +174,11 @@ export function VerificationsSection({
   const update = (index: number, patch: Partial<VerificationDraft>) =>
     onChange(verifications.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)));
   const remove = (index: number) => onChange(verifications.filter((_, i) => i !== index));
-  const add = () => onChange([...verifications, { ...emptyVerification }]);
+  const atLimit = verifications.length >= MAX_VERIFICATIONS;
+  const add = () => {
+    if (atLimit) return;
+    onChange([...verifications, { ...emptyVerification }]);
+  };
 
   return (
     <div className="space-y-3">
@@ -183,6 +196,8 @@ export function VerificationsSection({
           variant="outline"
           size="sm"
           onClick={add}
+          disabled={atLimit}
+          title={atLimit ? `At most ${MAX_VERIFICATIONS} verifications` : undefined}
           className="flex items-center gap-1"
         >
           <Plus className="h-4 w-4" />

--- a/frontend/src/lib/api/generated/schemas.gen.ts
+++ b/frontend/src/lib/api/generated/schemas.gen.ts
@@ -2077,6 +2077,135 @@ export const AgentMetadataSchema = {
                     minItems: 1,
                     maxItems: 25,
                     description: 'Payment sources advertised by this registry entry. Null for legacy metadata.'
+                },
+                verifications: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        type: 'object',
+                        properties: {
+                            method: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 40,
+                                description: 'Verification method discriminator, e.g. "KERI-ACDC"'
+                            },
+                            schemaVersion: {
+                                type: 'string',
+                                maxLength: 16,
+                                description: 'Version of this verification block'
+                            },
+                            issuer: {
+                                type: 'object',
+                                properties: {
+                                    aid: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Issuer KERI AID (ACDC sad.i) — the root trust anchor'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the issuer KEL (key state) for signature verification'
+                                    }
+                                },
+                                required: [
+                                    'aid',
+                                    'oobi'
+                                ],
+                                description: 'Credential issuer identity'
+                            },
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    said: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential schema SAID (ACDC sad.s)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the JSON schema; a verifier checks its hash equals said'
+                                    }
+                                },
+                                required: [
+                                    'said',
+                                    'oobi'
+                                ],
+                                description: 'Credential schema — the ACDC structure definition'
+                            },
+                            credential: {
+                                type: 'object',
+                                properties: {
+                                    said: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential SAID (ACDC sad.d)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said'
+                                    },
+                                    registry: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks'
+                                    }
+                                },
+                                required: [
+                                    'said',
+                                    'oobi'
+                                ],
+                                description: 'The verifiable credential (ACDC)'
+                            },
+                            holder: {
+                                type: 'object',
+                                properties: {
+                                    aid: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Issuee/holder KERI AID (ACDC sad.a.i)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the holder KEL'
+                                    }
+                                },
+                                required: [
+                                    'aid',
+                                    'oobi'
+                                ],
+                                description: 'Credential holder/issuee identity'
+                            },
+                            baseUrl: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries'
+                            }
+                        },
+                        required: [
+                            'method',
+                            'issuer',
+                            'schema',
+                            'credential',
+                            'holder'
+                        ]
+                    },
+                    maxItems: 10,
+                    description: 'KERI/Veridian verification claims advertised by this registry entry. Null when none.'
                 }
             },
             required: [
@@ -2088,7 +2217,8 @@ export const AgentMetadataSchema = {
                 'AgentPricing',
                 'image',
                 'metadataVersion',
-                'supportedPaymentSources'
+                'supportedPaymentSources',
+                'verifications'
             ],
             description: 'On-chain metadata for the agent'
         }
@@ -2465,6 +2595,135 @@ export const AgentIdentifierMetadataSchema = {
                     minItems: 1,
                     maxItems: 25,
                     description: 'Payment sources advertised by this registry entry. Null for legacy metadata.'
+                },
+                verifications: {
+                    type: 'array',
+                    nullable: true,
+                    items: {
+                        type: 'object',
+                        properties: {
+                            method: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 40,
+                                description: 'Verification method discriminator, e.g. "KERI-ACDC"'
+                            },
+                            schemaVersion: {
+                                type: 'string',
+                                maxLength: 16,
+                                description: 'Version of this verification block'
+                            },
+                            issuer: {
+                                type: 'object',
+                                properties: {
+                                    aid: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Issuer KERI AID (ACDC sad.i) — the root trust anchor'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the issuer KEL (key state) for signature verification'
+                                    }
+                                },
+                                required: [
+                                    'aid',
+                                    'oobi'
+                                ],
+                                description: 'Credential issuer identity'
+                            },
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    said: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential schema SAID (ACDC sad.s)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the JSON schema; a verifier checks its hash equals said'
+                                    }
+                                },
+                                required: [
+                                    'said',
+                                    'oobi'
+                                ],
+                                description: 'Credential schema — the ACDC structure definition'
+                            },
+                            credential: {
+                                type: 'object',
+                                properties: {
+                                    said: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential SAID (ACDC sad.d)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said'
+                                    },
+                                    registry: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks'
+                                    }
+                                },
+                                required: [
+                                    'said',
+                                    'oobi'
+                                ],
+                                description: 'The verifiable credential (ACDC)'
+                            },
+                            holder: {
+                                type: 'object',
+                                properties: {
+                                    aid: {
+                                        type: 'string',
+                                        minLength: 1,
+                                        maxLength: 128,
+                                        description: 'Issuee/holder KERI AID (ACDC sad.a.i)'
+                                    },
+                                    oobi: {
+                                        type: 'string',
+                                        maxLength: 500,
+                                        format: 'uri',
+                                        description: 'OOBI resolving the holder KEL'
+                                    }
+                                },
+                                required: [
+                                    'aid',
+                                    'oobi'
+                                ],
+                                description: 'Credential holder/issuee identity'
+                            },
+                            baseUrl: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries'
+                            }
+                        },
+                        required: [
+                            'method',
+                            'issuer',
+                            'schema',
+                            'credential',
+                            'holder'
+                        ]
+                    },
+                    maxItems: 10,
+                    description: 'KERI/Veridian verification claims advertised by this registry entry. Null when none.'
                 }
             },
             required: [
@@ -2476,7 +2735,8 @@ export const AgentIdentifierMetadataSchema = {
                 'AgentPricing',
                 'image',
                 'metadataVersion',
-                'supportedPaymentSources'
+                'supportedPaymentSources',
+                'verifications'
             ],
             description: 'On-chain metadata for the agent'
         }
@@ -2880,6 +3140,135 @@ export const RegistryEntrySchema = {
             maxItems: 25,
             description: 'Payment sources advertised by this registry entry. Null for legacy metadata.'
         },
+        verifications: {
+            type: 'array',
+            nullable: true,
+            items: {
+                type: 'object',
+                properties: {
+                    method: {
+                        type: 'string',
+                        minLength: 1,
+                        maxLength: 40,
+                        description: 'Verification method discriminator, e.g. "KERI-ACDC"'
+                    },
+                    schemaVersion: {
+                        type: 'string',
+                        maxLength: 16,
+                        description: 'Version of this verification block'
+                    },
+                    issuer: {
+                        type: 'object',
+                        properties: {
+                            aid: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 128,
+                                description: 'Issuer KERI AID (ACDC sad.i) — the root trust anchor'
+                            },
+                            oobi: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'OOBI resolving the issuer KEL (key state) for signature verification'
+                            }
+                        },
+                        required: [
+                            'aid',
+                            'oobi'
+                        ],
+                        description: 'Credential issuer identity'
+                    },
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            said: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 128,
+                                description: 'Credential schema SAID (ACDC sad.s)'
+                            },
+                            oobi: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'OOBI resolving the JSON schema; a verifier checks its hash equals said'
+                            }
+                        },
+                        required: [
+                            'said',
+                            'oobi'
+                        ],
+                        description: 'Credential schema — the ACDC structure definition'
+                    },
+                    credential: {
+                        type: 'object',
+                        properties: {
+                            said: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 128,
+                                description: 'Credential SAID (ACDC sad.d)'
+                            },
+                            oobi: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said'
+                            },
+                            registry: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 128,
+                                description: 'Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks'
+                            }
+                        },
+                        required: [
+                            'said',
+                            'oobi'
+                        ],
+                        description: 'The verifiable credential (ACDC)'
+                    },
+                    holder: {
+                        type: 'object',
+                        properties: {
+                            aid: {
+                                type: 'string',
+                                minLength: 1,
+                                maxLength: 128,
+                                description: 'Issuee/holder KERI AID (ACDC sad.a.i)'
+                            },
+                            oobi: {
+                                type: 'string',
+                                maxLength: 500,
+                                format: 'uri',
+                                description: 'OOBI resolving the holder KEL'
+                            }
+                        },
+                        required: [
+                            'aid',
+                            'oobi'
+                        ],
+                        description: 'Credential holder/issuee identity'
+                    },
+                    baseUrl: {
+                        type: 'string',
+                        maxLength: 500,
+                        format: 'uri',
+                        description: 'Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries'
+                    }
+                },
+                required: [
+                    'method',
+                    'issuer',
+                    'schema',
+                    'credential',
+                    'holder'
+                ]
+            },
+            maxItems: 10,
+            description: 'KERI/Veridian verification claims advertised by this registry entry. Null when none.'
+        },
         SmartContractWallet: {
             type: 'object',
             properties: {
@@ -2987,6 +3376,7 @@ export const RegistryEntrySchema = {
         'AgentPricing',
         'sendFundingLovelace',
         'supportedPaymentSources',
+        'verifications',
         'SmartContractWallet',
         'RecipientWallet',
         'CurrentTransaction'

--- a/frontend/src/lib/api/generated/types.gen.ts
+++ b/frontend/src/lib/api/generated/types.gen.ts
@@ -1107,6 +1107,79 @@ export type AgentMetadata = {
                 [key: string]: unknown;
             };
         }> | null;
+        /**
+         * KERI/Veridian verification claims advertised by this registry entry. Null when none.
+         */
+        verifications: Array<{
+            /**
+             * Verification method discriminator, e.g. "KERI-ACDC"
+             */
+            method: string;
+            /**
+             * Version of this verification block
+             */
+            schemaVersion?: string;
+            /**
+             * Credential issuer identity
+             */
+            issuer: {
+                /**
+                 * Issuer KERI AID (ACDC sad.i) — the root trust anchor
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the issuer KEL (key state) for signature verification
+                 */
+                oobi: string;
+            };
+            /**
+             * Credential schema — the ACDC structure definition
+             */
+            schema: {
+                /**
+                 * Credential schema SAID (ACDC sad.s)
+                 */
+                said: string;
+                /**
+                 * OOBI resolving the JSON schema; a verifier checks its hash equals said
+                 */
+                oobi: string;
+            };
+            /**
+             * The verifiable credential (ACDC)
+             */
+            credential: {
+                /**
+                 * Credential SAID (ACDC sad.d)
+                 */
+                said: string;
+                /**
+                 * OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said
+                 */
+                oobi: string;
+                /**
+                 * Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks
+                 */
+                registry?: string;
+            };
+            /**
+             * Credential holder/issuee identity
+             */
+            holder: {
+                /**
+                 * Issuee/holder KERI AID (ACDC sad.a.i)
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the holder KEL
+                 */
+                oobi: string;
+            };
+            /**
+             * Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries
+             */
+            baseUrl?: string;
+        }> | null;
     };
 };
 
@@ -1318,6 +1391,79 @@ export type AgentIdentifierMetadata = {
             extra?: {
                 [key: string]: unknown;
             };
+        }> | null;
+        /**
+         * KERI/Veridian verification claims advertised by this registry entry. Null when none.
+         */
+        verifications: Array<{
+            /**
+             * Verification method discriminator, e.g. "KERI-ACDC"
+             */
+            method: string;
+            /**
+             * Version of this verification block
+             */
+            schemaVersion?: string;
+            /**
+             * Credential issuer identity
+             */
+            issuer: {
+                /**
+                 * Issuer KERI AID (ACDC sad.i) — the root trust anchor
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the issuer KEL (key state) for signature verification
+                 */
+                oobi: string;
+            };
+            /**
+             * Credential schema — the ACDC structure definition
+             */
+            schema: {
+                /**
+                 * Credential schema SAID (ACDC sad.s)
+                 */
+                said: string;
+                /**
+                 * OOBI resolving the JSON schema; a verifier checks its hash equals said
+                 */
+                oobi: string;
+            };
+            /**
+             * The verifiable credential (ACDC)
+             */
+            credential: {
+                /**
+                 * Credential SAID (ACDC sad.d)
+                 */
+                said: string;
+                /**
+                 * OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said
+                 */
+                oobi: string;
+                /**
+                 * Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks
+                 */
+                registry?: string;
+            };
+            /**
+             * Credential holder/issuee identity
+             */
+            holder: {
+                /**
+                 * Issuee/holder KERI AID (ACDC sad.a.i)
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the holder KEL
+                 */
+                oobi: string;
+            };
+            /**
+             * Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries
+             */
+            baseUrl?: string;
         }> | null;
     };
 };
@@ -1538,6 +1684,79 @@ export type RegistryEntry = {
         extra?: {
             [key: string]: unknown;
         };
+    }> | null;
+    /**
+     * KERI/Veridian verification claims advertised by this registry entry. Null when none.
+     */
+    verifications: Array<{
+        /**
+         * Verification method discriminator, e.g. "KERI-ACDC"
+         */
+        method: string;
+        /**
+         * Version of this verification block
+         */
+        schemaVersion?: string;
+        /**
+         * Credential issuer identity
+         */
+        issuer: {
+            /**
+             * Issuer KERI AID (ACDC sad.i) — the root trust anchor
+             */
+            aid: string;
+            /**
+             * OOBI resolving the issuer KEL (key state) for signature verification
+             */
+            oobi: string;
+        };
+        /**
+         * Credential schema — the ACDC structure definition
+         */
+        schema: {
+            /**
+             * Credential schema SAID (ACDC sad.s)
+             */
+            said: string;
+            /**
+             * OOBI resolving the JSON schema; a verifier checks its hash equals said
+             */
+            oobi: string;
+        };
+        /**
+         * The verifiable credential (ACDC)
+         */
+        credential: {
+            /**
+             * Credential SAID (ACDC sad.d)
+             */
+            said: string;
+            /**
+             * OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said
+             */
+            oobi: string;
+            /**
+             * Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks
+             */
+            registry?: string;
+        };
+        /**
+         * Credential holder/issuee identity
+         */
+        holder: {
+            /**
+             * Issuee/holder KERI AID (ACDC sad.a.i)
+             */
+            aid: string;
+            /**
+             * OOBI resolving the holder KEL
+             */
+            oobi: string;
+        };
+        /**
+         * Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries
+         */
+        baseUrl?: string;
     }> | null;
     /**
      * Smart contract wallet managing this agent registration
@@ -8049,6 +8268,79 @@ export type PostRegistryData = {
             };
         }>;
         /**
+         * Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only.
+         */
+        verifications?: Array<{
+            /**
+             * Verification method discriminator, e.g. "KERI-ACDC"
+             */
+            method: string;
+            /**
+             * Version of this verification block
+             */
+            schemaVersion?: string;
+            /**
+             * Credential issuer identity
+             */
+            issuer: {
+                /**
+                 * Issuer KERI AID (ACDC sad.i) — the root trust anchor
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the issuer KEL (key state) for signature verification
+                 */
+                oobi: string;
+            };
+            /**
+             * Credential schema — the ACDC structure definition
+             */
+            schema: {
+                /**
+                 * Credential schema SAID (ACDC sad.s)
+                 */
+                said: string;
+                /**
+                 * OOBI resolving the JSON schema; a verifier checks its hash equals said
+                 */
+                oobi: string;
+            };
+            /**
+             * The verifiable credential (ACDC)
+             */
+            credential: {
+                /**
+                 * Credential SAID (ACDC sad.d)
+                 */
+                said: string;
+                /**
+                 * OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said
+                 */
+                oobi: string;
+                /**
+                 * Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks
+                 */
+                registry?: string;
+            };
+            /**
+             * Credential holder/issuee identity
+             */
+            holder: {
+                /**
+                 * Issuee/holder KERI AID (ACDC sad.a.i)
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the holder KEL
+                 */
+                oobi: string;
+            };
+            /**
+             * Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries
+             */
+            baseUrl?: string;
+        }>;
+        /**
          * List of example outputs from the agent
          */
         ExampleOutputs: Array<{
@@ -8356,6 +8648,79 @@ export type PostRegistryUpdateData = {
             extra?: {
                 [key: string]: unknown;
             };
+        }>;
+        /**
+         * Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only.
+         */
+        verifications?: Array<{
+            /**
+             * Verification method discriminator, e.g. "KERI-ACDC"
+             */
+            method: string;
+            /**
+             * Version of this verification block
+             */
+            schemaVersion?: string;
+            /**
+             * Credential issuer identity
+             */
+            issuer: {
+                /**
+                 * Issuer KERI AID (ACDC sad.i) — the root trust anchor
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the issuer KEL (key state) for signature verification
+                 */
+                oobi: string;
+            };
+            /**
+             * Credential schema — the ACDC structure definition
+             */
+            schema: {
+                /**
+                 * Credential schema SAID (ACDC sad.s)
+                 */
+                said: string;
+                /**
+                 * OOBI resolving the JSON schema; a verifier checks its hash equals said
+                 */
+                oobi: string;
+            };
+            /**
+             * The verifiable credential (ACDC)
+             */
+            credential: {
+                /**
+                 * Credential SAID (ACDC sad.d)
+                 */
+                said: string;
+                /**
+                 * OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said
+                 */
+                oobi: string;
+                /**
+                 * Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks
+                 */
+                registry?: string;
+            };
+            /**
+             * Credential holder/issuee identity
+             */
+            holder: {
+                /**
+                 * Issuee/holder KERI AID (ACDC sad.a.i)
+                 */
+                aid: string;
+                /**
+                 * OOBI resolving the holder KEL
+                 */
+                oobi: string;
+            };
+            /**
+             * Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries
+             */
+            baseUrl?: string;
         }>;
         /**
          * List of example outputs from the agent

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -12,6 +12,7 @@ import { cn, shortenAddress } from '@/lib/utils';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { deleteRegistry, RegistryEntry, postRegistryDeregister } from '@/lib/api/generated';
 import { agentHasX402Options } from '@/components/ai-agents/AgentX402Options';
+import { agentHasVerifications } from '@/components/ai-agents/AgentVerifications';
 import { toast } from 'react-toastify';
 import { handleApiCall } from '@/lib/utils';
 import Head from 'next/head';
@@ -691,6 +692,11 @@ export default function AIAgentsPage() {
                             {agentHasX402Options(agent.supportedPaymentSources) && (
                               <div className="mt-1">
                                 <Badge variant="secondary">x402</Badge>
+                              </div>
+                            )}
+                            {agentHasVerifications(agent.verifications) && (
+                              <div className="mt-1">
+                                <Badge variant="outline">Verifiable</Badge>
                               </div>
                             )}
                           </td>

--- a/packages/payment-core/package.json
+++ b/packages/payment-core/package.json
@@ -22,6 +22,7 @@
 		"./payment-source": "./src/payment-source.ts",
 		"./permissions": "./src/permissions.ts",
 		"./smart-contract-state": "./src/smart-contract-state.ts",
+		"./verification": "./src/verification.ts",
 		"./zod": "./src/zod.ts",
 		"./zod-openapi": "./src/zod-openapi.ts"
 	},

--- a/packages/payment-core/src/index.ts
+++ b/packages/payment-core/src/index.ts
@@ -7,6 +7,7 @@ export type PaymentSourceAdapter = {
 
 export { PaymentSourceType };
 export {
+	MAX_SUPPORTED_PAYMENT_SOURCES,
 	SupportedPaymentSourceChain,
 	isCardanoAddressForNetwork,
 	isCardanoPubKeyBaseAddressForNetwork,

--- a/packages/payment-core/src/index.ts
+++ b/packages/payment-core/src/index.ts
@@ -21,6 +21,18 @@ export {
 } from './payment-source';
 export { SmartContractState, smartContractStateEqualsOnChainState } from './smart-contract-state';
 export {
+	VerificationMethod,
+	parseVerificationsFromMetadata,
+	verificationMetadataSchema,
+	verificationRowToApi,
+	verificationSchema,
+	verificationToRow,
+	verificationsSchema,
+	verificationsToMetadata,
+	type AgentVerificationRow,
+	type Verification,
+} from './verification';
+export {
 	decodeBlockchainIdentifier,
 	generateBlockchainIdentifier,
 	type DecodedBlockchainIdentifier,

--- a/packages/payment-core/src/payment-source.ts
+++ b/packages/payment-core/src/payment-source.ts
@@ -87,18 +87,45 @@ function metadataToString(value: string | string[] | undefined) {
 	return value.join('');
 }
 
-export const supportedPaymentSourceMetadataSchema = z.object({
-	chain: metadataStringSchema,
-	network: metadataStringSchema,
+// One asset/amount line inside a `pricing.fixed` array. `asset` is the rail's
+// currency id: `''` (lovelace) or `policyId+assetName` hex for Cardano, the
+// ERC-20 contract `0x…` for x402/EVM. `decimals` is display-only and present
+// for EVM (escrow settles in atomic units, so Cardano may omit it).
+const supportedPaymentSourceMetadataAmountSchema = z.object({
+	asset: metadataStringSchema,
+	amount: metadataStringSchema,
+	decimals: metadataStringSchema.optional(),
+});
+
+// Shared pricing sub-object, identical across rails. `pricingType` is
+// Fixed/Free/Dynamic; `fixed` is present only for Fixed.
+const supportedPaymentSourceMetadataPricingSchema = z.object({
+	pricingType: metadataStringSchema,
+	fixed: z.array(supportedPaymentSourceMetadataAmountSchema).optional(),
+});
+
+// Superset of both rails' settlement fields; the parser reads only the keys
+// relevant to `chain`. Cardano uses `paymentSourceType`/`address` (escrow
+// contract); x402/EVM uses `scheme`/`payTo`/`resource`/`extra`.
+const supportedPaymentSourceMetadataSettlementSchema = z.object({
 	paymentSourceType: metadataStringSchema.optional(),
 	address: metadataStringSchema.optional(),
 	scheme: metadataStringSchema.optional(),
-	asset: metadataStringSchema.optional(),
-	amount: metadataStringSchema.optional(),
-	decimals: metadataStringSchema.optional(),
 	payTo: metadataStringSchema.optional(),
 	resource: metadataStringSchema.optional(),
 	extra: z.unknown().optional(),
+});
+
+// On-chain (CIP-25) shape of one supported payment source. Each leaf may be a
+// single string or an array of <=60-char chunks. A source is self-contained:
+// rail-native `settlement` (where/how funds move) + shared `pricing` (how much).
+// Reassembled into the flat `SupportedPaymentSource` domain shape by
+// `parseSupportedPaymentSourcesFromMetadata`.
+export const supportedPaymentSourceMetadataSchema = z.object({
+	chain: metadataStringSchema,
+	network: metadataStringSchema,
+	settlement: supportedPaymentSourceMetadataSettlementSchema.optional(),
+	pricing: supportedPaymentSourceMetadataPricingSchema.optional(),
 });
 
 function validateCardanoAddressForNetwork(address: string, network: Network) {
@@ -213,19 +240,35 @@ export function parseSupportedPaymentSourcesFromMetadata(value: unknown): Suppor
 	}
 
 	const reparsed = supportedPaymentSourcesSchema.safeParse(
-		parsed.data.map((source) => ({
-			chain: metadataToString(source.chain),
-			network: metadataToString(source.network),
-			paymentSourceType: metadataToString(source.paymentSourceType),
-			address: metadataToString(source.address),
-			scheme: metadataToString(source.scheme),
-			asset: metadataToString(source.asset),
-			amount: metadataToString(source.amount),
-			decimals: metadataToString(source.decimals) != null ? Number(metadataToString(source.decimals)) : undefined,
-			payTo: metadataToString(source.payTo),
-			resource: metadataToString(source.resource),
-			extra: source.extra,
-		})),
+		parsed.data.map((source) => {
+			const chain = metadataToString(source.chain);
+			const settlement = source.settlement ?? {};
+			// x402/EVM money lives in `pricing.fixed` (single entry); Cardano price
+			// is folded in for on-chain self-description but is read internally from
+			// the top-level `agentPricing`, so it is dropped on the way back to the
+			// flat domain shape.
+			const fixed = source.pricing?.fixed?.[0];
+			if (chain === SupportedPaymentSourceChain.EVM) {
+				const decimals = metadataToString(fixed?.decimals);
+				return {
+					chain,
+					network: metadataToString(source.network),
+					scheme: metadataToString(settlement.scheme),
+					asset: metadataToString(fixed?.asset),
+					amount: metadataToString(fixed?.amount),
+					decimals: decimals != null ? Number(decimals) : undefined,
+					payTo: metadataToString(settlement.payTo),
+					resource: metadataToString(settlement.resource),
+					extra: settlement.extra,
+				};
+			}
+			return {
+				chain,
+				network: metadataToString(source.network),
+				paymentSourceType: metadataToString(settlement.paymentSourceType),
+				address: metadataToString(settlement.address),
+			};
+		}),
 	);
 	return reparsed.success ? reparsed.data : null;
 }

--- a/packages/payment-core/src/payment-source.ts
+++ b/packages/payment-core/src/payment-source.ts
@@ -58,10 +58,15 @@ export const supportedPaymentSourceSchema = z.discriminatedUnion('chain', [
 	x402SupportedPaymentSourceSchema,
 ]);
 
+// Hard cap on advertised payment sources, enforced both on parse and when
+// emitting on-chain metadata. v2 auto-injects a Cardano source, so the emitted
+// list must be guarded against overflowing this same limit before minting.
+export const MAX_SUPPORTED_PAYMENT_SOURCES = 25;
+
 export const supportedPaymentSourcesSchema = z
 	.array(supportedPaymentSourceSchema)
 	.min(1)
-	.max(25)
+	.max(MAX_SUPPORTED_PAYMENT_SOURCES)
 	.describe('Payment sources advertised by this registry entry');
 
 export type SupportedPaymentSource = z.infer<typeof supportedPaymentSourceSchema>;

--- a/packages/payment-core/src/verification.spec.ts
+++ b/packages/payment-core/src/verification.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	parseVerificationsFromMetadata,
+	verificationsSchema,
+	verificationsToMetadata,
+	type Verification,
+} from './verification';
+
+const sample: Verification = {
+	method: 'KERI-ACDC',
+	schemaVersion: '1',
+	issuer: {
+		aid: 'EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y',
+		oobi: 'https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness',
+	},
+	schema: {
+		said: 'EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p',
+		oobi: 'https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p',
+	},
+	credential: {
+		said: 'EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z',
+		oobi: 'https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z',
+		registry: 'ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7',
+	},
+	holder: {
+		aid: 'EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4',
+		oobi: 'https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt',
+	},
+	baseUrl: 'https://verify.example.com',
+};
+
+// Mirrors `stringToMetadata(value, forceArray=true)`: short strings become a
+// single-element array, long ones split every 60 chars (CIP-25 64-byte cap).
+function chunk(value: string | undefined | null): string | string[] | undefined {
+	if (value == undefined) return undefined;
+	const out: string[] = [];
+	for (let i = 0; i < value.length; i += 60) out.push(value.slice(i, i + 60));
+	return out;
+}
+
+describe('verification metadata', () => {
+	it('validates a well-formed verification', () => {
+		expect(verificationsSchema.safeParse([sample]).success).toBe(true);
+	});
+
+	it('round-trips through the on-chain representation (chunk -> parse)', () => {
+		const onChain = verificationsToMetadata([sample], chunk);
+		expect(parseVerificationsFromMetadata(onChain)).toEqual([sample]);
+	});
+
+	it('chunks long OOBI URLs into <=60-char segments and reassembles them', () => {
+		const longOobi = `https://witness.example.com/oobi/${'E'.repeat(90)}/witness`;
+		const withLongOobi: Verification = { ...sample, issuer: { ...sample.issuer, oobi: longOobi } };
+		const onChain = verificationsToMetadata([withLongOobi], chunk);
+		expect(Array.isArray(onChain[0].issuer.oobi)).toBe(true);
+		expect((onChain[0].issuer.oobi as string[]).every((segment) => segment.length <= 60)).toBe(true);
+		expect(parseVerificationsFromMetadata(onChain)?.[0].issuer.oobi).toBe(longOobi);
+	});
+
+	it('omits optional fields (registry/baseUrl/schemaVersion) when absent', () => {
+		const minimal: Verification = {
+			method: sample.method,
+			issuer: sample.issuer,
+			schema: sample.schema,
+			credential: { said: sample.credential.said, oobi: sample.credential.oobi },
+			holder: sample.holder,
+		};
+		const onChain = verificationsToMetadata([minimal], chunk);
+		expect(onChain[0].schemaVersion).toBeUndefined();
+		expect(onChain[0].credential.registry).toBeUndefined();
+		expect(onChain[0].baseUrl).toBeUndefined();
+		expect(parseVerificationsFromMetadata(onChain)).toEqual([minimal]);
+	});
+
+	it('returns null for malformed or missing metadata rather than throwing', () => {
+		expect(parseVerificationsFromMetadata(null)).toBeNull();
+		expect(parseVerificationsFromMetadata('nope')).toBeNull();
+		// missing required issuer/schema/credential/holder
+		expect(parseVerificationsFromMetadata([{ method: ['KERI-ACDC'] }])).toBeNull();
+		// non-URL oobi fails the strict re-parse
+		expect(
+			parseVerificationsFromMetadata([{ ...verificationsToMetadata([sample], chunk)[0], baseUrl: ['not a url'] }]),
+		).toBeNull();
+	});
+
+	it('rejects more than the maximum number of verification entries', () => {
+		const many = Array.from({ length: 11 }, () => sample);
+		expect(verificationsSchema.safeParse(many).success).toBe(false);
+	});
+});

--- a/packages/payment-core/src/verification.ts
+++ b/packages/payment-core/src/verification.ts
@@ -1,0 +1,208 @@
+import { z } from './zod';
+
+// KERI/Veridian verification metadata advertised by a registry asset.
+//
+// Lets ANY third party independently verify an agent's identity credential
+// without trusting the issuing SaaS. The on-chain block carries only the KERI
+// trust anchors (AIDs, SAIDs) plus the OOBIs (Out-Of-Band Introductions) where
+// the heavy artifacts — KEL key state, the signed ACDC, the JSON schema, the
+// TEL revocation registry — are fetched and hash-checked against those anchors.
+// The OOBI URLs are untrusted; integrity comes from the on-chain SAIDs/AIDs.
+//
+// It is an array so verification is issuer-agnostic ("not only our claims"):
+// multiple independent issuers may each attest, and a verifier trusts whichever
+// issuer AIDs it chooses. ACDC field references below use `sad.*` notation.
+
+export const VerificationMethod = {
+	KeriAcdc: 'KERI-ACDC',
+} as const;
+
+// A CESR-encoded KERI AID or SAID (self-addressing identifier). Standard
+// prefixes are 44 chars; allow headroom for longer key/derivation codes.
+const keriIdentifierSchema = z.string().min(1).max(128);
+
+// OOBI / resolver URL. KERI OOBIs are http(s) endpoints that serve verifiable
+// material for the AID/SAID embedded in their path.
+const oobiUrlSchema = z.string().url().max(500);
+
+export const verificationSchema = z.object({
+	method: z.string().min(1).max(40).describe('Verification method discriminator, e.g. "KERI-ACDC"'),
+	schemaVersion: z.string().max(16).optional().describe('Version of this verification block'),
+	issuer: z
+		.object({
+			aid: keriIdentifierSchema.describe('Issuer KERI AID (ACDC sad.i) — the root trust anchor'),
+			oobi: oobiUrlSchema.describe('OOBI resolving the issuer KEL (key state) for signature verification'),
+		})
+		.describe('Credential issuer identity'),
+	schema: z
+		.object({
+			said: keriIdentifierSchema.describe('Credential schema SAID (ACDC sad.s)'),
+			oobi: oobiUrlSchema.describe('OOBI resolving the JSON schema; a verifier checks its hash equals said'),
+		})
+		.describe('Credential schema — the ACDC structure definition'),
+	credential: z
+		.object({
+			said: keriIdentifierSchema.describe('Credential SAID (ACDC sad.d)'),
+			oobi: oobiUrlSchema.describe('OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said'),
+			registry: keriIdentifierSchema
+				.optional()
+				.describe('Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks'),
+		})
+		.describe('The verifiable credential (ACDC)'),
+	holder: z
+		.object({
+			aid: keriIdentifierSchema.describe('Issuee/holder KERI AID (ACDC sad.a.i)'),
+			oobi: oobiUrlSchema.describe('OOBI resolving the holder KEL'),
+		})
+		.describe('Credential holder/issuee identity'),
+	baseUrl: oobiUrlSchema
+		.optional()
+		.describe('Optional witness/KERIA resolver root for live key-state ("verify at time T") and TEL queries'),
+});
+
+export const verificationsSchema = z
+	.array(verificationSchema)
+	.max(10)
+	.describe('Independent verification claims advertised by this registry entry (issuer-agnostic, multi-issuer)');
+
+export type Verification = z.infer<typeof verificationSchema>;
+
+// ---- on-chain (CIP-25) representation + (de)serialization ----
+
+const metadataStringSchema = z.string().or(z.array(z.string()).min(1));
+
+function metadataToString(value: string | string[] | undefined) {
+	if (value == undefined) return undefined;
+	if (typeof value === 'string') return value;
+	return value.join('');
+}
+
+// Permissive reader: every leaf may be a single string or an array of <=60-char
+// chunks. Reassembled into the strict `verificationSchema` shape by
+// `parseVerificationsFromMetadata`.
+const verificationMetadataReferenceSchema = z.object({
+	aid: metadataStringSchema.optional(),
+	said: metadataStringSchema.optional(),
+	oobi: metadataStringSchema.optional(),
+	registry: metadataStringSchema.optional(),
+});
+
+export const verificationMetadataSchema = z.object({
+	method: metadataStringSchema,
+	schemaVersion: metadataStringSchema.optional(),
+	issuer: verificationMetadataReferenceSchema.optional(),
+	schema: verificationMetadataReferenceSchema.optional(),
+	credential: verificationMetadataReferenceSchema.optional(),
+	holder: verificationMetadataReferenceSchema.optional(),
+	baseUrl: metadataStringSchema.optional(),
+});
+
+export function parseVerificationsFromMetadata(value: unknown): Verification[] | null {
+	if (value == null) {
+		return null;
+	}
+	const parsed = z.array(verificationMetadataSchema).safeParse(value);
+	if (!parsed.success) {
+		return null;
+	}
+	const reparsed = verificationsSchema.safeParse(
+		parsed.data.map((entry) => ({
+			method: metadataToString(entry.method),
+			schemaVersion: metadataToString(entry.schemaVersion),
+			issuer: entry.issuer
+				? { aid: metadataToString(entry.issuer.aid), oobi: metadataToString(entry.issuer.oobi) }
+				: undefined,
+			schema: entry.schema
+				? { said: metadataToString(entry.schema.said), oobi: metadataToString(entry.schema.oobi) }
+				: undefined,
+			credential: entry.credential
+				? {
+						said: metadataToString(entry.credential.said),
+						oobi: metadataToString(entry.credential.oobi),
+						registry: metadataToString(entry.credential.registry),
+					}
+				: undefined,
+			holder: entry.holder
+				? { aid: metadataToString(entry.holder.aid), oobi: metadataToString(entry.holder.oobi) }
+				: undefined,
+			baseUrl: metadataToString(entry.baseUrl),
+		})),
+	);
+	return reparsed.success ? reparsed.data : null;
+}
+
+// Build the on-chain (CIP-25) representation from validated verifications.
+// `chunk` is the caller's `stringToMetadata` (splits long strings into <=60-char
+// arrays for the CIP-25 64-byte cap); passed in so V1 and V2 builders, which pin
+// different mesh lines, share one emit shape without importing app `src/` here.
+// Flat persisted row shape (mirrors the `AgentVerification` Prisma model). Kept
+// here so the API boundary, serializer, and mint builders share one mapping
+// without importing Prisma types into payment-core.
+export type AgentVerificationRow = {
+	method: string;
+	schemaVersion: string | null;
+	issuerAid: string;
+	issuerOobi: string;
+	schemaSaid: string;
+	schemaOobi: string;
+	credentialSaid: string;
+	credentialOobi: string;
+	credentialRegistry: string | null;
+	holderAid: string;
+	holderOobi: string;
+	baseUrl: string | null;
+};
+
+// Validated nested verification -> flat DB row (createMany on register/update).
+export function verificationToRow(verification: Verification): AgentVerificationRow {
+	return {
+		method: verification.method,
+		schemaVersion: verification.schemaVersion ?? null,
+		issuerAid: verification.issuer.aid,
+		issuerOobi: verification.issuer.oobi,
+		schemaSaid: verification.schema.said,
+		schemaOobi: verification.schema.oobi,
+		credentialSaid: verification.credential.said,
+		credentialOobi: verification.credential.oobi,
+		credentialRegistry: verification.credential.registry ?? null,
+		holderAid: verification.holder.aid,
+		holderOobi: verification.holder.oobi,
+		baseUrl: verification.baseUrl ?? null,
+	};
+}
+
+// Flat DB row -> nested verification (serializing responses and on-chain emit).
+export function verificationRowToApi(row: AgentVerificationRow): Verification {
+	return {
+		method: row.method,
+		...(row.schemaVersion != null ? { schemaVersion: row.schemaVersion } : {}),
+		issuer: { aid: row.issuerAid, oobi: row.issuerOobi },
+		schema: { said: row.schemaSaid, oobi: row.schemaOobi },
+		credential: {
+			said: row.credentialSaid,
+			oobi: row.credentialOobi,
+			...(row.credentialRegistry != null ? { registry: row.credentialRegistry } : {}),
+		},
+		holder: { aid: row.holderAid, oobi: row.holderOobi },
+		...(row.baseUrl != null ? { baseUrl: row.baseUrl } : {}),
+	};
+}
+
+export function verificationsToMetadata(
+	verifications: Verification[],
+	chunk: (value: string | undefined | null) => string | string[] | undefined,
+) {
+	return verifications.map((verification) => ({
+		method: chunk(verification.method),
+		schemaVersion: verification.schemaVersion != null ? chunk(verification.schemaVersion) : undefined,
+		issuer: { aid: chunk(verification.issuer.aid), oobi: chunk(verification.issuer.oobi) },
+		schema: { said: chunk(verification.schema.said), oobi: chunk(verification.schema.oobi) },
+		credential: {
+			said: chunk(verification.credential.said),
+			oobi: chunk(verification.credential.oobi),
+			registry: verification.credential.registry != null ? chunk(verification.credential.registry) : undefined,
+		},
+		holder: { aid: chunk(verification.holder.aid), oobi: chunk(verification.holder.oobi) },
+		baseUrl: verification.baseUrl != null ? chunk(verification.baseUrl) : undefined,
+	}));
+}

--- a/packages/payment-source-v1/src/services/registry/register/service.spec.ts
+++ b/packages/payment-source-v1/src/services/registry/register/service.spec.ts
@@ -47,8 +47,11 @@ describe('V1 registry metadata', () => {
 			{
 				chain: ['Cardano'],
 				network: [Network.Preprod],
-				paymentSourceType: [PaymentSourceType.Web3CardanoV1],
-				address: [smartContractAddress],
+				settlement: {
+					paymentSourceType: [PaymentSourceType.Web3CardanoV1],
+					address: [smartContractAddress],
+				},
+				pricing: { pricingType: PricingType.Free },
 			},
 		]);
 	});

--- a/packages/payment-source-v1/src/services/registry/register/service.ts
+++ b/packages/payment-source-v1/src/services/registry/register/service.ts
@@ -25,6 +25,7 @@ import {
 	resolveRegistryRecipientWalletAddress,
 } from '@/services/registry/shared';
 import { SupportedPaymentSourceChain, type RegistryMetadataPaymentSource } from '@/types/payment-source';
+import { verificationRowToApi, verificationsToMetadata, type AgentVerificationRow } from '@/types/verification';
 
 const mutex = new Mutex();
 
@@ -84,6 +85,8 @@ export function buildAgentMetadata(
 		};
 		metadataVersion: number;
 		SupportedPaymentSources: RegistrySupportedPaymentSourceMetadataRow[];
+		// Persisted AgentVerification rows; reshaped to nested form before emit.
+		Verifications?: AgentVerificationRow[];
 	},
 	paymentSource: RegistryMetadataPaymentSource,
 ): RegistryMetadata {
@@ -101,6 +104,27 @@ export function buildAgentMetadata(
 						address: paymentSource.smartContractAddress,
 					},
 				];
+	// Cardano sources advertise the agent's pricing inline (one self-contained
+	// payable option per source). Derived from the same `request.Pricing` that
+	// still feeds the top-level `agentPricing` block, so the two stay consistent.
+	const cardanoPricingMetadata =
+		request.Pricing.pricingType == PricingType.Fixed
+			? {
+					pricingType: PricingType.Fixed,
+					fixed: (request.Pricing.FixedPricing?.Amounts ?? []).map((pricing) => ({
+						asset: stringToMetadata(pricing.unit, false),
+						amount: pricing.amount.toString(),
+					})),
+				}
+			: { pricingType: request.Pricing.pricingType };
+	// Optional KERI/Veridian verification claims (see @masumi/payment-core/
+	// verification). Gated on the same metadata version as supported_payment_sources
+	// (a v2-metadata concept); self-describing on chain for third-party verification.
+	const verificationRows = request.Verifications ?? [];
+	const verificationsMetadata =
+		request.metadataVersion >= DEFAULTS.DEFAULT_REGISTRY_METADATA_VERSION && verificationRows.length > 0
+			? verificationsToMetadata(verificationRows.map(verificationRowToApi), stringToMetadata)
+			: undefined;
 	const metadata = {
 		name: stringToMetadata(request.name),
 		description: stringToMetadata(request.description),
@@ -129,6 +153,9 @@ export function buildAgentMetadata(
 			other: stringToMetadata(request.other),
 		},
 		tags: request.tags,
+		// V1 (legacy) registries keep the top-level agentPricing block. Only V2
+		// drops it in favour of the per-source pricing folded into each Cardano
+		// supported payment source.
 		agentPricing:
 			request.Pricing.pricingType == PricingType.Fixed
 				? {
@@ -149,11 +176,15 @@ export function buildAgentMetadata(
 				? supportedPaymentSources.map((source) => ({
 						chain: stringToMetadata(source.chain),
 						network: stringToMetadata(String(source.network)),
-						paymentSourceType:
-							source.paymentSourceType != null ? stringToMetadata(source.paymentSourceType) : undefined,
-						address: stringToMetadata(source.chain === 'EVM' ? (source.address ?? source.payTo) : source.address),
+						settlement: {
+							paymentSourceType:
+								source.paymentSourceType != null ? stringToMetadata(source.paymentSourceType) : undefined,
+							address: stringToMetadata(source.address),
+						},
+						pricing: cardanoPricingMetadata,
 					}))
 				: undefined,
+		verifications: verificationsMetadata,
 	};
 	return cleanMetadata(metadata) as RegistryMetadata;
 }

--- a/packages/payment-source-v2/src/services/registry/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry/register/service.ts
@@ -43,7 +43,11 @@ import {
 import { type BatchRegistryMintItem, generateRegistryBatchMintTransaction } from '../../../builders/batch-registry';
 import { ensureCollateralReady } from '../../wallet-collateral/ensure-collateral-ready';
 import { unlockHotWalletIfNoPendingTransaction } from '../../wallet-lock-helpers';
-import { SupportedPaymentSourceChain, type RegistryMetadataPaymentSource } from '@/types/payment-source';
+import {
+	MAX_SUPPORTED_PAYMENT_SOURCES,
+	SupportedPaymentSourceChain,
+	type RegistryMetadataPaymentSource,
+} from '@/types/payment-source';
 import { verificationRowToApi, verificationsToMetadata, type AgentVerificationRow } from '@/types/verification';
 
 // V2 registry batch sizing. The on-chain `MintAction` validator runs once for
@@ -148,6 +152,20 @@ export function buildAgentMetadata(
 	const supportedPaymentSources = hasCardanoSource
 		? request.SupportedPaymentSources
 		: [defaultCardanoSource, ...request.SupportedPaymentSources];
+	// Guard the auto-injected Cardano source against overflowing the on-chain cap:
+	// emitting more than the max would make the entry fail its own re-parse, so a
+	// caller at the limit must leave room for the mandatory Cardano source.
+	if (supportedPaymentSources.length > MAX_SUPPORTED_PAYMENT_SOURCES) {
+		throw new Error(
+			`Cannot register agent: ${supportedPaymentSources.length} payment sources exceed ` +
+				`the on-chain maximum of ${MAX_SUPPORTED_PAYMENT_SOURCES}` +
+				(hasCardanoSource
+					? ''
+					: ` (a Cardano source is added automatically; provide at most ${
+							MAX_SUPPORTED_PAYMENT_SOURCES - 1
+						} other sources)`),
+		);
+	}
 	// Cardano sources advertise the agent's pricing inline (one self-contained
 	// payable option per source), mirroring how x402 sources carry their own
 	// amount. Derived from the same `request.Pricing` that still feeds the

--- a/packages/payment-source-v2/src/services/registry/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry/register/service.ts
@@ -44,6 +44,7 @@ import { type BatchRegistryMintItem, generateRegistryBatchMintTransaction } from
 import { ensureCollateralReady } from '../../wallet-collateral/ensure-collateral-ready';
 import { unlockHotWalletIfNoPendingTransaction } from '../../wallet-lock-helpers';
 import { SupportedPaymentSourceChain, type RegistryMetadataPaymentSource } from '@/types/payment-source';
+import { verificationRowToApi, verificationsToMetadata, type AgentVerificationRow } from '@/types/verification';
 
 // V2 registry batch sizing. The on-chain `MintAction` validator runs once for
 // the policy bucket and verifies every minted asset name against the set of
@@ -126,6 +127,8 @@ export function buildAgentMetadata(
 		};
 		metadataVersion: number;
 		SupportedPaymentSources: RegistrySupportedPaymentSourceMetadataRow[];
+		// Persisted AgentVerification rows; reshaped to nested form before emit.
+		Verifications?: AgentVerificationRow[];
 	},
 	paymentSource: RegistryMetadataPaymentSource,
 ): RegistryMetadata {
@@ -140,6 +143,28 @@ export function buildAgentMetadata(
 						address: paymentSource.smartContractAddress,
 					},
 				];
+	// Cardano sources advertise the agent's pricing inline (one self-contained
+	// payable option per source), mirroring how x402 sources carry their own
+	// amount. Derived from the same `request.Pricing` that still feeds the
+	// top-level `agentPricing` block, so the two stay consistent.
+	const cardanoPricingMetadata =
+		request.Pricing.pricingType == PricingType.Fixed
+			? {
+					pricingType: PricingType.Fixed,
+					fixed: (request.Pricing.FixedPricing?.Amounts ?? []).map((pricing) => ({
+						asset: stringToMetadata(pricing.unit, false),
+						amount: pricing.amount.toString(),
+					})),
+				}
+			: { pricingType: request.Pricing.pricingType };
+	// Optional KERI/Veridian verification claims (see @masumi/payment-core/
+	// verification). Gated on the same metadata version as supported_payment_sources
+	// (a v2-metadata concept); self-describing on chain for third-party verification.
+	const verificationRows = request.Verifications ?? [];
+	const verificationsMetadata =
+		request.metadataVersion >= DEFAULTS.DEFAULT_REGISTRY_METADATA_VERSION && verificationRows.length > 0
+			? verificationsToMetadata(verificationRows.map(verificationRowToApi), stringToMetadata)
+			: undefined;
 	const metadata = {
 		name: stringToMetadata(request.name),
 		description: stringToMetadata(request.description),
@@ -168,19 +193,6 @@ export function buildAgentMetadata(
 			other: stringToMetadata(request.other),
 		},
 		tags: request.tags,
-		agentPricing:
-			request.Pricing.pricingType == PricingType.Fixed
-				? {
-						pricingType: PricingType.Fixed,
-						fixedPricing:
-							request.Pricing.FixedPricing?.Amounts.map((pricing) => ({
-								unit: stringToMetadata(pricing.unit),
-								amount: pricing.amount.toString(),
-							})) ?? [],
-					}
-				: {
-						pricingType: request.Pricing.pricingType,
-					},
 		image: stringToMetadata(DEFAULTS.DEFAULT_IMAGE),
 		metadata_version: request.metadataVersion.toString(),
 		supported_payment_sources:
@@ -194,28 +206,41 @@ export function buildAgentMetadata(
 							// "null"/"undefined"; fail the registration so the bad row is surfaced.
 							throw new Error('Cannot register agent: x402 supported payment source is incomplete');
 						}
+						if (source.chain === SupportedPaymentSourceChain.EVM) {
+							return {
+								chain: stringToMetadata(source.chain),
+								network: stringToMetadata(String(source.network)),
+								settlement: {
+									scheme: stringToMetadata(source.scheme ?? X402PaymentScheme.Exact),
+									payTo: stringToMetadata(source.payTo),
+									resource: stringToMetadata(source.resource),
+									extra: source.extra,
+								},
+								pricing: {
+									pricingType: PricingType.Fixed,
+									fixed: [
+										{
+											asset: stringToMetadata(source.asset, false),
+											amount: String(source.amount),
+											decimals: String(source.decimals),
+										},
+									],
+								},
+							};
+						}
 						return {
 							chain: stringToMetadata(source.chain),
 							network: stringToMetadata(String(source.network)),
-							paymentSourceType:
-								source.paymentSourceType != null ? stringToMetadata(source.paymentSourceType) : undefined,
-							address: stringToMetadata(
-								source.chain === SupportedPaymentSourceChain.EVM ? (source.address ?? source.payTo) : source.address,
-							),
-							...(source.chain === SupportedPaymentSourceChain.EVM
-								? {
-										scheme: stringToMetadata(source.scheme ?? X402PaymentScheme.Exact),
-										asset: stringToMetadata(source.asset),
-										amount: String(source.amount),
-										decimals: String(source.decimals),
-										payTo: stringToMetadata(source.payTo),
-										resource: stringToMetadata(source.resource),
-										extra: source.extra,
-									}
-								: {}),
+							settlement: {
+								paymentSourceType:
+									source.paymentSourceType != null ? stringToMetadata(source.paymentSourceType) : undefined,
+								address: stringToMetadata(source.address),
+							},
+							pricing: cardanoPricingMetadata,
 						};
 					})
 				: undefined,
+		verifications: verificationsMetadata,
 	};
 	return cleanMetadata(metadata) as RegistryMetadata;
 }

--- a/packages/payment-source-v2/src/services/registry/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry/register/service.ts
@@ -132,17 +132,22 @@ export function buildAgentMetadata(
 	},
 	paymentSource: RegistryMetadataPaymentSource,
 ): RegistryMetadata {
-	const supportedPaymentSources =
-		request.SupportedPaymentSources.length > 0
-			? request.SupportedPaymentSources
-			: [
-					{
-						chain: SupportedPaymentSourceChain.Cardano,
-						network: paymentSource.network,
-						paymentSourceType: paymentSource.paymentSourceType,
-						address: paymentSource.smartContractAddress,
-					},
-				];
+	// A Cardano escrow source must always be present: V2 drops the top-level
+	// agentPricing and folds the agent's pricing into the Cardano source, so an
+	// entry advertising only x402/EVM sources would otherwise carry no Cardano
+	// pricing at all (breaking purchase/query, which resolve price from it).
+	const defaultCardanoSource = {
+		chain: SupportedPaymentSourceChain.Cardano,
+		network: paymentSource.network,
+		paymentSourceType: paymentSource.paymentSourceType,
+		address: paymentSource.smartContractAddress,
+	};
+	const hasCardanoSource = request.SupportedPaymentSources.some(
+		(source) => source.chain === SupportedPaymentSourceChain.Cardano,
+	);
+	const supportedPaymentSources = hasCardanoSource
+		? request.SupportedPaymentSources
+		: [defaultCardanoSource, ...request.SupportedPaymentSources];
 	// Cardano sources advertise the agent's pricing inline (one self-contained
 	// payable option per source), mirroring how x402 sources carry their own
 	// amount. Derived from the same `request.Pricing` that still feeds the

--- a/prisma/migrations/20260613000000_add_registry_request_verifications/migration.sql
+++ b/prisma/migrations/20260613000000_add_registry_request_verifications/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable: normalized KERI/Veridian verification claims advertised by a
+-- registry entry. Flat, queryable columns (no JSON blob); the nested
+-- issuer/schema/credential/holder grouping is reconstructed at the API boundary
+-- (see @masumi/payment-core/verification). Emitted into CIP-25 mint/update
+-- metadata for trustless, issuer-agnostic third-party verification.
+CREATE TABLE "AgentVerification" (
+  "id" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "registryRequestId" TEXT NOT NULL,
+  "method" TEXT NOT NULL,
+  "schemaVersion" TEXT,
+  "issuerAid" TEXT NOT NULL,
+  "issuerOobi" TEXT NOT NULL,
+  "schemaSaid" TEXT NOT NULL,
+  "schemaOobi" TEXT NOT NULL,
+  "credentialSaid" TEXT NOT NULL,
+  "credentialOobi" TEXT NOT NULL,
+  "credentialRegistry" TEXT,
+  "holderAid" TEXT NOT NULL,
+  "holderOobi" TEXT NOT NULL,
+  "baseUrl" TEXT,
+  CONSTRAINT "AgentVerification_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AgentVerification_registryRequestId_idx" ON "AgentVerification"("registryRequestId");
+
+ALTER TABLE "AgentVerification" ADD CONSTRAINT "AgentVerification_registryRequestId_fkey" FOREIGN KEY ("registryRequestId") REFERENCES "RegistryRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,6 +270,7 @@ model RegistryRequest {
   requestedById                  String?
   ExampleOutputs                 ExampleOutput[]
   SupportedPaymentSources        SupportedPaymentSource[]
+  Verifications                  AgentVerification[]
   Pricing                        AgentPricing             @relation(fields: [agentPricingId], references: [id])
   CurrentTransaction             Transaction?             @relation(fields: [currentTransactionId], references: [id])
   PaymentSource                  PaymentSource            @relation(fields: [paymentSourceId], references: [id])
@@ -282,6 +283,40 @@ model RegistryRequest {
   @@index([recipientHotWalletId])
   @@index([deregistrationHotWalletId])
   @@index([requestedById])
+}
+
+/// One KERI/Veridian verification claim advertised by a registry entry. Flat,
+/// queryable columns (no JSON blob); the nested issuer/schema/credential/holder
+/// grouping is reconstructed at the API boundary (see @masumi/payment-core/
+/// verification). Emitted into CIP-25 mint/update metadata for trustless,
+/// issuer-agnostic third-party verification.
+model AgentVerification {
+  id                 String          @id @default(cuid())
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  registryRequestId  String
+  /// Verification method discriminator, e.g. "KERI-ACDC".
+  method             String
+  schemaVersion      String?
+  /// Issuer KERI AID (ACDC sad.i) + OOBI resolving its KEL.
+  issuerAid          String
+  issuerOobi         String
+  /// Credential schema SAID (ACDC sad.s) + OOBI resolving the JSON schema.
+  schemaSaid         String
+  schemaOobi         String
+  /// Credential SAID (ACDC sad.d) + OOBI serving the signed ACDC.
+  credentialSaid     String
+  credentialOobi     String
+  /// Credential status registry / TEL SAID (ACDC sad.ri) for revocation. Optional.
+  credentialRegistry String?
+  /// Issuee/holder KERI AID (ACDC sad.a.i) + OOBI resolving its KEL.
+  holderAid          String
+  holderOobi         String
+  /// Optional witness/KERIA resolver root for live key-state and TEL queries.
+  baseUrl            String?
+  RegistryRequest    RegistryRequest @relation(fields: [registryRequestId], references: [id], onDelete: Cascade)
+
+  @@index([registryRequestId])
 }
 
 model SupportedPaymentSource {

--- a/src/routes/api/payments/index.ts
+++ b/src/routes/api/payments/index.ts
@@ -13,6 +13,7 @@ import { metadataToString } from '@/utils/converter/metadata-string-convert';
 import { generateSHA256Hash } from '@/utils/crypto';
 import stringify from 'canonical-json';
 import { fetchAssetInWalletAndMetadata } from '@/services/integrations/asset-metadata';
+import { resolveAgentPricingFromMetadata } from '@/routes/api/registry/wallet';
 import { decodeBlockchainIdentifier, generateBlockchainIdentifier } from '@masumi/payment-core/blockchain-identifier';
 import { buildSignedBlockchainIdentifierPayload } from '@/utils/generator/blockchain-identifier-payload';
 import { validateHexString } from '@/utils/validator/hex';
@@ -174,7 +175,10 @@ export const paymentInitPost = payAuthenticatedEndpointFactory.build({
 		}
 
 		const { assetInWallet, parsedMetadata } = fetchResult.data;
-		const pricing = parsedMetadata.agentPricing;
+		const pricing = resolveAgentPricingFromMetadata(parsedMetadata);
+		if (pricing == null) {
+			throw createHttpError(400, 'Agent metadata does not advertise any pricing');
+		}
 		if (pricing.pricingType == PricingType.Fixed && input.RequestedFunds != null) {
 			throw createHttpError(400, 'For fixed pricing, RequestedFunds must be null');
 		} else if (

--- a/src/routes/api/purchases/shared.ts
+++ b/src/routes/api/purchases/shared.ts
@@ -4,7 +4,7 @@ import { metadataToString } from '@/utils/converter/metadata-string-convert';
 import { generateSHA256Hash } from '@/utils/crypto';
 import { decodeBlockchainIdentifier } from '@masumi/payment-core/blockchain-identifier';
 import { getBlockfrostInstance } from '@/utils/blockfrost';
-import { metadataSchema } from '../registry/wallet';
+import { metadataSchema, resolveAgentPricingFromMetadata } from '../registry/wallet';
 import { normalizePurchaseUnit } from '@/utils/shared/transformers';
 import { validateHexString } from '@/utils/validator/hex';
 import { checkSignature, resolvePaymentKeyHash } from '@meshsdk/core';
@@ -117,7 +117,10 @@ export async function resolvePurchaseCreationContext({
 		throw createHttpError(404, 'Agent identifier metadata invalid or unsupported');
 	}
 
-	const pricing = parsedMetadata.data.agentPricing;
+	const pricing = resolveAgentPricingFromMetadata(parsedMetadata.data);
+	if (pricing == null) {
+		throw createHttpError(400, 'Agent metadata does not advertise any pricing');
+	}
 	if (pricing.pricingType !== PricingType.Fixed && pricing.pricingType !== PricingType.Dynamic) {
 		throw createHttpError(400, 'Agent identifier pricing type not supported');
 	}

--- a/src/routes/api/registry/agent-identifier/index.ts
+++ b/src/routes/api/registry/agent-identifier/index.ts
@@ -8,7 +8,7 @@ import { logger } from '@masumi/payment-core/logger';
 import { extractPolicyId, extractAssetName } from '@/utils/converter/agent-identifier';
 import { validateHexString } from '@/utils/validator/hex';
 import { getBlockfrostInstance } from '@/utils/blockfrost';
-import { metadataSchema } from '@/routes/api/registry/wallet';
+import { metadataSchema, resolveAgentPricingFromMetadata } from '@/routes/api/registry/wallet';
 import { metadataToString } from '@/utils/converter/metadata-string-convert';
 import { buildManagedHolderWalletScopeFilter } from '@/utils/shared/wallet-scope';
 import {
@@ -18,6 +18,7 @@ import {
 	supportedPaymentSourcesSchema,
 	type SupportedPaymentSource,
 } from '@/types/payment-source';
+import { parseVerificationsFromMetadata, verificationsSchema } from '@/types/verification';
 import type { Network as NetworkType } from '@/generated/prisma/client';
 
 function filterValidSupportedPaymentSources(
@@ -143,6 +144,9 @@ const agentMetadataObjectSchema = z.object({
 	supportedPaymentSources: supportedPaymentSourcesSchema
 		.nullable()
 		.describe('Payment sources advertised by this registry entry. Null for legacy metadata.'),
+	verifications: verificationsSchema
+		.nullable()
+		.describe('KERI/Veridian verification claims advertised by this registry entry. Null when none.'),
 });
 
 export const queryAgentByIdentifierSchemaOutput = z
@@ -257,6 +261,11 @@ export const queryAgentByIdentifierGet = readAuthenticatedEndpointFactory.build(
 			throw createHttpError(422, 'Agent metadata is invalid or malformed');
 		}
 
+		const resolvedAgentPricing = resolveAgentPricingFromMetadata(parsedMetadata.data);
+		if (resolvedAgentPricing == null) {
+			throw createHttpError(422, 'Agent metadata does not advertise any pricing');
+		}
+
 		// Step 9: Transform and return
 		return {
 			policyId: policyId,
@@ -293,16 +302,16 @@ export const queryAgentByIdentifierGet = readAuthenticatedEndpointFactory.build(
 					: undefined,
 				Tags: parsedMetadata.data.tags.map((tag) => metadataToString(tag)!),
 				AgentPricing:
-					parsedMetadata.data.agentPricing.pricingType == PricingType.Fixed
+					resolvedAgentPricing.pricingType == PricingType.Fixed
 						? {
-								pricingType: parsedMetadata.data.agentPricing.pricingType,
-								Pricing: parsedMetadata.data.agentPricing.fixedPricing.map((price) => ({
+								pricingType: resolvedAgentPricing.pricingType,
+								Pricing: resolvedAgentPricing.fixedPricing.map((price) => ({
 									amount: price.amount.toString(),
 									unit: metadataToString(price.unit)!,
 								})),
 							}
 						: {
-								pricingType: parsedMetadata.data.agentPricing.pricingType,
+								pricingType: resolvedAgentPricing.pricingType,
 							},
 				image: metadataToString(parsedMetadata.data.image)!,
 				metadataVersion: parsedMetadata.data.metadata_version,
@@ -310,6 +319,7 @@ export const queryAgentByIdentifierGet = readAuthenticatedEndpointFactory.build(
 					parseSupportedPaymentSourcesFromMetadata(parsedMetadata.data.supported_payment_sources),
 					input.network,
 				),
+				verifications: parseVerificationsFromMetadata(parsedMetadata.data.verifications),
 			},
 		};
 	},

--- a/src/routes/api/registry/deregister/index.ts
+++ b/src/routes/api/registry/deregister/index.ts
@@ -12,7 +12,7 @@ import { registryRequestOutputSchema } from '@/routes/api/registry';
 import { getBlockfrostInstance } from '@/utils/blockfrost';
 import { assertHotWalletInScope } from '@/utils/shared/wallet-scope';
 import { retryOnSerializationConflict } from '@/utils/db/retry';
-import { serializeSupportedPaymentSources } from '../serializers';
+import { serializeSupportedPaymentSources, serializeVerifications } from '../serializers';
 
 export const unregisterAgentSchemaInput = z.object({
 	agentIdentifier: z
@@ -185,6 +185,7 @@ export const unregisterAgentPost = payAuthenticatedEndpointFactory.build({
 									select: { walletVkey: true, walletAddress: true },
 								},
 								ExampleOutputs: { select: { name: true, url: true, mimeType: true } },
+								Verifications: true,
 								SupportedPaymentSources: {
 									select: {
 										chain: true,
@@ -250,6 +251,7 @@ export const unregisterAgentPost = payAuthenticatedEndpointFactory.build({
 						},
 			sendFundingLovelace: result.sendFundingLovelace?.toString() ?? null,
 			supportedPaymentSources: serializeSupportedPaymentSources(result.SupportedPaymentSources),
+			verifications: serializeVerifications(result.Verifications),
 			Tags: result.tags,
 			RecipientWallet: result.RecipientWallet,
 			CurrentTransaction: result.CurrentTransaction

--- a/src/routes/api/registry/diff/index.ts
+++ b/src/routes/api/registry/diff/index.ts
@@ -117,6 +117,7 @@ export const queryRegistryDiffGet = readAuthenticatedEndpointFactory.build({
 						mimeType: true,
 					},
 				},
+				Verifications: true,
 				SupportedPaymentSources: {
 					select: {
 						chain: true,

--- a/src/routes/api/registry/examples.ts
+++ b/src/routes/api/registry/examples.ts
@@ -52,6 +52,30 @@ export const registryEntryExample = {
 			address: 'addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm',
 		},
 	],
+	verifications: [
+		{
+			method: 'KERI-ACDC',
+			schemaVersion: '1',
+			issuer: {
+				aid: 'EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y',
+				oobi: 'https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness',
+			},
+			schema: {
+				said: 'EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p',
+				oobi: 'https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p',
+			},
+			credential: {
+				said: 'EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z',
+				oobi: 'https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z',
+				registry: 'ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7',
+			},
+			holder: {
+				aid: 'EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4',
+				oobi: 'https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt',
+			},
+			baseUrl: 'https://verify.example.com',
+		},
+	],
 	SmartContractWallet: {
 		walletVkey: 'wallet_vkey',
 		walletAddress: 'wallet_address',

--- a/src/routes/api/registry/index.ts
+++ b/src/routes/api/registry/index.ts
@@ -12,6 +12,7 @@ import { getBlockfrostInstance, validateAssetsOnChain } from '@/utils/blockfrost
 import { buildManagedHolderWalletScopeFilter } from '@/utils/shared/wallet-scope';
 import { normalizeRequestedRegistryFundingLovelace } from '@/services/registry/shared';
 import { validateSupportedPaymentSourcesOrThrow } from '@/types/payment-source';
+import { verificationToRow } from '@/types/verification';
 import {
 	deleteAgentRegistrationSchemaInput,
 	deleteAgentRegistrationSchemaOutput,
@@ -25,7 +26,11 @@ import {
 	registryRequestOutputSchema,
 } from './schemas';
 import { getRegistryEntriesForQuery } from './queries';
-import { serializeRegistryEntriesResponse, serializeSupportedPaymentSources } from './serializers';
+import {
+	serializeRegistryEntriesResponse,
+	serializeSupportedPaymentSources,
+	serializeVerifications,
+} from './serializers';
 import { resolveScopedRecipientWalletOrThrow, resolveScopedSellingWalletOrThrow } from './shared';
 
 export {
@@ -233,6 +238,9 @@ export const registerAgentPost = payAuthenticatedEndpointFactory.build({
 						},
 					},
 					tags: input.Tags,
+					...(input.verifications && input.verifications.length > 0
+						? { Verifications: { createMany: { data: input.verifications.map(verificationToRow) } } }
+						: {}),
 					Pricing: {
 						create:
 							input.AgentPricing.pricingType == PricingType.Fixed
@@ -277,6 +285,7 @@ export const registerAgentPost = payAuthenticatedEndpointFactory.build({
 							mimeType: true,
 						},
 					},
+					Verifications: true,
 					SupportedPaymentSources: {
 						select: {
 							chain: true,
@@ -337,6 +346,7 @@ export const registerAgentPost = payAuthenticatedEndpointFactory.build({
 							},
 				sendFundingLovelace: result.sendFundingLovelace?.toString() ?? null,
 				supportedPaymentSources: serializeSupportedPaymentSources(result.SupportedPaymentSources),
+				verifications: serializeVerifications(result.Verifications),
 				Tags: result.tags,
 				RecipientWallet: result.RecipientWallet,
 				CurrentTransaction: result.CurrentTransaction
@@ -444,6 +454,7 @@ export const deleteAgentRegistration = adminAuthenticatedEndpointFactory.build({
 					ExampleOutputs: {
 						select: { name: true, url: true, mimeType: true },
 					},
+					Verifications: true,
 					SupportedPaymentSources: {
 						select: {
 							chain: true,
@@ -504,6 +515,7 @@ export const deleteAgentRegistration = adminAuthenticatedEndpointFactory.build({
 							},
 				sendFundingLovelace: item.sendFundingLovelace?.toString() ?? null,
 				supportedPaymentSources: serializeSupportedPaymentSources(item.SupportedPaymentSources),
+				verifications: serializeVerifications(item.Verifications),
 				Tags: item.tags,
 				RecipientWallet: item.RecipientWallet,
 				CurrentTransaction: item.CurrentTransaction

--- a/src/routes/api/registry/queries.ts
+++ b/src/routes/api/registry/queries.ts
@@ -162,6 +162,7 @@ export async function getRegistryEntriesForQuery(
 					mimeType: true,
 				},
 			},
+			Verifications: true,
 			SupportedPaymentSources: {
 				select: {
 					chain: true,

--- a/src/routes/api/registry/schemas.ts
+++ b/src/routes/api/registry/schemas.ts
@@ -6,6 +6,7 @@ import {
 	TransactionStatus,
 } from '@/generated/prisma/client';
 import { supportedPaymentSourcesSchema } from '@/types/payment-source';
+import { verificationsSchema } from '@/types/verification';
 import { z } from '@masumi/payment-core/zod';
 
 export enum FilterStatus {
@@ -135,6 +136,9 @@ export const registryRequestOutputSchema = z
 		supportedPaymentSources: supportedPaymentSourcesSchema
 			.nullable()
 			.describe('Payment sources advertised by this registry entry. Null for legacy metadata.'),
+		verifications: verificationsSchema
+			.nullable()
+			.describe('KERI/Veridian verification claims advertised by this registry entry. Null when none.'),
 		SmartContractWallet: z
 			.object({
 				walletVkey: z.string().describe('Payment key hash of the smart contract wallet'),
@@ -213,6 +217,11 @@ export const registerAgentSchemaInput = z.object({
 		.optional()
 		.describe(
 			'Payment sources to persist for this registry request. If omitted, mint metadata advertises the active payment source.',
+		),
+	verifications: verificationsSchema
+		.optional()
+		.describe(
+			'Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only.',
 		),
 	ExampleOutputs: z
 		.array(

--- a/src/routes/api/registry/serializers.ts
+++ b/src/routes/api/registry/serializers.ts
@@ -1,5 +1,11 @@
 import { Network, PricingType, X402PaymentScheme, type Prisma } from '@/generated/prisma/client';
 import { SupportedPaymentSourceChain, type SupportedPaymentSource } from '@/types/payment-source';
+import {
+	verificationRowToApi,
+	verificationsSchema,
+	type AgentVerificationRow,
+	type Verification,
+} from '@/types/verification';
 import { logger } from '@masumi/payment-core/logger';
 import type { RegistryListRecord } from './queries';
 
@@ -69,6 +75,19 @@ export function serializeSupportedPaymentSources(
 	return serialized.length === 0 ? null : serialized;
 }
 
+// Reassemble persisted AgentVerification rows into the nested API shape. Re-validate
+// and drop (with a log) rather than 500 the page if a row is somehow malformed —
+// same defensive posture as supported payment sources.
+export function serializeVerifications(rows: AgentVerificationRow[] | null | undefined): Verification[] | null {
+	if (rows == null || rows.length === 0) return null;
+	const parsed = verificationsSchema.safeParse(rows.map(verificationRowToApi));
+	if (!parsed.success) {
+		logger.error('Skipping malformed persisted verifications');
+		return null;
+	}
+	return parsed.data;
+}
+
 export function serializeRegistryEntry(item: RegistryListRecord) {
 	return {
 		...item,
@@ -102,6 +121,7 @@ export function serializeRegistryEntry(item: RegistryListRecord) {
 					},
 		sendFundingLovelace: item.sendFundingLovelace?.toString() ?? null,
 		supportedPaymentSources: serializeSupportedPaymentSources(item.SupportedPaymentSources),
+		verifications: serializeVerifications(item.Verifications),
 		Tags: item.tags,
 		CurrentTransaction: item.CurrentTransaction
 			? {

--- a/src/routes/api/registry/update/index.ts
+++ b/src/routes/api/registry/update/index.ts
@@ -13,7 +13,8 @@ import { assertHotWalletInScope } from '@/utils/shared/wallet-scope';
 import { bumpRegistryAssetNameVersionV2 } from '@/services/registry/shared';
 import { recordBusinessEndpointError } from '@masumi/payment-core/metrics';
 import { supportedPaymentSourceSchema, validateSupportedPaymentSourcesOrThrow } from '@/types/payment-source';
-import { serializeSupportedPaymentSources } from '../serializers';
+import { serializeSupportedPaymentSources, serializeVerifications } from '../serializers';
+import { verificationToRow } from '@/types/verification';
 
 const updateSupportedPaymentSourcesSchema = z
 	.array(supportedPaymentSourceSchema)
@@ -304,6 +305,17 @@ export const updateAgentPost = payAuthenticatedEndpointFactory.build({
 						state: RegistrationState.UpdateRequested,
 						error: null,
 						tags: input.Tags,
+						// verifications is OPTIONAL on update: replace only when the caller
+						// provided the field (an empty array clears it); omitting it leaves
+						// the existing rows to carry into the re-mint.
+						...(input.verifications !== undefined
+							? {
+									Verifications: {
+										deleteMany: {},
+										createMany: { data: input.verifications.map(verificationToRow) },
+									},
+								}
+							: {}),
 						// Re-use the deregistration hot-wallet relation as the
 						// holder-side action wallet — the lock-and-query
 						// path already keys non-RegistrationRequested
@@ -373,6 +385,7 @@ export const updateAgentPost = payAuthenticatedEndpointFactory.build({
 						SmartContractWallet: { select: { walletVkey: true, walletAddress: true } },
 						RecipientWallet: { select: { walletVkey: true, walletAddress: true } },
 						ExampleOutputs: { select: { name: true, url: true, mimeType: true } },
+						Verifications: true,
 						SupportedPaymentSources: {
 							select: {
 								chain: true,
@@ -434,6 +447,7 @@ export const updateAgentPost = payAuthenticatedEndpointFactory.build({
 							},
 				sendFundingLovelace: result.sendFundingLovelace?.toString() ?? null,
 				supportedPaymentSources: serializeSupportedPaymentSources(result.SupportedPaymentSources),
+				verifications: serializeVerifications(result.Verifications),
 				Tags: result.tags,
 				RecipientWallet: result.RecipientWallet,
 				CurrentTransaction: result.CurrentTransaction

--- a/src/routes/api/registry/wallet/index.ts
+++ b/src/routes/api/registry/wallet/index.ts
@@ -12,10 +12,12 @@ import { extractAssetName } from '@/utils/converter/agent-identifier';
 import { getBlockfrostInstance } from '@/utils/blockfrost';
 import { assertHotWalletInScope } from '@/utils/shared/wallet-scope';
 import {
+	SupportedPaymentSourceChain,
 	parseSupportedPaymentSourcesFromMetadata,
 	supportedPaymentSourceMetadataSchema,
 	supportedPaymentSourcesSchema,
 } from '@/types/payment-source';
+import { parseVerificationsFromMetadata, verificationMetadataSchema, verificationsSchema } from '@/types/verification';
 
 export const metadataSchema = z.object({
 	name: z
@@ -94,11 +96,47 @@ export const metadataSchema = z.object({
 			z.object({
 				pricingType: z.enum([PricingType.Dynamic]),
 			}),
-		),
+		)
+		// Optional: current metadata folds pricing into each Cardano supported
+		// payment source and drops this top-level block. Legacy entries still carry it.
+		.optional(),
 	image: z.string().or(z.array(z.string())),
 	metadata_version: z.coerce.number().int().min(1).max(2),
 	supported_payment_sources: z.array(supportedPaymentSourceMetadataSchema).optional(),
+	verifications: z.array(verificationMetadataSchema).optional(),
 });
+
+type MetadataAgentPricing = NonNullable<z.infer<typeof metadataSchema>['agentPricing']>;
+
+// Current metadata folds pricing into each Cardano supported payment source and no
+// longer emits a top-level `agentPricing` block. Resolve the effective agent pricing,
+// preferring the per-source Cardano pricing and falling back to the legacy top-level
+// block for entries minted before the move. Returns null only for malformed metadata
+// that carries neither.
+export function resolveAgentPricingFromMetadata(
+	parsed: Pick<z.infer<typeof metadataSchema>, 'agentPricing' | 'supported_payment_sources'>,
+): MetadataAgentPricing | null {
+	const cardanoSource = parsed.supported_payment_sources?.find(
+		(source) => metadataToString(source.chain) === SupportedPaymentSourceChain.Cardano,
+	);
+	const sourcePricing = cardanoSource?.pricing;
+	if (sourcePricing != null) {
+		const pricingType = metadataToString(sourcePricing.pricingType);
+		if (pricingType === PricingType.Fixed) {
+			return {
+				pricingType: PricingType.Fixed,
+				fixedPricing: (sourcePricing.fixed ?? []).map((entry) => ({
+					amount: BigInt(metadataToString(entry.amount) ?? '0'),
+					unit: entry.asset,
+				})),
+			};
+		}
+		if (pricingType === PricingType.Free) return { pricingType: PricingType.Free };
+		if (pricingType === PricingType.Dynamic) return { pricingType: PricingType.Dynamic };
+		return null;
+	}
+	return parsed.agentPricing ?? null;
+}
 
 export const queryAgentFromWalletSchemaInput = z.object({
 	walletVkey: z.string().max(250).describe('The payment key of the wallet to be queried'),
@@ -245,6 +283,9 @@ export const queryAgentFromWalletSchemaOutput = z.object({
 							supportedPaymentSources: supportedPaymentSourcesSchema
 								.nullable()
 								.describe('Payment sources advertised by this registry entry. Null for legacy metadata.'),
+							verifications: verificationsSchema
+								.nullable()
+								.describe('KERI/Veridian verification claims advertised by this registry entry. Null when none.'),
 						})
 						.describe('On-chain metadata for the agent'),
 				})
@@ -322,6 +363,11 @@ export const queryAgentFromWalletGet = readAuthenticatedEndpointFactory.build({
 					logger.error('Error parsing metadata', { error });
 					return;
 				}
+				const resolvedAgentPricing = resolveAgentPricingFromMetadata(parsedMetadata.data);
+				if (resolvedAgentPricing == null) {
+					logger.error('Agent metadata does not advertise any pricing', { unit: asset.unit });
+					return;
+				}
 				detailedAssets.push({
 					unit: asset.unit,
 					Metadata: {
@@ -355,22 +401,23 @@ export const queryAgentFromWalletGet = readAuthenticatedEndpointFactory.build({
 							: undefined,
 						Tags: parsedMetadata.data.tags.map((tag) => metadataToString(tag)!),
 						AgentPricing:
-							parsedMetadata.data.agentPricing.pricingType == PricingType.Fixed
+							resolvedAgentPricing.pricingType == PricingType.Fixed
 								? {
-										pricingType: parsedMetadata.data.agentPricing.pricingType,
-										Pricing: parsedMetadata.data.agentPricing.fixedPricing.map((price) => ({
+										pricingType: resolvedAgentPricing.pricingType,
+										Pricing: resolvedAgentPricing.fixedPricing.map((price) => ({
 											amount: price.amount.toString(),
 											unit: metadataToString(price.unit)!,
 										})),
 									}
 								: {
-										pricingType: parsedMetadata.data.agentPricing.pricingType,
+										pricingType: resolvedAgentPricing.pricingType,
 									},
 						image: metadataToString(parsedMetadata.data.image)!,
 						metadataVersion: parsedMetadata.data.metadata_version,
 						supportedPaymentSources: parseSupportedPaymentSourcesFromMetadata(
 							parsedMetadata.data.supported_payment_sources,
 						),
+						verifications: parseVerificationsFromMetadata(parsedMetadata.data.verifications),
 					},
 				});
 			}),

--- a/src/types/payment-source.ts
+++ b/src/types/payment-source.ts
@@ -1,4 +1,5 @@
 export {
+	MAX_SUPPORTED_PAYMENT_SOURCES,
 	SupportedPaymentSourceChain,
 	isCardanoAddressForNetwork,
 	isCardanoPubKeyBaseAddressForNetwork,

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -1,0 +1,12 @@
+export {
+	VerificationMethod,
+	parseVerificationsFromMetadata,
+	verificationMetadataSchema,
+	verificationRowToApi,
+	verificationSchema,
+	verificationToRow,
+	verificationsSchema,
+	verificationsToMetadata,
+	type AgentVerificationRow,
+	type Verification,
+} from '@masumi/payment-core/verification';

--- a/src/utils/db/lock-and-query-registry-request/index.ts
+++ b/src/utils/db/lock-and-query-registry-request/index.ts
@@ -116,6 +116,7 @@ export async function lockAndQueryRegistryRequests({
 											},
 											ExampleOutputs: true,
 											SupportedPaymentSources: true,
+											Verifications: true,
 										},
 										orderBy: {
 											createdAt: 'asc',

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -2091,6 +2091,135 @@
                                 "minItems": 1,
                                 "maxItems": 25,
                                 "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
+                            },
+                            "verifications": {
+                                "type": "array",
+                                "nullable": true,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "method": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 40,
+                                            "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                        },
+                                        "schemaVersion": {
+                                            "type": "string",
+                                            "maxLength": 16,
+                                            "description": "Version of this verification block"
+                                        },
+                                        "issuer": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential issuer identity"
+                                        },
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential schema SAID (ACDC sad.s)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential schema — the ACDC structure definition"
+                                        },
+                                        "credential": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential SAID (ACDC sad.d)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                },
+                                                "registry": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "The verifiable credential (ACDC)"
+                                        },
+                                        "holder": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the holder KEL"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential holder/issuee identity"
+                                        },
+                                        "baseUrl": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                        }
+                                    },
+                                    "required": [
+                                        "method",
+                                        "issuer",
+                                        "schema",
+                                        "credential",
+                                        "holder"
+                                    ]
+                                },
+                                "maxItems": 10,
+                                "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
                             }
                         },
                         "required": [
@@ -2102,7 +2231,8 @@
                             "AgentPricing",
                             "image",
                             "metadataVersion",
-                            "supportedPaymentSources"
+                            "supportedPaymentSources",
+                            "verifications"
                         ],
                         "description": "On-chain metadata for the agent"
                     }
@@ -2478,6 +2608,135 @@
                                 "minItems": 1,
                                 "maxItems": 25,
                                 "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
+                            },
+                            "verifications": {
+                                "type": "array",
+                                "nullable": true,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "method": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 40,
+                                            "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                        },
+                                        "schemaVersion": {
+                                            "type": "string",
+                                            "maxLength": 16,
+                                            "description": "Version of this verification block"
+                                        },
+                                        "issuer": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential issuer identity"
+                                        },
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential schema SAID (ACDC sad.s)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential schema — the ACDC structure definition"
+                                        },
+                                        "credential": {
+                                            "type": "object",
+                                            "properties": {
+                                                "said": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential SAID (ACDC sad.d)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                },
+                                                "registry": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                }
+                                            },
+                                            "required": [
+                                                "said",
+                                                "oobi"
+                                            ],
+                                            "description": "The verifiable credential (ACDC)"
+                                        },
+                                        "holder": {
+                                            "type": "object",
+                                            "properties": {
+                                                "aid": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 128,
+                                                    "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                },
+                                                "oobi": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "OOBI resolving the holder KEL"
+                                                }
+                                            },
+                                            "required": [
+                                                "aid",
+                                                "oobi"
+                                            ],
+                                            "description": "Credential holder/issuee identity"
+                                        },
+                                        "baseUrl": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                        }
+                                    },
+                                    "required": [
+                                        "method",
+                                        "issuer",
+                                        "schema",
+                                        "credential",
+                                        "holder"
+                                    ]
+                                },
+                                "maxItems": 10,
+                                "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
                             }
                         },
                         "required": [
@@ -2489,7 +2748,8 @@
                             "AgentPricing",
                             "image",
                             "metadataVersion",
-                            "supportedPaymentSources"
+                            "supportedPaymentSources",
+                            "verifications"
                         ],
                         "description": "On-chain metadata for the agent"
                     }
@@ -2892,6 +3152,135 @@
                         "maxItems": 25,
                         "description": "Payment sources advertised by this registry entry. Null for legacy metadata."
                     },
+                    "verifications": {
+                        "type": "array",
+                        "nullable": true,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "method": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 40,
+                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                },
+                                "schemaVersion": {
+                                    "type": "string",
+                                    "maxLength": 16,
+                                    "description": "Version of this verification block"
+                                },
+                                "issuer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "aid": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                        }
+                                    },
+                                    "required": [
+                                        "aid",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential issuer identity"
+                                },
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "said": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                        }
+                                    },
+                                    "required": [
+                                        "said",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential schema — the ACDC structure definition"
+                                },
+                                "credential": {
+                                    "type": "object",
+                                    "properties": {
+                                        "said": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential SAID (ACDC sad.d)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                        },
+                                        "registry": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                        }
+                                    },
+                                    "required": [
+                                        "said",
+                                        "oobi"
+                                    ],
+                                    "description": "The verifiable credential (ACDC)"
+                                },
+                                "holder": {
+                                    "type": "object",
+                                    "properties": {
+                                        "aid": {
+                                            "type": "string",
+                                            "minLength": 1,
+                                            "maxLength": 128,
+                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                        },
+                                        "oobi": {
+                                            "type": "string",
+                                            "maxLength": 500,
+                                            "format": "uri",
+                                            "description": "OOBI resolving the holder KEL"
+                                        }
+                                    },
+                                    "required": [
+                                        "aid",
+                                        "oobi"
+                                    ],
+                                    "description": "Credential holder/issuee identity"
+                                },
+                                "baseUrl": {
+                                    "type": "string",
+                                    "maxLength": 500,
+                                    "format": "uri",
+                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                }
+                            },
+                            "required": [
+                                "method",
+                                "issuer",
+                                "schema",
+                                "credential",
+                                "holder"
+                            ]
+                        },
+                        "maxItems": 10,
+                        "description": "KERI/Veridian verification claims advertised by this registry entry. Null when none."
+                    },
                     "SmartContractWallet": {
                         "type": "object",
                         "properties": {
@@ -2999,6 +3388,7 @@
                     "AgentPricing",
                     "sendFundingLovelace",
                     "supportedPaymentSources",
+                    "verifications",
                     "SmartContractWallet",
                     "RecipientWallet",
                     "CurrentTransaction"
@@ -17367,6 +17757,134 @@
                                         "maxItems": 25,
                                         "description": "Payment sources to persist for this registry request. If omitted, mint metadata advertises the active payment source."
                                     },
+                                    "verifications": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 40,
+                                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                                },
+                                                "schemaVersion": {
+                                                    "type": "string",
+                                                    "maxLength": 16,
+                                                    "description": "Version of this verification block"
+                                                },
+                                                "issuer": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential issuer identity"
+                                                },
+                                                "schema": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential schema — the ACDC structure definition"
+                                                },
+                                                "credential": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential SAID (ACDC sad.d)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                        },
+                                                        "registry": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "The verifiable credential (ACDC)"
+                                                },
+                                                "holder": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the holder KEL"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential holder/issuee identity"
+                                                },
+                                                "baseUrl": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                                }
+                                            },
+                                            "required": [
+                                                "method",
+                                                "issuer",
+                                                "schema",
+                                                "credential",
+                                                "holder"
+                                            ]
+                                        },
+                                        "maxItems": 10,
+                                        "description": "Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only."
+                                    },
                                     "ExampleOutputs": {
                                         "type": "array",
                                         "items": {
@@ -17706,6 +18224,30 @@
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
                                                 }
                                             ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
+                                                }
+                                            ],
                                             "SmartContractWallet": {
                                                 "walletVkey": "wallet_vkey",
                                                 "walletAddress": "wallet_address"
@@ -17828,6 +18370,30 @@
                                                     "network": "Preprod",
                                                     "paymentSourceType": "Web3CardanoV2",
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
+                                                }
+                                            ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
                                                 }
                                             ],
                                             "SmartContractWallet": {
@@ -18199,6 +18765,30 @@
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
                                                 }
                                             ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
+                                                }
+                                            ],
                                             "SmartContractWallet": {
                                                 "walletVkey": "wallet_vkey",
                                                 "walletAddress": "wallet_address"
@@ -18383,6 +18973,134 @@
                                         },
                                         "maxItems": 25,
                                         "description": "Payment sources to replace on this registry request. Provide an empty array to clear them."
+                                    },
+                                    "verifications": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 40,
+                                                    "description": "Verification method discriminator, e.g. \"KERI-ACDC\""
+                                                },
+                                                "schemaVersion": {
+                                                    "type": "string",
+                                                    "maxLength": 16,
+                                                    "description": "Version of this verification block"
+                                                },
+                                                "issuer": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuer KERI AID (ACDC sad.i) — the root trust anchor"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the issuer KEL (key state) for signature verification"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential issuer identity"
+                                                },
+                                                "schema": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential schema SAID (ACDC sad.s)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the JSON schema; a verifier checks its hash equals said"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential schema — the ACDC structure definition"
+                                                },
+                                                "credential": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "said": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential SAID (ACDC sad.d)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI/endpoint serving the signed ACDC; a verifier checks its hash equals said"
+                                                        },
+                                                        "registry": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Credential status registry / TEL SAID (ACDC sad.ri) for independent revocation checks"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "said",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "The verifiable credential (ACDC)"
+                                                },
+                                                "holder": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "aid": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                            "maxLength": 128,
+                                                            "description": "Issuee/holder KERI AID (ACDC sad.a.i)"
+                                                        },
+                                                        "oobi": {
+                                                            "type": "string",
+                                                            "maxLength": 500,
+                                                            "format": "uri",
+                                                            "description": "OOBI resolving the holder KEL"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "aid",
+                                                        "oobi"
+                                                    ],
+                                                    "description": "Credential holder/issuee identity"
+                                                },
+                                                "baseUrl": {
+                                                    "type": "string",
+                                                    "maxLength": 500,
+                                                    "format": "uri",
+                                                    "description": "Optional witness/KERIA resolver root for live key-state (\"verify at time T\") and TEL queries"
+                                                }
+                                            },
+                                            "required": [
+                                                "method",
+                                                "issuer",
+                                                "schema",
+                                                "credential",
+                                                "holder"
+                                            ]
+                                        },
+                                        "maxItems": 10,
+                                        "description": "Optional KERI/Veridian verification claims advertised in the registry metadata for independent third-party verification. Accepted on any registration; surfaced in the UI for V2 registries only."
                                     },
                                     "ExampleOutputs": {
                                         "type": "array",
@@ -18718,6 +19436,30 @@
                                                     "network": "Preprod",
                                                     "paymentSourceType": "Web3CardanoV2",
                                                     "address": "addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm"
+                                                }
+                                            ],
+                                            "verifications": [
+                                                {
+                                                    "method": "KERI-ACDC",
+                                                    "schemaVersion": "1",
+                                                    "issuer": {
+                                                        "aid": "EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y",
+                                                        "oobi": "https://witness.example.com/oobi/EIaIeKvfBLmZf3wfqB0oR1uM5n8m9k2pQ7rT4sV1wX3y/witness"
+                                                    },
+                                                    "schema": {
+                                                        "said": "EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p",
+                                                        "oobi": "https://schema.example.com/oobi/EJ1gXWfzLyW2u0YY5Zb8c4d6e9f1g3h5j7k9l2m4n6p"
+                                                    },
+                                                    "credential": {
+                                                        "said": "EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "oobi": "https://cred.example.com/oobi/EHpH79tPZoSl7VJZ7xMi3JWF4rH9wZ2ntGvKABd9N14z",
+                                                        "registry": "ER7yQ3kL9mN2pT5vX8a1b4c7d0e3f6g9h2j5k8l1m4n7"
+                                                    },
+                                                    "holder": {
+                                                        "aid": "EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4",
+                                                        "oobi": "https://keria.example.com/oobi/EBcd1ef2gh3ij4kl5mn6op7qr8st9uv0wx1yz2ab3cd4/agent/EAgnt"
+                                                    },
+                                                    "baseUrl": "https://verify.example.com"
                                                 }
                                             ],
                                             "SmartContractWallet": {


### PR DESCRIPTION
## Summary

End-to-end **KERI/Veridian agent verifications** plus a **v2 registry metadata** restructure.

### Verifications
- New `verifications` block (issuer / schema / credential / holder AIDs + OOBIs, TEL registry, resolver baseUrl), Zod-validated and multi-issuer (anchors on-chain, evidence fetched + hash-checked off-chain).
- Optional on `register` + `update`; returned by all registry read endpoints.
- Emitted into v2 on-chain CIP-25 metadata; persisted in a normalized `AgentVerification` table (not a JSON blob).
- Frontend: add/edit verifications (v2 only) in the register dialog, detail-view cards for verifications + Cardano/EVM payment sources, and a "Verifiable" list badge.

### v2 metadata schema
- `supported_payment_sources` is now grouped (`settlement` + per-source `pricing`).
- Top-level `agentPricing` is dropped **for v2 only** (kept for v1); price is resolved from the Cardano source, with a legacy fallback in the payment/purchase readers.

### Verification
- `tsc` (backend + frontend) ✓, **430 tests** ✓, lint ✓, swagger + frontend API types regenerated.

Companion PR (registry indexer side): **masumi-registry-service** — adds `Web3CardanoV2` indexing, auto-migration of registry sources, and sync of this metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)