### PR TITLE
fix(frontend): show loading on x402 rail while chains resolve

### DIFF
--- a/frontend/src/lib/queries/useContextAgents.ts
+++ b/frontend/src/lib/queries/useContextAgents.ts
@@ -88,7 +88,7 @@ export function useContextAgents(params?: {
   searchQuery?: string;
 }) {
   const { apiClient, authorized, network, activeRail, selectedPaymentSource } = useAppContext();
-  const { networks } = useX402Networks({ silentErrors: true });
+  const { networks, isLoading: isX402NetworksLoading } = useX402Networks({ silentErrors: true });
 
   const envChainIds = useMemo(
     () => new Set(chainsForEnv(networks, network).map((chain) => chain.caip2Id)),
@@ -207,6 +207,12 @@ export function useContextAgents(params?: {
   // skeleton instead of an empty state or a half-labeled list.
   const registeredPending = isRegisteredQueryActive && registeredQuery.data === undefined;
 
+  // On the x402 rail the payment-scoped query is disabled until the active EVM
+  // chain ids resolve from useX402Networks. Without surfacing that window as
+  // loading, `isLoading` would be false with an empty list and the page would
+  // flash the "no agents accept x402 here" empty state before the chains load.
+  const x402ScopePending = activeRail === 'x402' && isX402NetworksLoading;
+
   // The list is fetched in full but bounded by fetchAllAgents' page cap. Surface when that
   // cap was hit so the page can warn the operator instead of silently showing a partial set.
   const truncated =
@@ -222,7 +228,7 @@ export function useContextAgents(params?: {
     agents,
     truncated,
     isPlaceholderData,
-    isLoading: allQuery.isLoading || registeredPending,
+    isLoading: allQuery.isLoading || registeredPending || x402ScopePending,
     isFetching: allQuery.isFetching || (isRegisteredQueryActive && registeredQuery.isFetching),
     refetch: async () => {
       await Promise.all([


### PR DESCRIPTION
Follow-up to #667 (review catch from @cursor).

## Problem
After #667 made the AI Agents payment-target query server-side filtered, the x402-rail query is disabled until the active EVM chain ids resolve from `useX402Networks`. `isLoading` only reflected the agent queries, so during that window `isLoading` was `false` with an empty list — the page flashed the "no agents accept x402 payment here" empty state before the chains finished loading.

## Fix
Surface the `useX402Networks` loading window in `isLoading` on the x402 rail (`x402ScopePending`). Once chains resolve, behavior is unchanged: a genuinely empty chain set still shows the empty state (it's only treated as loading while the networks query is actually in flight).

## Verification
Pre-push hook: ESLint + backend `tsc` + frontend `tsc` + generated-file check — all green.