### PR TITLE
fix(registry): v2 update mint, idempotent delete, server-side payment-source filter

### DIFF
--- a/frontend/openapi-docs.json
+++ b/frontend/openapi-docs.json
@@ -17485,6 +17485,26 @@
                         "description": "When set, return only the registry entry whose on-chain agent identifier matches exactly (same scope as list: network, payment source, and wallet permissions)",
                         "name": "filterAgentIdentifier",
                         "in": "query"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "description": "Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR."
+                        },
+                        "required": false,
+                        "description": "Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR.",
+                        "name": "filterSupportedPaymentSourceAddress",
+                        "in": "query"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "description": "Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR."
+                        },
+                        "required": false,
+                        "description": "Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR.",
+                        "name": "filterSupportedPaymentSourceNetworks",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/frontend/src/lib/api/generated/types.gen.ts
+++ b/frontend/src/lib/api/generated/types.gen.ts
@@ -8163,6 +8163,14 @@ export type GetRegistryData = {
          * When set, return only the registry entry whose on-chain agent identifier matches exactly (same scope as list: network, payment source, and wallet permissions)
          */
         filterAgentIdentifier?: string;
+        /**
+         * Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR.
+         */
+        filterSupportedPaymentSourceAddress?: string;
+        /**
+         * Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR.
+         */
+        filterSupportedPaymentSourceNetworks?: string;
     };
     url: '/registry';
 };

--- a/frontend/src/lib/queries/useContextAgents.ts
+++ b/frontend/src/lib/queries/useContextAgents.ts
@@ -24,6 +24,11 @@ type AgentQuery = {
   filterStatus?: 'Registered' | 'Deregistered' | 'Pending' | 'Failed';
   searchQuery?: string;
   filterSmartContractAddress?: string;
+  // Server-side "advertises this payment source" filters. Either matches an
+  // entry's supportedPaymentSources so the payment-target list no longer pages
+  // every agent on the network and filters client-side.
+  filterSupportedPaymentSourceAddress?: string;
+  filterSupportedPaymentSourceNetworks?: string;
 };
 
 async function fetchAllAgents(
@@ -45,6 +50,8 @@ async function fetchAllAgents(
             filterStatus: extra.filterStatus,
             searchQuery: extra.searchQuery || undefined,
             filterSmartContractAddress: extra.filterSmartContractAddress,
+            filterSupportedPaymentSourceAddress: extra.filterSupportedPaymentSourceAddress,
+            filterSupportedPaymentSourceNetworks: extra.filterSupportedPaymentSourceNetworks,
           },
         }),
       { errorMessage: 'Failed to load AI agents' },
