### PR TITLE
fix(registry): attach mint script per leg in v2 batch builders

### DIFF
--- a/frontend/src/components/ai-agents/MigrateAgentsDialog.tsx
+++ b/frontend/src/components/ai-agents/MigrateAgentsDialog.tsx
@@ -738,8 +738,12 @@ export function MigrateAgentsDialog({ open, onClose, onSuccess }: MigrateAgentsD
             single wide child (long address, a non-wrapping line) would stretch the whole
             dialog past its max width — clipping the right edge and pushing the footer's
             primary button off-screen. `[&>*]:min-w-0` lets each grid row shrink/wrap, and
-            overflow-x-hidden clips any residual so the action button stays in the box. */}
-        <DialogContent className="sm:max-w-[700px] overflow-y-auto overflow-x-hidden max-h-[90vh] [&>*]:min-w-0">
+            overflow-x-hidden clips any residual so the action button stays in the box.
+            `pb-0` removes the base bottom padding: a `sticky bottom-0` child anchors that
+            padding's height ABOVE the real bottom edge, which would leave a gap below the
+            footer where scrolled-out content peeks through. The footer supplies its own
+            bottom spacing via `py-4`. */}
+        <DialogContent className="sm:max-w-[700px] overflow-y-auto overflow-x-hidden max-h-[90vh] pb-0 [&>*]:min-w-0">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <ShieldCheck className="h-5 w-5 text-primary" />
@@ -1094,7 +1098,7 @@ export function MigrateAgentsDialog({ open, onClose, onSuccess }: MigrateAgentsD
             </div>
           )}
 
