### PR TITLE
fix silent updaterequested loop

### DIFF
--- a/docs/adr/0007-v2-collateral-readiness-invariant.md
+++ b/docs/adr/0007-v2-collateral-readiness-invariant.md
@@ -204,3 +204,23 @@ between `tx.transaction.create` and the post-submit `txHash` update.
 
 This applies BOTH to the helper's prep tx AND to every shared-Tx
 creation in the V2 batch services (see ADR-0006).
+
+## Amendments (2026-07-04) — V2 registry update/deregister
+
+Holder wallets after SaaS registration often hold ~10 ADA in three UTxOs
+(5 ADA collateral, ~3 ADA fee, NFT+ADA). Beyond the base invariant above,
+registry update/deregister needed:
+
+1. **`ensureCollateralReady` before `pickBatchCollateral`** on single-item
+   update/deregister paths. Wallets that consolidated to one `[NFT+ADA]`
+   UTxO never reached prep when collateral was picked first.
+2. **`capRegistryMintFundingLovelace`** must reserve ~3 ADA
+   (`REGISTRY_PLUTUS_TX_FEE_RESERVE`) for Plutus fees when capping mint
+   output funding; a 0.5 ADA reserve caused mesh `UTxO Fully Depleted`.
+3. **Registry update worker** must use
+   `advancedRetry({ throwOnUnrecoveredError: true })` (or handle
+   `success === false`); default `advancedRetry` returned without
+   throwing, leaving `UpdateRequested` rows with no persisted `error`.
+
+See `packages/payment-source-v2/src/services/registry/update/service.ts`
+and `batch-helpers.ts` (local diff, pending commit).

--- a/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
@@ -3,6 +3,10 @@ import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
 	computeCollateralFromExUnits,
+	countFeeEligibleUtxos,
+	capRegistryMintFundingLovelace,
+	shouldEmitWalletSplitter,
+	isRegistryTxInputSelectionError,
 	intersectTxWindows,
 	isTxSizeWithinLimit,
 	MAX_SAFE_TX_BYTES,
@@ -72,6 +76,84 @@ describe('intersectTxWindows', () => {
 			{ invalidBefore: 200, invalidAfter: 300 },
 		]);
 		expect(result).toEqual({ invalidBefore: 200, invalidAfter: 200 });
+	});
+});
+
+describe('countFeeEligibleUtxos', () => {
+	it('returns 0 when asset input and collateral consume every UTxO', () => {
+		const utxos = [
+			makeUtxo({ txHash: 'tx', outputIndex: 0, lovelace: '5000000' }),
+			makeUtxo({
+				txHash: 'tx',
+				outputIndex: 1,
+				lovelace: '4825523',
+				extraAssets: [{ unit: 'policy.name', quantity: '1' }],
+			}),
+		];
+		expect(
+			countFeeEligibleUtxos(utxos, [
+				{ txHash: 'tx', outputIndex: 0 },
+				{ txHash: 'tx', outputIndex: 1 },
+			]),
+		).toBe(0);
+	});
+
+	it('counts UTxOs not in the exclude set', () => {
+		const utxos = [
+			makeUtxo({ txHash: 'a', lovelace: '5000000' }),
+			makeUtxo({ txHash: 'b', lovelace: '8000000' }),
+		];
+		expect(countFeeEligibleUtxos(utxos, [{ txHash: 'a', outputIndex: 0 }])).toBe(1);
+	});
+});
+
+describe('shouldEmitWalletSplitter', () => {
+	it('skips splitter when wallet already has 3 UTxOs (fee-UTxO split prep)', () => {
+		const utxos = [
+			makeUtxo({ txHash: 'a', lovelace: '5000000' }),
+			makeUtxo({ txHash: 'b', lovelace: '3000000' }),
+			makeUtxo({ txHash: 'c', lovelace: '1470673' }),
+		];
+		expect(shouldEmitWalletSplitter(utxos, [utxos[1]])).toBe(false);
+	});
+
+	it('skips splitter when sole fee UTxO cannot fund 5 ADA splitter plus fees', () => {
+		const utxos = [makeUtxo({ txHash: 'a', lovelace: '3000000' }), makeUtxo({ txHash: 'b', lovelace: '5000000' })];
+		expect(shouldEmitWalletSplitter(utxos, [utxos[0]])).toBe(false);
+	});
+
+	it('emits splitter for 2-UTxO wallet with a large sole fee input', () => {
+		const utxos = [makeUtxo({ txHash: 'a', lovelace: '8000000' }), makeUtxo({ txHash: 'b', lovelace: '6000000' })];
+		expect(shouldEmitWalletSplitter(utxos, [utxos[0]])).toBe(true);
+	});
+});
+
+describe('isRegistryTxInputSelectionError', () => {
+	it('matches insufficient and depleted mesh input-selection failures', () => {
+		expect(isRegistryTxInputSelectionError(new Error('UTxO Balance Insufficient'))).toBe(true);
+		expect(isRegistryTxInputSelectionError(new Error('UTxO Fully Depleted'))).toBe(true);
+		expect(isRegistryTxInputSelectionError(new Error('something else'))).toBe(false);
+	});
+});
+
+describe('capRegistryMintFundingLovelace', () => {
+	it('caps default 5 ADA funding to available non-collateral lovelace', () => {
+		const collateral = makeUtxo({ txHash: 'c', lovelace: '5000000' });
+		const asset = makeUtxo({
+			txHash: 'a',
+			outputIndex: 2,
+			lovelace: '1470673',
+			extraAssets: [{ unit: 'policy.name', quantity: '1' }],
+		});
+		const fee = makeUtxo({ txHash: 'f', lovelace: '3000000' });
+		const capped = capRegistryMintFundingLovelace(
+			[collateral, fee, asset],
+			collateral,
+			[asset],
+			'5000000',
+		);
+		// 3M fee + 1.47M asset - 3M plutus reserve ≈ 1.47M → clamped to min mint output
+		expect(BigInt(capped)).toBe(1_500_000n);
 	});
 });
 

--- a/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
@@ -99,10 +99,7 @@ describe('countFeeEligibleUtxos', () => {
 	});
 
 	it('counts UTxOs not in the exclude set', () => {
-		const utxos = [
-			makeUtxo({ txHash: 'a', lovelace: '5000000' }),
-			makeUtxo({ txHash: 'b', lovelace: '8000000' }),
-		];
+		const utxos = [makeUtxo({ txHash: 'a', lovelace: '5000000' }), makeUtxo({ txHash: 'b', lovelace: '8000000' })];
 		expect(countFeeEligibleUtxos(utxos, [{ txHash: 'a', outputIndex: 0 }])).toBe(1);
 	});
 });
@@ -146,12 +143,7 @@ describe('capRegistryMintFundingLovelace', () => {
 			extraAssets: [{ unit: 'policy.name', quantity: '1' }],
 		});
 		const fee = makeUtxo({ txHash: 'f', lovelace: '3000000' });
-		const capped = capRegistryMintFundingLovelace(
-			[collateral, fee, asset],
-			collateral,
-			[asset],
-			'5000000',
-		);
+		const capped = capRegistryMintFundingLovelace([collateral, fee, asset], collateral, [asset], '5000000');
 		// 3M fee + 1.47M asset - 3M plutus reserve ≈ 1.47M → clamped to min mint output
 		expect(BigInt(capped)).toBe(1_500_000n);
 	});

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -143,8 +143,95 @@ function isPureLovelace(utxo: UTxO): boolean {
 }
 
 /** Canonical reference string for a UTxO — must match the format the builders use. */