@@ -91,16 +98,41 @@ export function useContextAgents(params?: {
   const sourceAddress =
     selectedPaymentSource?.network === network ? selectedPaymentSource.smartContractAddress : null;
 
-  // Every agent on the network, used to find entries that accept payment on this context
-  // regardless of where they are registered.
+  // CAIP-2 ids of the EVM chains active in this environment, as the comma-separated
+  // value the registry endpoint's filterSupportedPaymentSourceNetworks expects.
+  const envChainIdsCsv = useMemo(() => [...envChainIds].join(','), [envChainIds]);
+
+  // Agents that accept payment on THIS context as a payment target (regardless of where
+  // they are registered). Previously this paged every agent on the network and matched
+  // `supportedPaymentSources` client-side; now the registry endpoint filters by the
+  // selected source address (Cardano) or active EVM chain ids (x402) server-side.
+  // Disabled until we have something to scope by, so we never fetch the whole network.
+  const paymentScope: Pick<
+    AgentQuery,
+    'filterSupportedPaymentSourceAddress' | 'filterSupportedPaymentSourceNetworks'
+  > =
+    activeRail === 'x402'
+      ? { filterSupportedPaymentSourceNetworks: envChainIdsCsv || undefined }
+      : { filterSupportedPaymentSourceAddress: sourceAddress ?? undefined };
+  const hasPaymentScope = activeRail === 'x402' ? !!envChainIdsCsv : !!sourceAddress;
+
   const allQuery = useQuery({
-    queryKey: ['context-agents', 'all', network, params?.filterStatus, params?.searchQuery],
+    queryKey: [
+      'context-agents',
+      'payment',
+      network,
+      activeRail,
+      activeRail === 'x402' ? envChainIdsCsv : sourceAddress,
+      params?.filterStatus,
+      params?.searchQuery,
+    ],
     queryFn: () =>
       fetchAllAgents(apiClient, network, {
         filterStatus: params?.filterStatus,
         searchQuery: params?.searchQuery,
+        ...paymentScope,
       }),
-    enabled: !!apiClient && authorized,
+    enabled: !!apiClient && authorized && hasPaymentScope,
     staleTime: 15000,
     // Keep showing the previous results while a status/search change refetches, so the
     // table can dim (isPlaceholderData) rather than flashing empty mid-search.

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -176,6 +176,13 @@ export default function AIAgentsPage() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [selectedAgentToDelete, setSelectedAgentToDelete] = useState<AIAgent | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  // Synchronous in-flight guard for delete/deregister. `setIsDeleting(true)` is
+  // async, so a fast double-click on Confirm fires `handleDeleteConfirm` twice
+  // before the button disables — sending two DELETEs for the same id. The second
+  // then races the first (the backend reports the row already gone). A ref flips
+  // synchronously on the first call so the duplicate is rejected immediately;
+  // `isDeleting` on the button is post-render defence-in-depth.
+  const isDeletingRef = useRef(false);
   const [selectedAgentToUpdate, setSelectedAgentToUpdate] = useState<AIAgent | null>(null);
   // Snapshot the agent's payment-source smart-contract address AT CLICK TIME.
   // The agent list is already filtered to `selectedPaymentSource`, so at the
@@ -321,6 +328,16 @@ export default function AIAgentsPage() {
   };
 
   const handleDeleteConfirm = async () => {
+    if (isDeletingRef.current) return;
+    isDeletingRef.current = true;
+    try {
+      await runDeleteConfirm();
+    } finally {
+      isDeletingRef.current = false;
+    }
+  };
+
+  const runDeleteConfirm = async () => {
     if (
       selectedAgentToDelete?.state === 'RegistrationFailed' ||
       selectedAgentToDelete?.state === 'DeregistrationConfirmed'

--- a/src/routes/api/registry/index.ts
+++ b/src/routes/api/registry/index.ts
@@ -1,13 +1,15 @@
 import { payAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import { readAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import { z } from '@masumi/payment-core/zod';
-import { PaymentSourceType, PricingType, Prisma, RegistrationState } from '@/generated/prisma/client';
+import { PaymentSourceType, PricingType, RegistrationState } from '@/generated/prisma/client';
+import type { Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import createHttpError from 'http-errors';
 import { DEFAULTS } from '@masumi/payment-core/config';
 import { AuthContext, checkIsAllowedNetworkOrThrowUnauthorized } from '@masumi/payment-core/auth';
 import { adminAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import { recordBusinessEndpointError } from '@masumi/payment-core/metrics';
+import { logger } from '@masumi/payment-core/logger';
 import { getBlockfrostInstance, validateAssetsOnChain } from '@/utils/blockfrost';
 import { buildManagedHolderWalletScopeFilter } from '@/utils/shared/wallet-scope';
 import { normalizeRequestedRegistryFundingLovelace } from '@/services/registry/shared';
@@ -383,20 +385,59 @@ export const deleteAgentRegistration = adminAuthenticatedEndpointFactory.build({
 	handler: async ({ input }) => {
 		const startTime = Date.now();
 		try {
+			// Shared include so the record we read up front matches the shape we
+			// return — this lets us return the already-read record verbatim if the
+			// delete races with a concurrent removal (see the P2025 handling below).
+			const deleteRegistryInclude = {
+				Pricing: {
+					include: {
+						FixedPricing: {
+							include: { Amounts: { select: { unit: true, amount: true } } },
+						},
+					},
+				},
+				SmartContractWallet: {
+					select: { walletVkey: true, walletAddress: true },
+				},
+				RecipientWallet: {
+					select: { walletVkey: true, walletAddress: true },
+				},
+				ExampleOutputs: {
+					select: { name: true, url: true, mimeType: true },
+				},
+				Verifications: true,
+				SupportedPaymentSources: {
+					select: {
+						chain: true,
+						network: true,
+						paymentSourceType: true,
+						address: true,
+						scheme: true,
+						asset: true,
+						amount: true,
+						decimals: true,
+						payTo: true,
+						resource: true,
+						extra: true,
+					},
+				},
+				CurrentTransaction: {
+					select: {
+						txHash: true,
+						status: true,
+						confirmations: true,
+						fees: true,
+						blockHeight: true,
+						blockTime: true,
+					},
+				},
+			} satisfies Prisma.RegistryRequestInclude;
+
 			const registryRequest = await prisma.registryRequest.findUnique({
 				where: {
 					id: input.id,
 				},
-				include: {
-					PaymentSource: {
-						select: {
-							id: true,
-							network: true,
-							policyId: true,
-							smartContractAddress: true,
-						},
-					},
-				},
+				include: deleteRegistryInclude,
 			});
 
 			if (!registryRequest) {
@@ -433,55 +474,44 @@ export const deleteAgentRegistration = adminAuthenticatedEndpointFactory.build({
 				);
 			}
 
-			const item = await prisma.registryRequest.delete({
-				where: {
-					id: registryRequest.id,
-				},
-				include: {
-					Pricing: {
-						include: {
-							FixedPricing: {
-								include: { Amounts: { select: { unit: true, amount: true } } },
-							},
-						},
+			const item = await prisma.registryRequest
+				.delete({
+					where: {
+						id: registryRequest.id,
 					},
-					SmartContractWallet: {
-						select: { walletVkey: true, walletAddress: true },
-					},
-					RecipientWallet: {
-						select: { walletVkey: true, walletAddress: true },
-					},
-					ExampleOutputs: {
-						select: { name: true, url: true, mimeType: true },
-					},
-					Verifications: true,
-					SupportedPaymentSources: {
-						select: {
-							chain: true,
-							network: true,
-							paymentSourceType: true,
-							address: true,
-							scheme: true,
-							asset: true,
-							amount: true,
-							decimals: true,
-							payTo: true,
-							resource: true,
-							extra: true,
-						},
-					},
-					CurrentTransaction: {
-						select: {
-							txHash: true,
-							status: true,
-							confirmations: true,
-							fees: true,
-							blockHeight: true,
-							blockTime: true,
-						},
-					},
-				},
-			});
+					include: deleteRegistryInclude,
+				})
+				.catch(async (error: unknown) => {
+					// P2025 = "record required but not found" for the delete. With a
+					// pure-id delete this can only happen when the row was already gone
+					// at delete time — i.e. a duplicate/concurrent DELETE for the same id
+					// removed it first (this endpoint is the ONLY code that deletes
+					// registry rows). Confirm it is genuinely gone before reporting
+					// success rather than assuming: if it is gone, deletion is idempotent
+					// so return the record we already read and let the client close the
+					// dialog and drop the row (the previous behaviour surfaced an opaque
+					// 500 and left the stale row on screen). If — against expectation —
+					// the row is still present, surface a retryable error instead of
+					// faking a success the UI can't honour.
+					// Structural P2025 check (not `instanceof Prisma.*`) to match the
+					// rest of this route dir (see update/index.ts) and stay compatible
+					// with the unit-test prisma mock, which re-exports enums only and has
+					// no `Prisma` namespace at runtime.
+					if ((error as { code?: string }).code === 'P2025') {
+						const stillExists = await prisma.registryRequest.findUnique({
+							where: { id: registryRequest.id },
+							select: { id: true },
+						});
+						if (!stillExists) {
+							logger.info('Registry delete raced with a concurrent removal; row already gone, treating as deleted', {
+								id: input.id,
+							});
+							return registryRequest;
+						}
+						throw createHttpError(409, 'Agent Registration could not be deleted; please retry');
+					}
+					throw error;
+				});
 
 			return {
 				...item,

--- a/src/routes/api/registry/queries.ts
+++ b/src/routes/api/registry/queries.ts
@@ -1,4 +1,5 @@
 import { PricingType, RegistrationState } from '@/generated/prisma/client';
+import type { Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { AuthContext } from '@masumi/payment-core/auth';
 import { parseAmountSearchRange } from '@/utils/shared/queries';
@@ -62,6 +63,21 @@ export async function getRegistryEntriesForQuery(
 		? parseAmountSearchRange(searchLower)
 		: undefined;
 
+	// Optional server-side "advertises this payment source" filter. The frontend
+	// AI Agents page needs agents that accept a given Cardano source (by address)
+	// or x402 EVM chain (by CAIP-2 network) as a PAYMENT target, regardless of
+	// where they are registered. Without this it had to page every agent on the
+	// network and match `supportedPaymentSources` client-side. Address and
+	// networks are OR-ed so a single `some` row matching either qualifies.
+	const supportedNetworks = input.filterSupportedPaymentSourceNetworks
+		?.split(',')
+		.map((value) => value.trim())
+		.filter((value) => value.length > 0);
+	const supportedPaymentSourceOr: Prisma.SupportedPaymentSourceWhereInput[] = [
+		...(input.filterSupportedPaymentSourceAddress ? [{ address: input.filterSupportedPaymentSourceAddress }] : []),
+		...(supportedNetworks && supportedNetworks.length > 0 ? [{ network: { in: supportedNetworks } }] : []),
+	];
+
 	return prisma.registryRequest.findMany({
 		where: {
 			PaymentSource: {
@@ -74,6 +90,9 @@ export async function getRegistryEntriesForQuery(
 			...buildManagedHolderWalletScopeFilter(walletScopeIds),
 			...(stateFilter ? { state: { in: stateFilter } } : {}),
 			...(input.filterAgentIdentifier ? { agentIdentifier: input.filterAgentIdentifier } : {}),
+			...(supportedPaymentSourceOr.length > 0
+				? { SupportedPaymentSources: { some: { OR: supportedPaymentSourceOr } } }
+				: {}),
 			...(searchLower
 				? {
 						OR: [

--- a/src/routes/api/registry/schemas.ts
+++ b/src/routes/api/registry/schemas.ts
@@ -41,6 +41,18 @@ export const queryRegistryRequestSchemaInput = z.object({
 		.describe(
 			'When set, return only the registry entry whose on-chain agent identifier matches exactly (same scope as list: network, payment source, and wallet permissions)',
 		),
+	filterSupportedPaymentSourceAddress: z
+		.string()
+		.optional()
+		.describe(
+			'Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR.',
+		),
+	filterSupportedPaymentSourceNetworks: z
+		.string()
+		.optional()
+		.describe(
+			'Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR.',
+		),
 });
 
 export const registryRequestOutputSchema = z

--- a/src/services/registry/shared.spec.ts
+++ b/src/services/registry/shared.spec.ts
@@ -1,0 +1,217 @@
+import { jest } from '@jest/globals';
+import type { UTxO } from '@meshsdk/core';
+import { SERVICE_CONSTANTS } from '@masumi/payment-core/config';
+
+/**
+ * Regression coverage for the V2 registry UpdateAction transaction builder
+ * (`generateRegistryUpdateTransactionAutomaticFees`).
+ *
+ * The bug this guards against: an update burns the old asset and mints the new
+ * one — two mint legs under one policy. Mesh's `mint()` flushes the PREVIOUS
+ * leg via `queueMint()`, and `queueMint()` throws
+ * `queueMint: Missing mint script information` unless that leg already carries
+ * its `scriptSource`. The original builder attached `mintingScript()` /
+ * `mintRedeemerValue()` ONCE after both `mint()` calls, so the mint-new leg's
+ * `mint()` flushed an unscripted burn-old leg and the whole update threw — the
+ * exact `queueMint: Missing mint script information` surfaced in production.
+ *
+ * `FakeMeshTxBuilder` faithfully replicates the relevant slice of Mesh's
+ * `mint()` / `mintingScript()` / `mintRedeemerValue()` / `queueMint()` contract
+ * (see @meshsdk/transaction dist `MeshTxBuilderCore`) so a regression to the
+ * once-after-both pattern re-breaks this test.
+ */
+
+type MintLeg = {
+	type: 'Plutus' | 'Native';
+	policyId: string;
+	assetName: string;
+	amount: string;
+	scriptSource?: { type: 'Provided'; scriptCode: string };
+	redeemer?: unknown;
+};
+
+const builtBuilders: FakeMeshTxBuilder[] = [];
+
+class FakeMeshTxBuilder {
+	addingPlutusMint = false;
+	mintItem: MintLeg | undefined = undefined;
+	mints: MintLeg[] = [];
+	serializer = {
+		deserializer: {
+			key: {
+				deserializeAddress: (_addr: string) => ({
+					pubKeyHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+				}),
+			},
+		},
+	};
+
+	constructor() {
+		builtBuilders.push(this);
+	}
+
+	protocolParams() {
+		return this;
+	}
+
+	mintPlutusScript() {
+		this.addingPlutusMint = true;
+		return this;
+	}
+
+	mint(quantity: string, policy: string, name: string) {
+		if (this.mintItem) {
+			this.queueMint();
+		}
+		this.mintItem = {
+			type: this.addingPlutusMint ? 'Plutus' : 'Native',
+			policyId: policy,
+			assetName: name,
+			amount: quantity,
+		};
+		this.addingPlutusMint = false;
+		return this;
+	}
+
+	mintingScript(scriptCode: string) {
+		if (!this.mintItem) throw new Error('Undefined mint');
+		this.mintItem.scriptSource = { type: 'Provided', scriptCode };
+		return this;
+	}
+
+	mintRedeemerValue(redeemer: unknown, _type?: unknown, exUnits?: unknown) {
+		if (!this.mintItem) throw new Error('Undefined mint redeemer');
+		this.mintItem.redeemer = { data: redeemer, exUnits };
+		return this;
+	}
+
+	queueMint() {
+		if (!this.mintItem) throw new Error('queueMint: Undefined mint');
+		if (!this.mintItem.scriptSource) {
+			throw new Error('queueMint: Missing mint script information');
+		}
+		const current = this.mintItem;
+		const samePolicy = this.mints.find((m) => m.policyId === current.policyId);
+		if (samePolicy !== undefined) {
+			if (JSON.stringify(samePolicy.redeemer) !== JSON.stringify(current.redeemer)) {
+				throw new Error('queueMint: Redeemer for the same policy id must be the same');
+			}
+			if (JSON.stringify(samePolicy.scriptSource) !== JSON.stringify(current.scriptSource)) {
+				throw new Error('queueMint: Script source for the same policy id must be the same');
+			}
+		}
+		this.mints.push(current);
+		this.mintItem = undefined;
+	}
+
+	metadataValue() {
+		return this;
+	}
+	txIn() {
+		return this;
+	}
+	selectUtxosFrom() {
+		return this;
+	}
+	txInCollateral() {
+		return this;
+	}
+	setTotalCollateral() {
+		return this;
+	}
+	txOut() {
+		return this;
+	}
+	requiredSignerHash() {
+		return this;
+	}
+	setNetwork() {
+		return this;
+	}
+	changeAddress() {
+		return this;
+	}
+
+	async complete() {
+		if (this.mintItem) {
+			this.queueMint();
+		}
+		return 'beadface';
+	}
+}
+
+jest.unstable_mockModule('@meshsdk/core', () => ({
+	MeshTxBuilder: FakeMeshTxBuilder,
+}));
+
+jest.unstable_mockModule('@/utils/mesh-cost-model-sync', () => ({
+	getCachedChainProtocolParameters: () => null,
+	syncMeshCostModelsFromChain: async () => undefined,
+}));
+
+const { generateRegistryUpdateTransactionAutomaticFees } = await import('./shared');
+
+const POLICY_ID = 'a'.repeat(56);
+const SCRIPT = { version: 'V3' as const, code: 'aabbccdd' };
+
+function utxo(txHash: string, outputIndex: number): UTxO {
+	return {
+		input: { txHash, outputIndex },
+		output: {
+			address: 'addr_test1placeholder',
+			amount: [{ unit: 'lovelace', quantity: '5000000' }],
+		},
+	} as unknown as UTxO;
+}
+
+const provider = {
+	fetchProtocolParameters: async () => ({
+		priceMem: '0.0577',
+		priceStep: '0.0000721',
+		collateralPercentage: 150,
+	}),
+	evaluateTx: async () => [{ tag: 'MINT', index: 0, budget: { mem: 1_000_000, steps: 500_000_000 } }],
+} as never;
+
+beforeEach(() => {
+	builtBuilders.length = 0;
+});
+
+describe('generateRegistryUpdateTransactionAutomaticFees', () => {
+	it('builds the burn-old + mint-new pair without throwing queueMint: Missing mint script information', async () => {
+		const oldAssetName = '01' + 'aa'.repeat(28) + '000000';
+		const newAssetName = '02' + 'bb'.repeat(28) + '000000';
+
+		await expect(
+			generateRegistryUpdateTransactionAutomaticFees(
+				provider,
+				'preprod',
+				SCRIPT,
+				'addr_test1updater',
+				'addr_test1recipient',
+				'2000000',
+				POLICY_ID,
+				oldAssetName,
+				newAssetName,
+				utxo('1111', 0),
+				utxo('cccc', 0),
+				[utxo('dddd', 0)],
+				{ name: 'Agent A', description: 'desc' },
+			),
+		).resolves.toBe('beadface');
+
+		// The wrapper builds twice (evaluation pass + final pass). Each must queue
+		// both legs as scripted Plutus mints under the shared UpdateAction redeemer.
+		const finalBuilder = builtBuilders[builtBuilders.length - 1];
+		expect(finalBuilder.mints).toHaveLength(2);
+		const byAsset = Object.fromEntries(finalBuilder.mints.map((m) => [m.assetName, m]));
+		expect(byAsset[oldAssetName].amount).toBe('-1');
+		expect(byAsset[newAssetName].amount).toBe(String(SERVICE_CONSTANTS.SMART_CONTRACT.mintQuantity));
+		for (const leg of finalBuilder.mints) {
+			expect(leg.type).toBe('Plutus');
+			expect(leg.scriptSource).toEqual({ type: 'Provided', scriptCode: SCRIPT.code });
+			// UpdateAction redeemer alternative is 1.
+			expect(leg.redeemer).toEqual({ data: { alternative: 1, fields: [] }, exUnits: expect.anything() });
+		}
+	});
+});

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -385,10 +385,22 @@ async function generateRegistryUpdateTransaction(
 	txBuilder.protocolParams(protocolParameters);
 	const deserializedAddress = txBuilder.serializer.deserializer.key.deserializeAddress(walletAddress);
 
+	// Burn-old + mint-new are two mint legs under one UpdateAction policy bucket.
+	// Mesh's `mint()` flushes the PREVIOUS leg via `queueMint()`, which throws
+	// `queueMint: Missing mint script information` unless that leg already carries
+	// its `scriptSource` — so the script + redeemer must be attached to EACH leg,
+	// not once after both (doing it once threw as soon as the mint-new `mint()`
+	// flushed the unscripted burn-old leg). `mintPlutusScript()` also only arms
+	// the very next `mint()`, so it precedes each. `queueMint` then merges both
+	// same-policy legs into one bucket (it asserts the redeemer + scriptSource are
+	// identical across legs, which they are).
 	txBuilder
 		.txIn(assetUtxo.input.txHash, assetUtxo.input.outputIndex)
 		.mintPlutusScript(script.version)
 		.mint('-1', policyId, oldAssetName)
+		.mintingScript(script.code)
+		.mintRedeemerValue({ alternative: V2_UPDATE_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits)
+		.mintPlutusScript(script.version)
 		.mint(SERVICE_CONSTANTS.SMART_CONTRACT.mintQuantity, policyId, newAssetName)
 		.mintingScript(script.code)
 		.mintRedeemerValue({ alternative: V2_UPDATE_REDEEMER_ALTERNATIVE, fields: [] }, 'Mesh', exUnits)

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -17485,6 +17485,26 @@
                         "description": "When set, return only the registry entry whose on-chain agent identifier matches exactly (same scope as list: network, payment source, and wallet permissions)",
                         "name": "filterAgentIdentifier",
                         "in": "query"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "description": "Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR."
+                        },
+                        "required": false,
+                        "description": "Return only entries that advertise a supported payment source with this address (the Cardano smart-contract address, or an EVM x402 payTo/address). Matched server-side so callers do not have to fetch every entry and filter client-side. Combined with filterSupportedPaymentSourceNetworks as a logical OR.",
+                        "name": "filterSupportedPaymentSourceAddress",
+                        "in": "query"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "description": "Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR."
+                        },
+                        "required": false,
+                        "description": "Comma-separated list of supported-payment-source networks to match (Cardano network name, or CAIP-2 EVM chain ids such as eip155:8453). Returns entries advertising a supported payment source on any of these networks. Combined with filterSupportedPaymentSourceAddress as a logical OR.",
+                        "name": "filterSupportedPaymentSourceNetworks",
+                        "in": "query"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Three related registry fixes.

## 1. `queueMint: Missing mint script information` on register/update

The V2 UpdateAction tx burns the old asset and mints the new one — two mint legs under one policy. Mesh's `mint()` flushes the *previous* leg via `queueMint()`, which throws `queueMint: Missing mint script information` unless that leg already carries its `scriptSource`. The builder attached `mintingScript()`/`mintRedeemerValue()` **once after both** `mint()` calls, so the mint-new leg flushed an unscripted burn-old leg and the whole update threw.

This is the path hit when **re-registering an agent that already exists on V2** (register → update = burn+remint). The earlier batch-mint fix didn't touch it.

Is the error message accurate? Literally yes (the leg genuinely had no script at queue time) but misleading as an operator error — the real cause is builder call-ordering, not a missing policy script. Fixed by attaching the script + shared redeemer **per leg**; `queueMint` then merges both same-policy legs into one atomic bucket. Adds `shared.spec.ts` with a faithful `FakeMeshTxBuilder` that reproduces Mesh's contract so a regression re-breaks the test.

All multi-leg mint paths are now per-leg: batch mint + batch burn (already merged), and update burn+remint (this PR). Single mint/deregister were always correct.

## 2. Deleting a failed registration 500s (P2025) and the row stays on screen

Root cause is a duplicate DELETE for the same id (double-click): the second request reads the row, then its delete races the first. This endpoint is the only code that deletes registry rows, and a pure-id delete only throws P2025 once the row is already gone — so "still on screen" was just the list not refetching after the 500.

- Backend: on P2025, re-check existence; if genuinely gone, treat delete as idempotent success and return the already-read record (return 409 only in the unexpected case it still exists). Structural `code === 'P2025'` check matches the rest of the route dir + the unit-test prisma mock.
- Frontend: synchronous in-flight ref guard so a fast double-click can't fire a second DELETE before the button disables.

## 3. AI Agents page loaded every agent on the network and filtered client-side

The "accepts this context as a payment target" list paged every agent on the network and matched `supportedPaymentSources` in the browser. Added optional server-side list filters:

- `filterSupportedPaymentSourceAddress` (Cardano source address / EVM payTo)
- `filterSupportedPaymentSourceNetworks` (comma-separated Cardano network / CAIP-2 EVM ids)

OR-ed via `SupportedPaymentSources.some{}` against the indexed `address` / `[chain,network]` columns. `useContextAgents` now scopes by the selected source address (Cardano rail) or active EVM chain ids (x402 rail) and is disabled until there's something to scope by. Other registry lists (`useAgents`, `useInboxAgents`, `useMigrationStatus`/`agent-migration`) already scope server-side via `filterSmartContractAddress`; `useSearch` only indexes wallets + sources — so this was the one offender. Swagger + frontend api types regenerated.

## Verification
Pre-push hook: ESLint, backend `tsc`, frontend `tsc`, generated-file check — all green. Unit tests for the update fix (`shared.spec.ts`) and batch builder pass. (e2e not run.)