-          <DialogFooter className="gap-2 sm:gap-0 sticky bottom-0 -mx-6 -mb-6 border-t bg-background px-6 py-4">
+          <DialogFooter className="gap-2 sm:gap-0 sticky bottom-0 -mx-6 border-t bg-background px-6 py-4">
             {!isDone ? (
               <>
                 {/* Cancel-during-run: flips the `cancelRef` flag the loop

--- a/packages/payment-source-v2/src/builders/__tests__/batch-registry.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/batch-registry.test.ts
@@ -1,0 +1,312 @@
+import { jest } from '@jest/globals';
+import type { UTxO } from '@meshsdk/core';
+
+/**
+ * Regression coverage for the V2 batch registry mint/burn builders.
+ *
+ * The bug these guard against: Mesh's `mint()` flushes the PREVIOUS mint item
+ * via `queueMint()`, and `queueMint()` throws
+ * `queueMint: Missing mint script information` unless that previous item
+ * already carries its `scriptSource`. The original builders attached
+ * `mintingScript()` / `mintRedeemerValue()` ONCE after the asset loop, so the
+ * 2nd asset's `mint()` flushed an unscripted 1st item and the whole batch
+ * threw — meaning the builder only ever worked at size 1.
+ *
+ * `FakeMeshTxBuilder` below faithfully replicates the relevant slice of Mesh's
+ * `mint()` / `mintingScript()` / `mintRedeemerValue()` / `queueMint()`
+ * contract (see @meshsdk/transaction dist `MeshTxBuilderCore`). The fake
+ * decouples the test from mesh's CBOR serializer while still failing exactly
+ * the way the real builder would if a leg is left unscripted — so a future
+ * regression to the once-after-the-loop pattern re-breaks this test.
+ */
+
+type MintLeg = {
+	type: 'Plutus' | 'Native';
+	policyId: string;
+	assetName: string;
+	amount: string;
+	scriptSource?: { type: 'Provided'; scriptCode: string };
+	redeemer?: unknown;
+};
+
+const builtBuilders: FakeMeshTxBuilder[] = [];
+
+class FakeMeshTxBuilder {
+	addingPlutusMint = false;
+	mintItem: MintLeg | undefined = undefined;
+	mints: MintLeg[] = [];
+	mintCalls = 0;
+	serializer = {
+		deserializer: {
+			key: {
+				deserializeAddress: (_addr: string) => ({
+					pubKeyHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+				}),
+			},
+		},
+	};
+
+	constructor() {
+		builtBuilders.push(this);
+	}
+
+	protocolParams() {
+		return this;
+	}
+
+	// Mirrors mesh: only arms `addingPlutusMint` for the very NEXT mint() call.
+	mintPlutusScript() {
+		this.addingPlutusMint = true;
+		return this;
+	}
+
+	// Mirrors mesh: flush the pending leg before starting a new one.
+	mint(quantity: string, policy: string, name: string) {
+		this.mintCalls += 1;
+		if (this.mintItem) {
+			this.queueMint();
+		}
+		this.mintItem = {
+			type: this.addingPlutusMint ? 'Plutus' : 'Native',
+			policyId: policy,
+			assetName: name,
+			amount: quantity,
+		};
+		this.addingPlutusMint = false;
+		return this;
+	}
+
+	mintingScript(scriptCode: string) {
+		if (!this.mintItem) throw new Error('Undefined mint');
+		this.mintItem.scriptSource = { type: 'Provided', scriptCode };
+		return this;
+	}
+
+	mintRedeemerValue(redeemer: unknown, _type?: unknown, exUnits?: unknown) {
+		if (!this.mintItem) throw new Error('Undefined mint redeemer');
+		this.mintItem.redeemer = { data: redeemer, exUnits };
+		return this;
+	}
+
+	// Mirrors mesh: an unscripted Plutus leg is the failure the builders must
+	// avoid. Same-policy legs merge (asserting redeemer + scriptSource match).
+	queueMint() {
+		if (!this.mintItem) throw new Error('queueMint: Undefined mint');
+		if (!this.mintItem.scriptSource) {
+			throw new Error('queueMint: Missing mint script information');
+		}
+		const current = this.mintItem;
+		const samePolicy = this.mints.find((m) => m.policyId === current.policyId);
+		if (samePolicy !== undefined) {
+			if (JSON.stringify(samePolicy.redeemer) !== JSON.stringify(current.redeemer)) {
+				throw new Error('queueMint: Redeemer for the same policy id must be the same');
+			}
+			if (JSON.stringify(samePolicy.scriptSource) !== JSON.stringify(current.scriptSource)) {
+				throw new Error('queueMint: Script source for the same policy id must be the same');
+			}
+		}
+		this.mints.push(current);
+		this.mintItem = undefined;
+	}
+
+	metadataValue() {
+		return this;
+	}
+	txIn() {
+		return this;
+	}
+	selectUtxosFrom() {
+		return this;
+	}
+	txInCollateral() {
+		return this;
+	}
+	setTotalCollateral() {
+		return this;
+	}
+	txOut() {
+		return this;
+	}
+	requiredSignerHash() {
+		return this;
+	}
+	setNetwork() {
+		return this;
+	}
+	changeAddress() {
+		return this;
+	}
+
+	async complete() {
+		// mesh flushes the last pending leg at complete()
+		if (this.mintItem) {
+			this.queueMint();
+		}
+		return 'beadface';
+	}
+}
+
+jest.unstable_mockModule('@meshsdk/core', () => ({
+	MeshTxBuilder: FakeMeshTxBuilder,
+}));
+
+jest.unstable_mockModule('@/utils/mesh-cost-model-sync', () => ({
+	getCachedChainProtocolParameters: () => null,
+}));
+
+jest.unstable_mockModule('../../utils/mesh-cost-model-sync', () => ({
+	syncMeshCostModelsFromChainV2: async () => undefined,
+}));
+
+const { generateRegistryBatchMintTransaction, generateRegistryBatchDeregisterTransactionAutomaticFees } =
+	await import('../batch-registry');
+
+const POLICY_ID = 'a'.repeat(56);
+const SCRIPT = { version: 'V3' as const, code: 'aabbccdd' };
+
+const PROTOCOL_PARAMS = {
+	priceMem: '0.0577',
+	priceStep: '0.0000721',
+	collateralPercentage: 150,
+};
+
+function utxo(
+	txHash: string,
+	outputIndex: number,
+	lovelace = '5000000',
+	extraAmount: Array<{ unit: string; quantity: string }> = [],
+): UTxO {
+	return {
+		input: { txHash, outputIndex },
+		output: {
+			address: 'addr_test1placeholder',
+			amount: [{ unit: 'lovelace', quantity: lovelace }, ...extraAmount],
+		},
+	} as unknown as UTxO;
+}
+
+const fetcher = {
+	fetchProtocolParameters: async () => PROTOCOL_PARAMS,
+} as never;
+
+beforeEach(() => {
+	builtBuilders.length = 0;
+});
+
+describe('generateRegistryBatchMintTransaction', () => {
+	const items = [
+		{
+			recipientWalletAddress: 'addr_test1recipient_a',
+			fundingLovelace: '2000000',
+			assetName: '01' + 'aa'.repeat(28) + '000000',
+			firstUtxo: utxo('1111', 0),
+			metadata: { name: 'Agent A' },
+		},
+		{
+			recipientWalletAddress: 'addr_test1recipient_b',
+			fundingLovelace: '2000000',
+			assetName: '02' + 'bb'.repeat(28) + '000000',
+			firstUtxo: utxo('2222', 1),
+			metadata: { name: 'Agent B' },
+		},
+	];
+
+	it('builds a multi-asset (>=2) mint without throwing queueMint: Missing mint script information', async () => {
+		const collateral = utxo('cccc', 0);
+		const wallet = [utxo('cccc', 0), utxo('dddd', 0), utxo('eeee', 0)];
+
+		await expect(
+			generateRegistryBatchMintTransaction(
+				fetcher,
+				'preprod',
+				SCRIPT,
+				'addr_test1minter',
+				POLICY_ID,
+				items,
+				collateral,
+				wallet,
+			),
+		).resolves.toBe('beadface');
+
+		expect(builtBuilders).toHaveLength(1);
+		const builder = builtBuilders[0];
+		// Every minted leg must be queued, typed Plutus, scripted, and carry the
+		// shared MintAction redeemer. The pre-fix code typed legs 2..N as Native
+		// (mintPlutusScript only armed the first mint) and never scripted legs.
+		expect(builder.mints).toHaveLength(2);
+		for (const leg of builder.mints) {
+			expect(leg.type).toBe('Plutus');
+			expect(leg.scriptSource).toEqual({ type: 'Provided', scriptCode: SCRIPT.code });
+			expect(leg.redeemer).toEqual({ data: { alternative: 0, fields: [] }, exUnits: expect.anything() });
+		}
+		expect(builder.mints.map((m) => m.assetName).sort()).toEqual(items.map((i) => i.assetName).sort());
+	});
+
+	it('still builds the single-item batch (no regression at size 1)', async () => {
+		const collateral = utxo('cccc', 0);
+		const wallet = [utxo('cccc', 0), utxo('dddd', 0)];
+
+		await expect(
+			generateRegistryBatchMintTransaction(
+				fetcher,
+				'preprod',
+				SCRIPT,
+				'addr_test1minter',
+				POLICY_ID,
+				[items[0]],
+				collateral,
+				wallet,
+			),
+		).resolves.toBe('beadface');
+		expect(builtBuilders[0].mints).toHaveLength(1);
+		expect(builtBuilders[0].mints[0].type).toBe('Plutus');
+	});
+});
+
+describe('generateRegistryBatchDeregisterTransactionAutomaticFees', () => {
+	it('builds a multi-asset (>=2) burn without throwing queueMint: Missing mint script information', async () => {
+		const assetNameA = '01' + 'aa'.repeat(28) + '000000';
+		const assetNameB = '02' + 'bb'.repeat(28) + '000000';
+		const items = [
+			{
+				assetName: assetNameA,
+				assetUtxo: utxo('1111', 0, '2000000', [{ unit: POLICY_ID + assetNameA, quantity: '1' }]),
+			},
+			{
+				assetName: assetNameB,
+				assetUtxo: utxo('2222', 0, '2000000', [{ unit: POLICY_ID + assetNameB, quantity: '1' }]),
+			},
+		];
+		const collateral = utxo('cccc', 0);
+		const wallet = [utxo('cccc', 0), utxo('dddd', 0)];
+
+		const burnFetcher = {
+			fetchProtocolParameters: async () => PROTOCOL_PARAMS,
+			evaluateTx: async () => [{ tag: 'MINT', index: 0, budget: { mem: 1_000_000, steps: 500_000_000 } }],
+		} as never;
+
+		await expect(
+			generateRegistryBatchDeregisterTransactionAutomaticFees(
+				burnFetcher,
+				'preprod',
+				SCRIPT,
+				'addr_test1burner',
+				POLICY_ID,
+				items,
+				collateral,
+				wallet,
+			),
+		).resolves.toBe('beadface');
+
+		// Two builders are constructed: the evaluation pass and the final pass.
+		// Both must queue both burn legs as scripted Plutus mints (qty -1).
+		const finalBuilder = builtBuilders[builtBuilders.length - 1];
+		expect(finalBuilder.mints).toHaveLength(2);
+		for (const leg of finalBuilder.mints) {
+			expect(leg.type).toBe('Plutus');
+			expect(leg.amount).toBe('-1');
+			expect(leg.scriptSource).toEqual({ type: 'Provided', scriptCode: SCRIPT.code });
+			expect(leg.redeemer).toEqual({ data: { alternative: 2, fields: [] }, exUnits: expect.anything() });
+		}
+	});
+});

--- a/packages/payment-source-v2/src/builders/batch-registry.ts
+++ b/packages/payment-source-v2/src/builders/batch-registry.ts
@@ -175,16 +175,24 @@ export async function generateRegistryBatchMintTransaction(
 	txBuilder.protocolParams(protocolParameters);
 	const deserializedAddress = txBuilder.serializer.deserializer.key.deserializeAddress(mintingWalletAddress);
 
-	// Mint context: select the policy script ONCE, then append every asset.
-	// `mintingScript` + `mintRedeemerValue` apply to the whole policy bucket
-	// — the V2 validator validates the bucket atomically against `MintAction`.
-	txBuilder.mintPlutusScript(script.version);
+	// Mint context: attach the policy script + shared `MintAction` redeemer to
+	// EVERY asset leg. Mesh's `mint()` flushes the previous mint item via
+	// `queueMint()`, which requires that item to already carry its `scriptSource`
+	// — so the script/redeemer must be set per leg, not once after the loop
+	// (doing it once throws `queueMint: Missing mint script information` as soon
+	// as the 2nd asset's `mint()` flushes the 1st). `mintPlutusScript()` must
+	// also precede each `mint()` because it only arms `addingPlutusMint` for the
+	// very next call. `queueMint` then merges every same-policy leg into one
+	// bucket (it asserts the redeemer + scriptSource are identical across legs,
+	// which they are), so the V2 validator still validates the bucket atomically
+	// against a single `MintAction`.
 	for (const item of items) {
-		txBuilder.mint(SERVICE_CONSTANTS.SMART_CONTRACT.mintQuantity, policyId, item.assetName);
+		txBuilder
+			.mintPlutusScript(script.version)
+			.mint(SERVICE_CONSTANTS.SMART_CONTRACT.mintQuantity, policyId, item.assetName)
+			.mintingScript(script.code)
+			.mintRedeemerValue({ alternative: V2_MINT_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits);
 	}
-	txBuilder
-		.mintingScript(script.code)
-		.mintRedeemerValue({ alternative: V2_MINT_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits);
 
 	// Combined CIP-25 metadata: one `721` label with one policy id entry whose
 	// per-asset map covers every minted name. `version: '1'` follows the V1
@@ -389,13 +397,18 @@ async function buildBatchDeregisterTx(
 		txBuilder.txIn(item.assetUtxo.input.txHash, item.assetUtxo.input.outputIndex);
 	}
 
-	txBuilder.mintPlutusScript(script.version);
+	// Per-leg script + shared `BurnAction` redeemer attachment. See the mint
+	// builder above for why this must be done inside the loop and not once
+	// after it (Mesh's `mint()` flushes the prior leg via `queueMint()`, which
+	// requires the leg's `scriptSource` to already be set, else it throws
+	// `queueMint: Missing mint script information`).
 	for (const item of items) {
-		txBuilder.mint('-1', policyId, item.assetName);
+		txBuilder
+			.mintPlutusScript(script.version)
+			.mint('-1', policyId, item.assetName)
+			.mintingScript(script.code)
+			.mintRedeemerValue({ alternative: V2_BURN_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits);
 	}
-	txBuilder
-		.mintingScript(script.code)
-		.mintRedeemerValue({ alternative: V2_BURN_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits);
 
 	// Hand remaining wallet UTxOs to Mesh's coin selector instead of force-adding
 	// every one. Anything already declared as a `.txIn` above (via inputRefs) is


### PR DESCRIPTION
## Problem

Batch register/deregister failed with:

> `queueMint: Missing mint script information`

## Root cause

Mesh's `mint()` flushes the **previous** mint leg via `queueMint()`, which requires that leg to already carry its `scriptSource`. The V2 batch mint/burn builders attached `mintingScript()` / `mintRedeemerValue()` **once after** the asset loop:

```ts
txBuilder.mintPlutusScript(version);
for (item) txBuilder.mint(qty, policy, name);   // 2nd item flushes an unscripted 1st leg → throw
txBuilder.mintingScript(code).mintRedeemerValue(...);
```

So on the 2nd asset, leg 1 is flushed with no script and `queueMint` throws. Secondary bug: `mintPlutusScript()` only arms the *next* `mint()`, so legs 2..N would be typed `Native`. Net effect: the batch builder only ever worked at size 1 — which is why the recent size-shrink path "succeeded" by shrinking to a single item.

## Fix

Attach the policy script + shared redeemer **per leg** inside the loop (canonical Mesh multi-asset pattern). `queueMint` merges same-policy legs into one atomic bucket (it asserts redeemer + scriptSource are identical across legs). Applied to both the mint builder (`generateRegistryBatchMintTransaction`) and the burn/deregister builder (`buildBatchDeregisterTx`), which had the same latent bug for ≥2 burns.

## Test

Adds `batch-registry.test.ts` with a faithful `FakeMeshTxBuilder` replicating Mesh's `mint`/`queueMint` contract (throws the exact error on an unscripted leg), so a regression to the old once-after-the-loop pattern re-breaks the test. Covers ≥2-item mint, single-item mint, and ≥2-item burn.

- New test: 3/3 pass
- Full v2 builders suite: 70/70 pass
- `tsc --noEmit` (pre-push) clean