-function refKey(input: { txHash: string; outputIndex: number }): string {
+export function refKey(input: { txHash: string; outputIndex: number }): string {
 	return `${input.txHash}#${input.outputIndex}`;
+}
+
+/**
+ * Count wallet UTxOs that mesh can use for fees/change after mandatory script
+ * inputs and the collateral UTxO are reserved. Registry update/deregister txs
+ * need at least one fee-eligible UTxO in addition to the asset input and
+ * collateral — a wallet with exactly [NFT+ADA, 5 ADA collateral] passes
+ * `classifyWalletState().ready` but still cannot build the script tx.
+ */
+export function countFeeEligibleUtxos(
+	utxos: UTxO[],
+	excludeSpendingInputs: Array<{ txHash: string; outputIndex: number }>,
+): number {
+	const excludeKeys = new Set<string>();
+	for (const ref of excludeSpendingInputs) {
+		excludeKeys.add(refKey(ref));
+	}
+	return utxos.filter((utxo) => !excludeKeys.has(refKey(utxo.input))).length;
+}
+
+/**
+ * Whether to emit the conditional 5 ADA wallet-splitter output. Skipped when the
+ * wallet already has a UTxO-count buffer (≥3) from fee-UTxO split prep, or when
+ * the sole fee input cannot fund the splitter plus tx fees.
+ */
+export function shouldEmitWalletSplitter(allWalletUtxos: UTxO[], feeEligibleUtxos: UTxO[]): boolean {
+	if (feeEligibleUtxos.length !== 1) return false;
+	if (allWalletUtxos.length >= 3) return false;
+	const feeLovelace = lovelaceFromUtxo(feeEligibleUtxos[0]);
+	return feeLovelace >= WALLET_SPLITTER_LOVELACE + 2_000_000n;
+}
+
+/** Minimum lovelace on a minted registry NFT output (~1.5 ADA). */
+export const REGISTRY_MIN_MINT_OUTPUT_LOVELACE = 1_500_000n;
+
+/**
+ * ADA headroom reserved for Plutus script fees + min-change when capping mint
+ * output funding. Holder wallets after registration often hold ~10 ADA total;
+ * a 0.5 ADA reserve leaves the cap too high and mesh fails with
+ * `UTxO Fully Depleted` when building update/deregister txs.
+ */
+export const REGISTRY_PLUTUS_TX_FEE_RESERVE = 3_000_000n;
+
+/**
+ * Cap mint funding to what non-collateral wallet inputs can cover. Holder wallets
+ * after registration often hold only ~10 ADA total; default 5 ADA funding plus a
+ * 5 ADA splitter cannot be covered by a 3 ADA fee-UTxO from split prep.
+ */
+export function capRegistryMintFundingLovelace(
+	utxos: UTxO[],
+	collateralUtxo: UTxO,
+	spendingAssetUtxos: UTxO[],
+	requestedFunding: string,
+	minFunding: bigint = REGISTRY_MIN_MINT_OUTPUT_LOVELACE,
+	feeReserve: bigint = REGISTRY_PLUTUS_TX_FEE_RESERVE,
+): string {
+	const exclude = new Set<string>([refKey(collateralUtxo.input)]);
+	for (const assetUtxo of spendingAssetUtxos) {
+		exclude.add(refKey(assetUtxo.input));
+	}
+	let available = 0n;
+	for (const utxo of utxos) {
+		if (!exclude.has(refKey(utxo.input))) {
+			available += lovelaceFromUtxo(utxo);
+		}
+	}
+	for (const assetUtxo of spendingAssetUtxos) {
+		available += lovelaceFromUtxo(assetUtxo);
+	}
+	const cap = available > feeReserve ? available - feeReserve : minFunding;
+	const requested = BigInt(requestedFunding);
+	let effective = requested < cap ? requested : cap;
+	if (effective < minFunding) {
+		effective = minFunding;
+	}
+	return effective.toString();
+}
+
+/** Mesh / cardano-sdk input-selection failures when wallet ADA cannot cover outputs + fees. */
+export function isRegistryTxInputSelectionError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	const failure =
+		error != null && typeof error === 'object' && 'failure' in error
+			? String((error as { failure: unknown }).failure)
+			: '';
+	const combined = `${message} ${failure}`.toLowerCase();
+	return combined.includes('insufficient') || combined.includes('depleted') || combined.includes('balance');
 }
 
 /**

--- a/packages/payment-source-v2/src/builders/batch-registry.ts
+++ b/packages/payment-source-v2/src/builders/batch-registry.ts
@@ -15,7 +15,12 @@ import { SERVICE_CONSTANTS } from '@masumi/payment-core/config';
 import { logger } from '@masumi/payment-core/logger';
 import { getCachedChainProtocolParameters } from '@/utils/mesh-cost-model-sync';
 import { syncMeshCostModelsFromChainV2 } from '../utils/mesh-cost-model-sync';
-import { deriveTotalCollateral, lovelaceFromUtxo, WALLET_SPLITTER_LOVELACE } from './batch-helpers';
+import {
+	deriveTotalCollateral,
+	lovelaceFromUtxo,
+	shouldEmitWalletSplitter,
+	WALLET_SPLITTER_LOVELACE,
+} from './batch-helpers';
 
 // V2 mint contract `Action` enum: MintAction=0, UpdateAction=1, BurnAction=2.
 // See smart-contracts/registry-v2/validators/mint.ak.
@@ -297,7 +302,7 @@ export async function generateRegistryBatchMintTransaction(
 	// post-tx (collateral untouched + change), so a splitter there is
 	// over-emission. See `batch-helpers.ts WALLET_SPLITTER_LOVELACE` for
 	// full rationale and the precise per-length analysis.
-	if (walletUtxosForSelection.length === 1) {
+	if (shouldEmitWalletSplitter(walletUtxos, walletUtxosForSelection)) {
 		txBuilder.txOut(mintingWalletAddress, [{ unit: 'lovelace', quantity: WALLET_SPLITTER_LOVELACE.toString() }]);
 	}
 
@@ -456,7 +461,7 @@ async function buildBatchDeregisterTx(
 	// rationale; the burn caller already filters collateral + assetUtxos
 	// upstream so `walletUtxosForSelection.length` is the fee-eligible
 	// count directly.
-	if (walletUtxosForSelection.length === 1) {
+	if (shouldEmitWalletSplitter(walletUtxos, walletUtxosForSelection)) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: WALLET_SPLITTER_LOVELACE.toString() }]);
 	}
 
@@ -643,7 +648,7 @@ async function buildBatchUpdateTx(
 		]);
 	}
 
-	if (walletUtxosForSelection.length === 1) {
+	if (shouldEmitWalletSplitter(walletUtxos, walletUtxosForSelection)) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: WALLET_SPLITTER_LOVELACE.toString() }]);
 	}
 

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -201,6 +201,47 @@ async function processSingleDeregistration(
 		throw new Error('No UTXOs found for the wallet');
 	}
 	const blockchainProvider = await createMeshProvider(paymentSource.PaymentSourceConfig.rpcProviderApiKey);
+	const { assetUtxo, assetName } = validated.item;
+	const initialCollateralCheck = await ensureCollateralReady({
+		walletDbId: deregistrationWallet.id,
+		walletAddress: address,
+		meshWallet: wallet,
+		utxos,
+		blockchainProvider,
+		network,
+		serviceLabel: 'registry-deregister-single',
+		excludeSpendingInputsForFeeCheck: [assetUtxo.input],
+	});
+	if (initialCollateralCheck.status === 'failed' && initialCollateralCheck.reason === 'insufficient_funds') {
+		const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${initialCollateralCheck.details}. Top up the wallet with ADA and retry.`;
+		await markRequestFailed(request, new Error(failureMessage));
+		return;
+	}
+	if (initialCollateralCheck.status === 'failed') {
+		const reachedLimit = await recordRegistryPrepFailure(request.id);
+		if (reachedLimit) {
+			await markRequestFailed(
+				request,
+				new Error(
+					`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${initialCollateralCheck.details}. Check the wallet's UTxO set and retry.`,
+				),
+			);
+		}
+		return;
+	}
+	if (initialCollateralCheck.status !== 'ready') {
+		return;
+	}
+	const collateralUtxo = pickBatchCollateral(utxos, [assetUtxo.input]);
+	if (collateralUtxo == null) {
+		await markRequestFailed(
+			request,
+			new Error(
+				'Wallet has no separate UTxO with ≥5 ADA for collateral after UTxO preparation. Top up the wallet with ADA and retry.',
+			),
+		);
+		return;
+	}
 	const collateralCheck = await ensureCollateralReady({
 		walletDbId: deregistrationWallet.id,
 		walletAddress: address,
@@ -209,6 +250,7 @@ async function processSingleDeregistration(
 		blockchainProvider,
 		network,
 		serviceLabel: 'registry-deregister-single',
+		excludeSpendingInputsForFeeCheck: [assetUtxo.input, collateralUtxo.input],
 	});
 	if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
 		// Wallet cannot fund the collateral prep tx for this attempt. Fail with a
@@ -244,16 +286,7 @@ async function processSingleDeregistration(
 	}
 	// Collateral ready — clear any transient prep-failure count.
 	await resetRegistryPrepFailureCount(request.id);
-	if (!request.agentIdentifier) {
-		throw new Error('Agent identifier is required for deregistration');
-	}
-	const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
 	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
-	if (collateralUtxo == null) {
-		throw new Error('Collateral UTXO not found');
-	}
-	const assetName = extractAssetName(request.agentIdentifier);
 	const unsignedTx = await generateRegistryDeregisterTransactionAutomaticFees(
 		blockchainProvider,
 		network,
@@ -261,7 +294,7 @@ async function processSingleDeregistration(
 		address,
 		policyId,
 		assetName,
-		tokenUtxo,
+		assetUtxo,
 		collateralUtxo,
 		limitedFilteredUtxos,
 		getBurnRedeemerAlternative(PaymentSourceType.Web3CardanoV2),
@@ -386,52 +419,6 @@ export async function deRegisterAgentV2() {
 					return;
 				}
 
-				const collateralCheck = await ensureCollateralReady({
-					walletDbId: deregistrationWallet.id,
-					walletAddress: address,
-					meshWallet: wallet,
-					utxos,
-					blockchainProvider,
-					network,
-					serviceLabel: 'registry-deregister-batch',
-				});
-				if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
-					// Wallet cannot fund collateral for the whole batch (all items share
-					// this wallet). Fail every item with a clear reason instead of
-					// silently deferring forever, so they land in DeregistrationFailed,
-					// are visible, and can be retried once the wallet is funded (the
-					// deregister route resets each in place).
-					const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${collateralCheck.details}. Top up the wallet with ADA and retry.`;
-					await Promise.allSettled(
-						registryRequests.map((request) => markRequestFailed(request, new Error(failureMessage))),
-					);
-					return;
-				}
-				if (collateralCheck.status === 'failed') {
-					// reason === 'prep_tx_failed' (transient; wallet already unlocked).
-					// Bound per-request retries so a deterministically-failing prep
-					// surfaces as DeregistrationFailed instead of looping forever.
-					await Promise.allSettled(
-						registryRequests.map(async (request) => {
-							const reachedLimit = await recordRegistryPrepFailure(request.id);
-							if (reachedLimit) {
-								await markRequestFailed(
-									request,
-									new Error(
-										`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${collateralCheck.details}. Check the wallet's UTxO set and retry.`,
-									),
-								);
-							}
-						}),
-					);
-					return;
-				}
-				if (collateralCheck.status !== 'ready') {
-					return;
-				}
-				// Collateral ready — clear any transient prep-failure count on every item.
-				await Promise.allSettled(registryRequests.map((request) => resetRegistryPrepFailureCount(request.id)));
-
 				// Per-request validation: each item needs its asset UTxO in
 				// the wallet. Missing-asset failures become per-item DB
 				// failures.
@@ -460,21 +447,51 @@ export async function deRegisterAgentV2() {
 				const excludeRefs = validated.map((v) => v.item.assetUtxo.input);
 				const collateralUtxo = pickBatchCollateral(utxos, excludeRefs);
 				if (collateralUtxo == null) {
-					// Wallet has no separate collateral candidate — typical for a
-					// just-registered seller wallet where the agent NFT UTxO is
-					// the only UTxO. The V1 single-tx builder handles this by
-					// passing the asset UTxO as BOTH `assetUtxo` and
-					// `collateralUtxo` (mesh-sdk routes `.txIn(...)` and
-					// `.txInCollateral(...)` into separate body fields and
-					// dedupes at assembly). Fall back to the per-item single-tx
-					// path which already uses that pattern via
-					// `generateRegistryDeregisterTransactionAutomaticFees`.
 					logger.warn(
 						'V2 deregister batch could not find separate collateral UTxO; falling back to single-item [batch-fallback] per-request processing [batch-fallback]',
 					);
 					await fallbackToSingleItems(validated, paymentSource, network, script, policyId);
 					return;
 				}
+
+				const collateralCheck = await ensureCollateralReady({
+					walletDbId: deregistrationWallet.id,
+					walletAddress: address,
+					meshWallet: wallet,
+					utxos,
+					blockchainProvider,
+					network,
+					serviceLabel: 'registry-deregister-batch',
+					excludeSpendingInputsForFeeCheck: [...excludeRefs, collateralUtxo.input],
+				});
+				if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
+					const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${collateralCheck.details}. Top up the wallet with ADA and retry.`;
+					await Promise.allSettled(
+						registryRequests.map((request) => markRequestFailed(request, new Error(failureMessage))),
+					);
+					return;
+				}
+				if (collateralCheck.status === 'failed') {
+					await Promise.allSettled(
+						registryRequests.map(async (request) => {
+							const reachedLimit = await recordRegistryPrepFailure(request.id);
+							if (reachedLimit) {
+								await markRequestFailed(
+									request,
+									new Error(
+										`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${collateralCheck.details}. Check the wallet's UTxO set and retry.`,
+									),
+								);
+							}
+						}),
+					);
+					return;
+				}
+				if (collateralCheck.status !== 'ready') {
+					return;
+				}
+				// Collateral ready — clear any transient prep-failure count on every item.
+				await Promise.allSettled(registryRequests.map((request) => resetRegistryPrepFailureCount(request.id)));
 
 				// Filter the wallet UTxOs that flow into the tx (used for fee /
 				// change) so the asset-holding UTxOs and the collateral don't
@@ -775,13 +792,17 @@ async function fallbackToSingleItems(
 	if (validated.length === 0) return;
 	const v = validated[0];
 	try {
-		await advancedRetry({
+		const retryResult = await advancedRetry({
 			errorResolvers: [delayErrorResolver({ configuration: SERVICE_CONSTANTS.RETRY })],
+			throwOnUnrecoveredError: true,
 			operation: async () => {
 				await processSingleDeregistration(v, paymentSource, network, script, policyId);
 				return true;
 			},
 		});
+		if (retryResult.success === false) {
+			await markRequestFailed(v.request, retryResult.error);
+		}
 	} catch (error) {
 		await markRequestFailed(v.request, error);
 	}

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -11,7 +11,7 @@ import { advancedRetry, delayErrorResolver } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@/utils/errors/blockchain-error-interpreter';
 import { extractAssetName, extractPolicyId } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos, sortUtxosByLovelaceDesc } from '@/utils/utxo';
+import { sortUtxosByLovelaceDesc } from '@/utils/utxo';
 import {
 	connectExistingTransaction,
 	createMeshProvider,
@@ -21,14 +21,14 @@ import {
 import {
 	bumpRegistryAssetNameVersionV2,
 	findRegistryTokenUtxo,
-	generateRegistryUpdateTransactionAutomaticFees,
 	resolveRegistryDeregistrationWallet,
 	resolveRegistryFundingLovelace,
 } from '@/services/registry/shared';
 import {
 	assertTxSizeWithinLimit,
+	capRegistryMintFundingLovelace,
+	isRegistryTxInputSelectionError,
 	pickBatchCollateral,
-	WALLET_SPLITTER_LOVELACE,
 } from '../../../builders/batch-helpers';
 import {
 	type BatchRegistryUpdateItem,
@@ -169,163 +169,219 @@ async function processUpdate(
 	}
 	validateRegistrationPricing(request);
 
-	const oldAssetName = extractAssetName(request.agentIdentifier);
 	const oldPolicyId = extractPolicyId(request.agentIdentifier);
 	if (oldPolicyId !== policyId) {
 		throw new Error('agentIdentifier policy does not match payment source script');
 	}
-	const newAssetName = bumpRegistryAssetNameVersionV2(oldAssetName);
-	const newAgentIdentifier = policyId + newAssetName;
 
 	const holderWallet = resolveRegistryDeregistrationWallet(request);
-	const walletSession = await loadHotWalletSession({
-		network: paymentSource.network,
-		rpcProviderApiKey: paymentSource.PaymentSourceConfig.rpcProviderApiKey,
-		encryptedMnemonic: holderWallet.Secret.encryptedMnemonic,
-		hotWalletId: holderWallet.id,
-	});
-	const { wallet, utxos, address } = walletSession;
-	if (utxos.length === 0) {
-		throw new Error('No UTXOs found for the wallet');
-	}
-	const blockchainProvider = await createMeshProvider(paymentSource.PaymentSourceConfig.rpcProviderApiKey);
-	const collateralCheck = await ensureCollateralReady({
-		walletDbId: holderWallet.id,
-		walletAddress: address,
-		meshWallet: wallet,
-		utxos,
-		blockchainProvider,
-		network,
-		serviceLabel: 'registry-update',
-	});
-	if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
-		// Collateral could not be prepared for this attempt. Fail the request
-		// (instead of silently re-deferring in UpdateRequested forever, which
-		// looks like "stuck, nothing happens") so the operator sees a clear
-		// reason and can fix it and retry — the update endpoint accepts
-		// UpdateFailed and re-queues it as UpdateRequested.
-		const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${collateralCheck.details}. Top up the holder wallet with ADA and retry the update.`;
-		await markRequestFailed(request, new Error(failureMessage));
-		return;
-	}
-	if (collateralCheck.status === 'failed') {
-		// reason === 'prep_tx_failed' (insufficient_funds handled above): a
-		// TRANSIENT prep error the wallet was already unlocked for. Normally leave
-		// the request queued for the next tick, but bound the retries so a
-		// DETERMINISTICALLY-failing prep eventually surfaces as UpdateFailed
-		// instead of looping forever.
-		const reachedLimit = await recordRegistryPrepFailure(request.id);
-		if (reachedLimit) {
+	try {
+		const walletSession = await loadHotWalletSession({
+			network: paymentSource.network,
+			rpcProviderApiKey: paymentSource.PaymentSourceConfig.rpcProviderApiKey,
+			encryptedMnemonic: holderWallet.Secret.encryptedMnemonic,
+			hotWalletId: holderWallet.id,
+		});
+		const { wallet, utxos, address } = walletSession;
+		if (utxos.length === 0) {
+			throw new Error('No UTXOs found for the wallet');
+		}
+		const blockchainProvider = await createMeshProvider(paymentSource.PaymentSourceConfig.rpcProviderApiKey);
+		const paymentSourceMetadata: RegistryMetadataPaymentSource = {
+			network: paymentSource.network,
+			paymentSourceType: paymentSource.paymentSourceType,
+			smartContractAddress: paymentSource.smartContractAddress,
+		};
+		const validated = buildUpdateItem(request, utxos, address, policyId, paymentSourceMetadata);
+		const { newAgentIdentifier } = validated;
+		const assetInput = validated.item.assetUtxo.input;
+		// Holder wallets often consolidate to a single [NFT + ADA] UTxO after
+		// registration. Run UTxO prep BEFORE picking collateral — otherwise
+		// pickBatchCollateral returns null and we never reach ensureCollateralReady.
+		const initialCollateralCheck = await ensureCollateralReady({
+			walletDbId: holderWallet.id,
+			walletAddress: address,
+			meshWallet: wallet,
+			utxos,
+			blockchainProvider,
+			network,
+			serviceLabel: 'registry-update',
+			excludeSpendingInputsForFeeCheck: [assetInput],
+		});
+		if (initialCollateralCheck.status === 'failed' && initialCollateralCheck.reason === 'insufficient_funds') {
+			const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${initialCollateralCheck.details}. Top up the holder wallet with ADA and retry the update.`;
+			await markRequestFailed(request, new Error(failureMessage));
+			return;
+		}
+		if (initialCollateralCheck.status === 'failed') {
+			const reachedLimit = await recordRegistryPrepFailure(request.id);
+			if (reachedLimit) {
+				await markRequestFailed(
+					request,
+					new Error(
+						`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${initialCollateralCheck.details}. Check the holder wallet's UTxO set and retry.`,
+					),
+				);
+			}
+			return;
+		}
+		if (initialCollateralCheck.status !== 'ready') {
+			logger.info('V2 update deferred while holder wallet UTxO prep is in flight', {
+				requestId: request.id,
+				holderWalletId: holderWallet.id,
+				prepTxHash: initialCollateralCheck.status === 'deferred' ? initialCollateralCheck.prepTxHash : undefined,
+			});
+			return;
+		}
+		// Collateral must not overlap the asset UTxO being burned (Conway forbids
+		// collateral ∩ inputs).
+		const collateralUtxo = pickBatchCollateral(utxos, [assetInput]);
+		if (collateralUtxo == null) {
 			await markRequestFailed(
 				request,
 				new Error(
-					`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${collateralCheck.details}. Check the holder wallet's UTxO set and retry.`,
+					'Holder wallet has no separate UTxO with ≥5 ADA for collateral after UTxO preparation. Top up the holder wallet with ADA (recommend ≥15 ADA) and retry the update.',
 				),
 			);
+			return;
 		}
-		return;
-	}
-	if (collateralCheck.status !== 'ready') {
-		// status === 'deferred': a collateral prep tx is in flight; keep the row
-		// queued so the next scheduler tick re-picks it up once the prep tx
-		// confirms (mirrors register/deregister single-item).
-		return;
-	}
-	// Collateral ready — clear any transient prep-failure count so it never
-	// slow-accumulates into a false UpdateFailed across many update cycles.
-	await resetRegistryPrepFailureCount(request.id);
-
-	// Holder-holds-asset guard: findRegistryTokenUtxo throws if the resolved
-	// holder wallet's UTxOs no longer contain this asset. The UpdateAction tx
-	// is signed by `holderWallet` (the on-chain holder recorded at request
-	// time), so if the asset has since moved out of that managed wallet there is
-	// nothing to burn+remint and the tx would fail on chain anyway — fail fast
-	// here with a clear message instead.
-	const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8_000_000);
-	const collateralUtxo = limitedFilteredUtxos[0];
-	if (collateralUtxo == null) {
-		throw new Error('Collateral UTXO not found');
-	}
-
-	const paymentSourceMetadata: RegistryMetadataPaymentSource = {
-		network: paymentSource.network,
-		paymentSourceType: paymentSource.paymentSourceType,
-		smartContractAddress: paymentSource.smartContractAddress,
-	};
-	const metadata = buildAgentMetadata(request, paymentSourceMetadata);
-
-	// Default the version-bumped NFT recipient to the CURRENT HOLDER (`address`,
-	// the wallet that signs this tx), NOT request.SmartContractWallet. When the
-	// holder differs from SmartContractWallet (the common case — the route
-	// records the on-chain holder as DeregistrationHotWallet), sending the new
-	// asset to SmartContractWallet would silently migrate the registry NFT to a
-	// different wallet on every default update. An explicit caller-supplied
-	// RecipientWallet still overrides.
-	const recipientWalletAddress = request.RecipientWallet?.walletAddress ?? address;
-	const fundingLovelace = resolveRegistryFundingLovelace(request);
-
-	const unsignedTx = await generateRegistryUpdateTransactionAutomaticFees(
-		blockchainProvider,
-		network,
-		script,
-		address,
-		recipientWalletAddress,
-		fundingLovelace,
-		policyId,
-		oldAssetName,
-		newAssetName,
-		tokenUtxo,
-		collateralUtxo,
-		limitedFilteredUtxos,
-		metadata,
-		paymentSource.PaymentSourceConfig.rpcProviderApiKey,
-		WALLET_SPLITTER_LOVELACE,
-	);
-	const signedTx = await wallet.signTx(unsignedTx, true);
-
-	// Submit FIRST, then write DB. Same rationale as
-	// register/deregister single-item: on submit failure there is no
-	// orphan Transaction row to clean up, and we revert state back to
-	// UpdateRequested so the next tick can retry.
-	let newTxHash: string;
-	try {
-		newTxHash = await wallet.submitTx(signedTx);
-	} catch (error) {
-		logger.error('Error submitting V2 update tx', { error, requestId: request.id });
-		await prisma.registryRequest.update({
-			where: { id: request.id },
-			data: {
-				state: RegistrationState.UpdateRequested,
-				DeregistrationHotWallet: {
-					update: { lockedAt: null },
-				},
-			},
+		const collateralCheck = await ensureCollateralReady({
+			walletDbId: holderWallet.id,
+			walletAddress: address,
+			meshWallet: wallet,
+			utxos,
+			blockchainProvider,
+			network,
+			serviceLabel: 'registry-update',
+			excludeSpendingInputsForFeeCheck: [assetInput, collateralUtxo.input],
 		});
-		return;
-	}
+		if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
+			// Collateral could not be prepared for this attempt. Fail the request
+			// (instead of silently re-deferring in UpdateRequested forever, which
+			// looks like "stuck, nothing happens") so the operator sees a clear
+			// reason and can fix it and retry — the update endpoint accepts
+			// UpdateFailed and re-queues it as UpdateRequested.
+			const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${collateralCheck.details}. Top up the holder wallet with ADA and retry the update.`;
+			await markRequestFailed(request, new Error(failureMessage));
+			return;
+		}
+		if (collateralCheck.status === 'failed') {
+			// reason === 'prep_tx_failed' (insufficient_funds handled above): transient
+			// prep error. Bound retries so a deterministically-failing prep eventually
+			// surfaces as UpdateFailed; otherwise leave the row queued for the next tick.
+			const reachedLimit = await recordRegistryPrepFailure(request.id);
+			if (reachedLimit) {
+				await markRequestFailed(
+					request,
+					new Error(
+						`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${collateralCheck.details}. Check the holder wallet's UTxO set and retry.`,
+					),
+				);
+			}
+			return;
+		}
+		if (collateralCheck.status !== 'ready') {
+			// status === 'deferred': a collateral or fee-UTxO prep tx is in flight;
+			// keep the row queued so the next scheduler tick re-picks it once the
+			// prep tx confirms (mirrors register/deregister single-item).
+			logger.info('V2 update deferred while holder wallet UTxO prep is in flight', {
+				requestId: request.id,
+				holderWalletId: holderWallet.id,
+				prepTxHash: collateralCheck.status === 'deferred' ? collateralCheck.prepTxHash : undefined,
+			});
+			return;
+		}
+		// Collateral ready — clear any transient prep-failure count so it never
+		// slow-accumulates into a false UpdateFailed across many update cycles.
+		await resetRegistryPrepFailureCount(request.id);
 
-	await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		validated.item.fundingLovelace = capRegistryMintFundingLovelace(
+			utxos,
+			collateralUtxo,
+			[validated.item.assetUtxo],
+			validated.item.fundingLovelace,
+		);
 
-	// Atomic flip: new asset identifier replaces the old, state advances to
-	// UpdateInitiated, shared Tx row is attached. tx-sync then verifies the
-	// new asset on chain.
-	await retryOnSerializationConflict(
-		() =>
-			prisma.registryRequest.update({
+		const spendableUtxos = sortUtxosByLovelaceDesc(utxos);
+
+		let unsignedTx: string;
+		try {
+			unsignedTx = await generateRegistryBatchUpdateTransactionAutomaticFees(
+				asV2Provider(blockchainProvider),
+				network,
+				script,
+				address,
+				policyId,
+				[validated.item],
+				collateralUtxo,
+				spendableUtxos,
+				paymentSource.PaymentSourceConfig.rpcProviderApiKey,
+			);
+		} catch (buildError) {
+			if (isRegistryTxInputSelectionError(buildError)) {
+				const message = buildError instanceof Error ? buildError.message : String(buildError);
+				await markRequestFailed(
+					request,
+					new Error(
+						`Holder wallet has no UTxO available to pay registry update fees after reserving the NFT input and collateral. ` +
+							`Top up the holder wallet with ADA (recommend ≥15 ADA) and retry the update. Original error: ${message}`,
+					),
+				);
+				return;
+			}
+			throw buildError;
+		}
+		const signedTx = await wallet.signTx(unsignedTx, true);
+
+		// Submit FIRST, then write DB. Same rationale as
+		// register/deregister single-item: on submit failure there is no
+		// orphan Transaction row to clean up, and we revert state back to
+		// UpdateRequested so the next tick can retry.
+		let newTxHash: string;
+		try {
+			newTxHash = await wallet.submitTx(signedTx);
+		} catch (error) {
+			logger.error('Error submitting V2 update tx', { error, requestId: request.id });
+			await prisma.registryRequest.update({
 				where: { id: request.id },
 				data: {
-					state: RegistrationState.UpdateInitiated,
-					agentIdentifier: newAgentIdentifier,
-					...createPendingTransaction(holderWallet.id, newTxHash),
+					state: RegistrationState.UpdateRequested,
+					DeregistrationHotWallet: {
+						update: { lockedAt: null },
+					},
 				},
-			}),
-		{ label: 'v2-update-post-submit' },
-	);
-	logger.debug(`Created V2 update transaction:
+			});
+			return;
+		}
+
+		await walletSession.evaluateProjectedBalance(unsignedTx, spendableUtxos);
+
+		// Atomic flip: new asset identifier replaces the old, state advances to
+		// UpdateInitiated, shared Tx row is attached. tx-sync then verifies the
+		// new asset on chain.
+		await retryOnSerializationConflict(
+			() =>
+				prisma.registryRequest.update({
+					where: { id: request.id },
+					data: {
+						state: RegistrationState.UpdateInitiated,
+						agentIdentifier: newAgentIdentifier,
+						...createPendingTransaction(holderWallet.id, newTxHash),
+					},
+				}),
+			{ label: 'v2-update-post-submit' },
+		);
+		logger.debug(`Created V2 update transaction:
               Tx ID: ${newTxHash}
               View on https://${network === 'preprod' ? 'preprod.' : ''}cardanoscan.io/transaction/${newTxHash}
           `);
+	} finally {
+		// lockAndQueryRegistryRequests sets lockedAt before we run. Release it
+		// whenever this tick did not attach a PendingTransaction (deferred prep,
+		// transient prep failure, or throw before post-submit). No-ops when a
+		// pending tx is in flight — tx-sync owns that unlock path.
+		await unlockHotWalletIfNoPendingTransaction(holderWallet.id, 'registry-update-finally');
+	}
 }
 
 // Batch several same-wallet UpdateRequested rows into ONE UpdateAction tx that
@@ -359,6 +415,75 @@ async function processBatchUpdate(
 	}
 	const blockchainProvider = await createMeshProvider(rpcApiKey);
 
+	const paymentSourceMetadata: RegistryMetadataPaymentSource = {
+		network: paymentSource.network,
+		paymentSourceType: paymentSource.paymentSourceType,
+		smartContractAddress: paymentSource.smartContractAddress,
+	};
+
+	const validated: ValidatedUpdateItem[] = [];
+	for (const request of requests) {
+		try {
+			validated.push(buildUpdateItem(request, utxos, address, policyId, paymentSourceMetadata));
+		} catch (validationError) {
+			// Mid-batch: keep the shared wallet lock so the remaining items can build.
+			await markRequestFailed(request, validationError, { unlockWallet: false });
+		}
+	}
+	if (validated.length === 0) {
+		await unlockHotWalletIfNoPendingTransaction(holderWallet.id, 'registry-update-batch');
+		return;
+	}
+
+	const assetInputs = validated.map((v) => v.item.assetUtxo.input);
+	const initialCollateralCheck = await ensureCollateralReady({
+		walletDbId: holderWallet.id,
+		walletAddress: address,
+		meshWallet: wallet,
+		utxos,
+		blockchainProvider,
+		network,
+		serviceLabel: 'registry-update-batch',
+		excludeSpendingInputsForFeeCheck: assetInputs,
+	});
+	if (initialCollateralCheck.status === 'failed' && initialCollateralCheck.reason === 'insufficient_funds') {
+		const failureMessage = `Wallet balance too low to fund the collateral preparation transaction: ${initialCollateralCheck.details}. Top up the holder wallet with ADA and retry the update.`;
+		await Promise.allSettled(requests.map((request) => markRequestFailed(request, new Error(failureMessage))));
+		return;
+	}
+	if (initialCollateralCheck.status === 'failed') {
+		await Promise.allSettled(
+			requests.map(async (request) => {
+				const reachedLimit = await recordRegistryPrepFailure(request.id);
+				if (reachedLimit) {
+					await markRequestFailed(
+						request,
+						new Error(
+							`Collateral preparation failed repeatedly (>= ${MAX_COLLATERAL_PREP_FAILURES} attempts): ${initialCollateralCheck.details}. Check the holder wallet's UTxO set and retry.`,
+						),
+					);
+				}
+			}),
+		);
+		return;
+	}
+	if (initialCollateralCheck.status !== 'ready') {
+		logger.info('V2 update batch deferred while holder wallet UTxO prep is in flight', {
+			requestIds: validated.map((v) => v.request.id),
+			holderWalletId: holderWallet.id,
+			prepTxHash: initialCollateralCheck.status === 'deferred' ? initialCollateralCheck.prepTxHash : undefined,
+		});
+		return;
+	}
+
+	const collateralUtxo = pickBatchCollateral(utxos, assetInputs);
+	if (collateralUtxo == null) {
+		const failureMessage =
+			'Holder wallet has no separate UTxO with ≥5 ADA for collateral after UTxO preparation. Top up the holder wallet with ADA (recommend ≥15 ADA) and retry the update.';
+		await Promise.allSettled(validated.map((v) => markRequestFailed(v.request, new Error(failureMessage))));
+		return;
+	}
+
 	const collateralCheck = await ensureCollateralReady({
 		walletDbId: holderWallet.id,
 		walletAddress: address,
@@ -367,6 +492,7 @@ async function processBatchUpdate(
 		blockchainProvider,
 		network,
 		serviceLabel: 'registry-update-batch',
+		excludeSpendingInputsForFeeCheck: [...assetInputs, collateralUtxo.input],
 	});
 	if (collateralCheck.status === 'failed' && collateralCheck.reason === 'insufficient_funds') {
 		// Shared-wallet funding problem — fail every item with a clear reason so
@@ -396,43 +522,24 @@ async function processBatchUpdate(
 		return;
 	}
 	if (collateralCheck.status !== 'ready') {
-		// deferred: a prep tx is in flight; the whole batch stays queued.
+		// deferred: a collateral or fee-UTxO prep tx is in flight; the whole batch stays queued.
+		logger.info('V2 update batch deferred while holder wallet UTxO prep is in flight', {
+			requestIds: validated.map((v) => v.request.id),
+			holderWalletId: holderWallet.id,
+			prepTxHash: collateralCheck.status === 'deferred' ? collateralCheck.prepTxHash : undefined,
+		});
 		return;
 	}
 	// Collateral ready — clear any transient prep-failure count on every item.
 	await Promise.allSettled(requests.map((request) => resetRegistryPrepFailureCount(request.id)));
 
-	const paymentSourceMetadata: RegistryMetadataPaymentSource = {
-		network: paymentSource.network,
-		paymentSourceType: paymentSource.paymentSourceType,
-		smartContractAddress: paymentSource.smartContractAddress,
-	};
-
-	const validated: ValidatedUpdateItem[] = [];
-	for (const request of requests) {
-		try {
-			validated.push(buildUpdateItem(request, utxos, address, policyId, paymentSourceMetadata));
-		} catch (validationError) {
-			// Mid-batch: keep the shared wallet lock so the remaining items can build.
-			await markRequestFailed(request, validationError, { unlockWallet: false });
-		}
-	}
-	if (validated.length === 0) {
-		await unlockHotWalletIfNoPendingTransaction(holderWallet.id, 'registry-update-batch');
-		return;
-	}
-
-	// Prefer a pure-ADA collateral UTxO, but mixed-asset collateral is valid
-	// under CIP-40. This builder still keeps collateral separate from the asset
-	// UTxOs being burned/continued.
-	const collateralUtxo = pickBatchCollateral(
-		utxos,
-		validated.map((v) => v.item.assetUtxo.input),
-	);
-	if (collateralUtxo == null) {
-		logger.warn('V2 update batch: no suitable collateral UTxO (>=5 ADA); deferring to next tick');
-		await unlockHotWalletIfNoPendingTransaction(holderWallet.id, 'registry-update-batch');
-		return;
+	for (const entry of validated) {
+		entry.item.fundingLovelace = capRegistryMintFundingLovelace(
+			utxos,
+			collateralUtxo,
+			validated.map((v) => v.item.assetUtxo),
+			entry.item.fundingLovelace,
+		);
 	}
 
 	const items = validated.map((v) => v.item);
@@ -453,6 +560,15 @@ async function processBatchUpdate(
 		);
 		assertTxSizeWithinLimit(unsignedTx, 'v2-registry-batch-update');
 	} catch (buildError) {
+		if (isRegistryTxInputSelectionError(buildError)) {
+			const message = buildError instanceof Error ? buildError.message : String(buildError);
+			const failure = new Error(
+				`Holder wallet has no UTxO available to pay registry update fees after reserving NFT inputs and collateral. ` +
+					`Top up the holder wallet with ADA (recommend ≥15 ADA) and retry the update. Original error: ${message}`,
+			);
+			await Promise.allSettled(validated.map((v) => markRequestFailed(v.request, failure)));
+			return;
+		}
 		logger.error('V2 update batch build failed; marking batch failed [batch-fallback]', {
 			error: buildError instanceof Error ? { message: buildError.message, name: buildError.name } : buildError,
 			batchSize: validated.length,
@@ -579,13 +695,17 @@ export async function updateAgentV2() {
 					if (requests.length === 1) {
 						const request = requests[0];
 						try {
-							await advancedRetry({
+							const retryResult = await advancedRetry({
 								errorResolvers: [delayErrorResolver({ configuration: SERVICE_CONSTANTS.RETRY })],
+								throwOnUnrecoveredError: true,
 								operation: async () => {
 									await processUpdate(request, paymentSource, network, script, policyId);
 									return true;
 								},
 							});
+							if (retryResult.success === false) {
+								await markRequestFailed(request, retryResult.error);
+							}
 						} catch (error) {
 							await markRequestFailed(request, error);
 						}

--- a/packages/payment-source-v2/src/services/wallet-collateral/ensure-collateral-ready.ts
+++ b/packages/payment-source-v2/src/services/wallet-collateral/ensure-collateral-ready.ts
@@ -7,6 +7,7 @@ import { recordV2CollateralPrepHashDivergence } from '@masumi/payment-core/metri
 import { retryOnSerializationConflict } from '@/utils/db/retry';
 import { resolveTxHash, SLOT_CONFIG_NETWORK, unixTimeToEnclosingSlot } from '@meshsdk/core';
 import type { Network, UTxO } from '@meshsdk/core';
+import { countFeeEligibleUtxos } from '../../builders/batch-helpers';
 import { isDefinitiveNodeRejection } from '../submit-error-classifier';
 
 /**
@@ -34,6 +35,12 @@ export const COLLATERAL_RESERVE_LOVELACE = 5_000_000n;
  * of fee. 7 ADA covers all three with a comfortable safety margin.
  */
 export const PREP_TX_MIN_LOVELACE = 7_000_000n;
