### PR TITLE
fix(registry): always send verifications on v2 agent update

### DIFF
--- a/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
+++ b/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
@@ -565,7 +565,6 @@ export function RegisterAIAgentDialog({
           );
           const hadEvmSources =
             (editingAgent.supportedPaymentSources ?? []).length > existingNonEvmSources.length;
-          const hadVerifications = (editingAgent.verifications ?? []).length > 0;
           const updateResponse = await postRegistryUpdate({
             client: apiClient,
             body: {
@@ -588,9 +587,14 @@ export function RegisterAIAgentDialog({
                     supportedPaymentSources: [...existingNonEvmSources, ...evmSupportedSources],
                   }
                 : {}),
-              ...(verifications.length > 0 || hadVerifications
-                ? { verifications: verificationsToApi(verifications) }
-                : {}),
+              // Update is V2-only (isV2Target is forced true above) and the
+              // form's `verifications` state is the authoritative user-facing
+              // list (loaded from the agent on open). Always send it so the
+              // backend mirrors exactly what the user sees — sending `[]`
+              // clears stored rows. Gating on a derived `hadVerifications`
+              // flag would silently keep stale rows when the list API returns
+              // `verifications: null` for rows it dropped as malformed.
+              verifications: verificationsToApi(verifications),
             },
           });
 


### PR DESCRIPTION
## Problem

On V2 agent update, the `verifications` field was only sent when the form had entries **or** the agent previously had verifications (`hadVerifications`). That flag was derived from the list/detail API's serialized value — which is `null` in two distinct cases:

- the agent genuinely has no verifications, **and**
- the agent has rows the serializer dropped as malformed (`serializeVerifications` returns `null` on `safeParse` failure — `src/routes/api/registry/serializers.ts:84`).

The backend update treats an **omitted** `verifications` field as "no change" and an **empty array** as "clear" (`src/routes/api/registry/update/index.ts:308`). So when serialization returned `null` for malformed-but-present rows, `hadVerifications` stayed `false`, the field was omitted, and the stale rows survived an update the user never saw and could not clear from the UI.

## Fix

Update mode is V2-only (`isV2Target` is forced `true`) and the form's `verifications` state is already the authoritative user-facing list (loaded from the agent on open). So always send `verifications: verificationsToApi(verifications)` on update — an empty array correctly clears stored rows, mirroring exactly what the user sees. Removed the `hadVerifications` guard.

The sibling `supportedPaymentSources`/`hadEvmSources` guard has a similar shape but different semantics (it merges preserved non-EVM sources), so it was intentionally left unchanged.

## Test plan

- [x] `eslint` clean on the changed file
- [x] frontend `tsc --noEmit` passes (pre-push)
- [ ] Manual: update a V2 agent that had verifications, clear the section, confirm stored rows are removed