+/** Extra pure-ADA output emitted by fee-UTxO split prep so script txs have a fee input. */
+export const FEE_UTXO_PREP_LOVELACE = 3_000_000n;
+/**
+ * Minimum total lovelace for fee-UTxO split prep (5 ADA + 3 ADA outputs + tx fee buffer).
+ */
+export const FEE_UTXO_PREP_MIN_LOVELACE = COLLATERAL_RESERVE_LOVELACE + FEE_UTXO_PREP_LOVELACE + 1_500_000n;
 
 export type EnsureCollateralReadyResult =
 	| { status: 'ready' }
@@ -57,6 +64,13 @@ export type EnsureCollateralReadyParams = {
 	/** Short label for log lines so a single grep can attribute prep calls to
 	 *  the service that triggered them (e.g. 'request-refund'). */
 	serviceLabel: string;
+	/**
+	 * Registry update/deregister script txs consume one UTxO as the asset input
+	 * and another as collateral. When every remaining UTxO is excluded here, mesh
+	 * has no fee input (`UTxO Balance Insufficient`). Submit a split prep tx
+	 * (same as the collateral-prep path) before building the script tx.
+	 */
+	excludeSpendingInputsForFeeCheck?: Array<{ txHash: string; outputIndex: number }>;
 };
 
 export type WalletStateClassification = {
@@ -220,9 +234,25 @@ export function classifyWalletState(utxos: UTxO[]): WalletStateClassification {
 export async function ensureCollateralReady(params: EnsureCollateralReadyParams): Promise<EnsureCollateralReadyResult> {
 	const { walletDbId, walletAddress, meshWallet, utxos, serviceLabel, network } = params;
 	const classification = classifyWalletState(utxos);
+	const feeExclude = params.excludeSpendingInputsForFeeCheck;
+	const needsFeeUtxoSplit =
+		classification.ready && feeExclude != null && countFeeEligibleUtxos(utxos, feeExclude) === 0;
 
-	if (classification.ready) {
+	if (classification.ready && !needsFeeUtxoSplit) {
 		return { status: 'ready' };
+	}
+
+	if (needsFeeUtxoSplit) {
+		logger.info(
+			'V2 wallet is collateral-ready but has no fee-eligible UTxO after excluding script/collateral inputs; submitting fee-UTxO split prep [collateral-prep]',
+			{
+				walletDbId,
+				walletAddress,
+				serviceLabel,
+				excludedInputCount: feeExclude.length,
+				utxoCount: classification.utxoCount,
+			},
+		);
 	}
 
 	// Previously this branch existed to surface "money trapped in token-bearing
@@ -235,7 +265,8 @@ export async function ensureCollateralReady(params: EnsureCollateralReadyParams)
 	// `fundedForPrep` gate below now uses `totalLovelace` and treats mixed
 	// and pure UTxOs equivalently.
 
-	if (!classification.fundedForPrep) {
+	const minLovelaceForPrep = needsFeeUtxoSplit ? FEE_UTXO_PREP_MIN_LOVELACE : PREP_TX_MIN_LOVELACE;
+	if (classification.totalLovelace < minLovelaceForPrep) {
 		// WARN, not ERROR: every scheduler tick that picks this wallet up
 		// re-runs the helper, so an underfunded wallet would otherwise spam
 		// an identical ERROR row every ~30-60 s until operator funds it. No
@@ -252,7 +283,8 @@ export async function ensureCollateralReady(params: EnsureCollateralReadyParams)
 			totalLovelace: classification.totalLovelace.toString(),
 			pureLovelaceTotal: classification.pureLovelaceTotal.toString(),
 			hasPureAdaUtxo: classification.hasPureAdaUtxo,
-			minRequiredLovelace: PREP_TX_MIN_LOVELACE.toString(),
+			minRequiredLovelace: minLovelaceForPrep.toString(),
+			prepKind: needsFeeUtxoSplit ? 'fee-utxo-split' : 'collateral',
 			note: 'wallet does not hold enough TOTAL lovelace to fund a collateral-prep tx. Mixed-asset UTxOs are acceptable inputs; this log repeats every scheduler tick until operator funds the wallet.',
 		});
 		// The outer caller's `lockAndQueryX` set `lockedAt = now` on this wallet.
@@ -266,24 +298,30 @@ export async function ensureCollateralReady(params: EnsureCollateralReadyParams)
 		return {
 			status: 'failed',
 			reason: 'insufficient_funds',
-			details: `wallet has ${classification.totalLovelace.toString()} lovelace across ${classification.utxoCount} UTxO(s); need at least ${PREP_TX_MIN_LOVELACE.toString()} total lovelace to build collateral prep tx (mixed-asset UTxOs accepted)`,
+			details: `wallet has ${classification.totalLovelace.toString()} lovelace across ${classification.utxoCount} UTxO(s); need at least ${minLovelaceForPrep.toString()} total lovelace to build ${needsFeeUtxoSplit ? 'fee-UTxO split' : 'collateral'} prep tx (mixed-asset UTxOs accepted)`,
 		};
 	}
 
-	// Build the prep tx. Send the collateral reserve explicitly back to
-	// the wallet's own address; mesh will then add a change output for
-	// the remainder, naturally restoring the separate reserve/change shape
-	// the current V2 builders expect on the next script tx.
+	// Build the prep tx. Standard collateral prep sends one 5 ADA output back to
+	// self; fee-UTxO split prep sends two explicit outputs so holder wallets
+	// with [NFT+ADA, 5 ADA collateral] gain a third pure-ADA UTxO for mesh fees.
 	const meshTx = new MeshTransaction({
 		initiator: meshWallet,
 		fetcher: params.blockchainProvider,
 	}).setMetadata(674, {
-		msg: ['Masumi', 'CollateralPrep'],
+		msg: ['Masumi', needsFeeUtxoSplit ? 'FeeUtxoPrep' : 'CollateralPrep'],
 	});
 
-	meshTx.sendAssets({ address: walletAddress }, [
-		{ unit: 'lovelace', quantity: COLLATERAL_RESERVE_LOVELACE.toString() },
-	]);
+	if (needsFeeUtxoSplit) {
+		meshTx.sendAssets({ address: walletAddress }, [
+			{ unit: 'lovelace', quantity: COLLATERAL_RESERVE_LOVELACE.toString() },
+		]);
+		meshTx.sendAssets({ address: walletAddress }, [{ unit: 'lovelace', quantity: FEE_UTXO_PREP_LOVELACE.toString() }]);
+	} else {
+		meshTx.sendAssets({ address: walletAddress }, [
+			{ unit: 'lovelace', quantity: COLLATERAL_RESERVE_LOVELACE.toString() },
+		]);
+	}
 
 	// Explicit invalid_hereafter ~5 minutes ahead so we can persist it as the
 	// TTL boundary for `funding-reconciliation`. Without an explicit TTL the

--- a/src/services/transactions/wallet-timeouts/service.ts
+++ b/src/services/transactions/wallet-timeouts/service.ts
@@ -565,26 +565,35 @@ export async function updateWalletTransactionHash() {
 		});
 	}
 	try {
-		// Two recovery branches:
-		//   1) wallet has a PendingTransaction whose `lastCheckedAt` is older than 1 min
-		//      AND the wallet's outer `lockedAt` is either stale (past WALLET_LOCK_TIMEOUT_INTERVAL)
-		//      or null. The `lockedAt` AND-guard is crucial: without it, a worker that
-		//      JUST created a PendingTransaction (whose `lastCheckedAt` is seeded to now
-		//      by `createPendingTransaction`) but is still inside its build/sign/submit
-		//      window — possibly >1 min on slow Blockfrost / large batches — would be
-		//      raced by this cron, which would disconnect the PendingTransaction and
-		//      unlock the wallet while the worker is about to write the txHash. A
-		//      second worker picking the wallet up would then collide on the same
-		//      UTxOs.
+		// Recovery branches:
+		//   1a) PendingTransaction has `txHash` set (submit completed — collateral
+		//       prep, fee-split prep, or any path that recorded the hash). Poll for
+		//       on-chain confirmation once `lastCheckedAt` is older than 1 min.
+		//       No `lockedAt` stale guard here: the hash proves broadcast finished,
+		//       so disconnecting early cannot race an in-flight submit.
+		//   1b) PendingTransaction with no `txHash` yet — keep the `lockedAt`
+		//       stale-or-null guard so this cron cannot disconnect while a worker
+		//       is still inside its build/sign/submit window.
 		//   2) wallet has NO PendingTransaction but `lockedAt` is older than
-		//      WALLET_LOCK_TIMEOUT_INTERVAL — an orphan lock from a `lockAndQueryX`
-		//      caller that crashed/exited between committing the lock and creating
-		//      its PendingTransaction. Without this branch the wallet stays locked
-		//      forever (the relation filter requires `PendingTransaction != null`).
+		//      WALLET_LOCK_TIMEOUT_INTERVAL — orphan lock from a crashed
+		//      `lockAndQueryX` caller.
 		const lockedHotWallets = await prisma.hotWallet.findMany({
 			where: {
 				deletedAt: null,
 				OR: [
+					{
+						PendingTransaction: {
+							txHash: { not: null },
+							OR: [
+								{
+									lastCheckedAt: {
+										lte: new Date(Date.now() - 1000 * 60 * 1),
+									},
+								},
+								{ lastCheckedAt: null },
+							],
+						},
+					},
 					{
 						PendingTransaction: {
 							// Prisma `lte` does NOT match NULL — without the explicit null branch


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**

- V2 registry updates no longer hang in UpdateRequested on lean holder wallets (~10 ADA / ~3 UTxOs).
- Plutus fee reserve raised from 0.5 ADA to 3 ADA so mint funding cap matches real tx cost.
- Collateral prep runs before collateral pick so single-UTxO wallets can still build.
- advancedRetry now throws on failure — rows go to UpdateFailed with an error instead of silent retry.
- Mesh input-selection errors (UTxO Balance Insufficient, etc.) are detected and surfaced.
- Pending-tx polling tightened so UpdateInitiated → UpdateConfirmed resolves faster.
- Same throwOnUnrecoveredError fix applied to deregister.
- Unit tests + ADR 0007 amendments document the new invariants.

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
