### PR TITLE
feat: allow enterprise addresses for escrow participants

### DIFF
--- a/packages/payment-core/src/index.ts
+++ b/packages/payment-core/src/index.ts
@@ -10,7 +10,7 @@ export {
 	MAX_SUPPORTED_PAYMENT_SOURCES,
 	SupportedPaymentSourceChain,
 	isCardanoAddressForNetwork,
-	isCardanoPubKeyBaseAddressForNetwork,
+	isCardanoPubKeyAddressForNetwork,
 	parseSupportedPaymentSourcesFromMetadata,
 	paymentSourceTypeSchema,
 	supportedPaymentSourceMetadataSchema,

--- a/packages/payment-core/src/payment-source.spec.ts
+++ b/packages/payment-core/src/payment-source.spec.ts
@@ -1,13 +1,15 @@
 import { Network, PaymentSourceType } from '@prisma/client';
 import {
 	isCardanoAddressForNetwork,
-	isCardanoPubKeyBaseAddressForNetwork,
+	isCardanoPubKeyAddressForNetwork,
 	supportedPaymentSourceSchema,
 	validateSupportedPaymentSourcesOrThrow,
 } from './payment-source';
 
 const PREPROD_BASE_ADDRESS =
 	'addr_test1qq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0czhmdlpagxe5n8ppnrf6424tt8gwweumrtg2q7234x2p2qzjenfx';
+// Same payment key hash as PREPROD_BASE_ADDRESS, no stake credential.
+const PREPROD_ENTERPRISE_ADDRESS = 'addr_test1vq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0c75xvdu';
 const PREPROD_SCRIPT_ADDRESS = 'addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm';
 
 describe('payment-source address validation', () => {
@@ -15,9 +17,14 @@ describe('payment-source address validation', () => {
 		expect(isCardanoAddressForNetwork(PREPROD_SCRIPT_ADDRESS, Network.Preprod)).toBe(true);
 	});
 
-	it('requires a stake credential for V2 return addresses', () => {
-		expect(isCardanoPubKeyBaseAddressForNetwork(PREPROD_BASE_ADDRESS, Network.Preprod)).toBe(true);
-		expect(isCardanoPubKeyBaseAddressForNetwork(PREPROD_SCRIPT_ADDRESS, Network.Preprod)).toBe(false);
+	it('accepts base and enterprise pubkey addresses, rejects script addresses', () => {
+		expect(isCardanoPubKeyAddressForNetwork(PREPROD_BASE_ADDRESS, Network.Preprod)).toBe(true);
+		expect(isCardanoPubKeyAddressForNetwork(PREPROD_ENTERPRISE_ADDRESS, Network.Preprod)).toBe(true);
+		expect(isCardanoPubKeyAddressForNetwork(PREPROD_SCRIPT_ADDRESS, Network.Preprod)).toBe(false);
+	});
+
+	it('rejects addresses from the wrong network', () => {
+		expect(isCardanoPubKeyAddressForNetwork(PREPROD_ENTERPRISE_ADDRESS, Network.Mainnet)).toBe(false);
 	});
 
 	it('accepts standard x402 EVM sources for V2 registry entries without requiring address duplication', () => {

--- a/packages/payment-core/src/payment-source.ts
+++ b/packages/payment-core/src/payment-source.ts
@@ -155,24 +155,37 @@ export function isCardanoAddressForNetwork(address: string, network: Network): b
 	}
 }
 
-function validateCardanoPubKeyBaseAddressForNetwork(address: string, network: Network) {
+function validateCardanoPubKeyAddressForNetwork(address: string, network: Network) {
 	validateCardanoAddressForNetwork(address, network);
 	const parsedAddress = deserializeAddress(address);
-	if (parsedAddress.getType() !== AddressType.BasePaymentKeyStakeKey) {
-		throw new Error('Cardano address must be a base address with payment and stake key credentials');
+	const addressType = parsedAddress.getType();
+	// The vested_pay validators (V1 and V2) only ever read the PAYMENT
+	// credential of participant addresses (`address_to_verification_key`
+	// matches `VerificationKey(vkey)` and ignores the stake part), and payouts
+	// are full-address equality against the datum. Base (payment key + stake
+	// key) and enterprise (payment key, no stake) addresses are therefore both
+	// safe; the datum builders encode a missing stake credential as Plutus
+	// `None`. Script payment credentials remain banned — every spending
+	// redeemer does `expect Some(vk) = address_to_verification_key(...)`, so a
+	// script-credential participant permanently bricks the escrow. Pointer,
+	// reward, and script-stake variants stay rejected as well.
+	if (addressType !== AddressType.BasePaymentKeyStakeKey && addressType !== AddressType.EnterpriseKey) {
+		throw new Error('Cardano address must be a base or enterprise address with a payment key credential');
 	}
 
 	try {
 		resolvePaymentKeyHash(address);
-		resolveStakeKeyHash(address);
+		if (addressType === AddressType.BasePaymentKeyStakeKey) {
+			resolveStakeKeyHash(address);
+		}
 	} catch {
-		throw new Error('Cardano address must include payment and stake key credentials');
+		throw new Error('Cardano address must include a payment key credential');
 	}
 }
 
-export function isCardanoPubKeyBaseAddressForNetwork(address: string, network: Network): boolean {
+export function isCardanoPubKeyAddressForNetwork(address: string, network: Network): boolean {
 	try {
-		validateCardanoPubKeyBaseAddressForNetwork(address, network);
+		validateCardanoPubKeyAddressForNetwork(address, network);
 		return true;
 	} catch {
 		return false;

--- a/packages/payment-source-v1/src/contract-generator.spec.ts
+++ b/packages/payment-source-v1/src/contract-generator.spec.ts
@@ -1,0 +1,76 @@
+import { SmartContractState } from '@masumi/payment-core';
+import { generateBlockchainIdentifier } from '@masumi/payment-core/blockchain-identifier';
+import { getDatumFromBlockchainIdentifier } from './contract-generator';
+
+const PREPROD_BASE_ADDRESS =
+	'addr_test1qq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0czhmdlpagxe5n8ppnrf6424tt8gwweumrtg2q7234x2p2qzjenfx';
+// Same payment key hash as PREPROD_BASE_ADDRESS, no stake credential.
+const PREPROD_ENTERPRISE_ADDRESS = 'addr_test1vq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0c75xvdu';
+const PREPROD_SCRIPT_ADDRESS = 'addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm';
+const PAYMENT_KEY_HASH = '1f9d349ec66fb28920e0f093edce415792ce0281a8825015ce3e16bf';
+
+type MConstr = { alternative: number; fields: unknown[] };
+
+const blockchainIdentifier = generateBlockchainIdentifier(
+	'aa'.repeat(32),
+	'bb'.repeat(16),
+	'cc'.repeat(32),
+	'dd'.repeat(32),
+);
+
+function buildDatum(overrides: { buyerAddress?: string; sellerAddress?: string } = {}) {
+	return getDatumFromBlockchainIdentifier({
+		buyerAddress: overrides.buyerAddress ?? PREPROD_BASE_ADDRESS,
+		sellerAddress: overrides.sellerAddress ?? PREPROD_BASE_ADDRESS,
+		blockchainIdentifier,
+		collateralReturnLovelace: 0n,
+		inputHash: null,
+		resultHash: null,
+		payByTime: 1_000n,
+		resultTime: 2_000n,
+		unlockTime: 3_000n,
+		externalDisputeUnlockTime: 4_000n,
+		newCooldownTimeSeller: 0n,
+		newCooldownTimeBuyer: 0n,
+		state: SmartContractState.FundsLocked,
+	});
+}
+
+function addressField(datum: ReturnType<typeof buildDatum>, index: number): MConstr {
+	return (datum.value as unknown as MConstr).fields[index] as MConstr;
+}
+
+describe('V1 getDatum participant address encoding', () => {
+	it('encodes a base address with an inline stake credential (Some)', () => {
+		const buyer = addressField(buildDatum(), 0);
+		expect(buyer.alternative).toBe(0);
+		const payment = buyer.fields[0] as MConstr;
+		expect(payment.alternative).toBe(0);
+		expect(payment.fields[0]).toBe(PAYMENT_KEY_HASH);
+		const stakeOption = buyer.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(0); // Some(Inline(cred))
+	});
+
+	it('encodes an enterprise address with stake credential None', () => {
+		const buyer = addressField(buildDatum({ buyerAddress: PREPROD_ENTERPRISE_ADDRESS }), 0);
+		const payment = buyer.fields[0] as MConstr;
+		expect(payment.fields[0]).toBe(PAYMENT_KEY_HASH);
+		const stakeOption = buyer.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(1); // None
+		expect(stakeOption.fields).toHaveLength(0);
+	});
+
+	it('accepts an enterprise seller as well', () => {
+		const seller = addressField(buildDatum({ sellerAddress: PREPROD_ENTERPRISE_ADDRESS }), 1);
+		const payment = seller.fields[0] as MConstr;
+		expect(payment.fields[0]).toBe(PAYMENT_KEY_HASH);
+		const stakeOption = seller.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(1); // None
+	});
+
+	it('rejects script-credential participant addresses', () => {
+		expect(() => buildDatum({ sellerAddress: PREPROD_SCRIPT_ADDRESS })).toThrow(
+			'sellerAddress must be a Cardano base or enterprise address with a payment key credential',
+		);
+	});
+});

--- a/packages/payment-source-v1/src/contract-generator.ts
+++ b/packages/payment-source-v1/src/contract-generator.ts
@@ -6,7 +6,9 @@
 // V1 deployments and locked funds. See docs/adr/0005-meshsdk-version-pinning-v1-v2.md.
 import { mPubKeyAddress, type Data, type PlutusScript } from '@meshsdk/core';
 import {
+	AddressType,
 	applyParamsToScript,
+	deserializeAddress,
 	deserializePlutusScript,
 	resolvePaymentKeyHash,
 	resolvePlutusScriptAddress,
@@ -227,6 +229,27 @@ export function getDatumFromBlockchainIdentifier({
 	});
 }
 
+function getPubKeyAddressDatum(address: string, fieldName: string) {
+	const parsedAddress = deserializeAddress(address);
+	const addressType = parsedAddress.getType();
+	// The V1 vested_pay validator only reads the payment credential of datum
+	// addresses (`address_to_verification_key`), so enterprise (stake-less)
+	// pubkey addresses are spendable alongside base addresses — mesh encodes
+	// the omitted stake credential as Plutus `None` (`Constr 1 []`), which the
+	// decoder in src/utils/converter/string-datum-convert already handles.
+	// Script payment credentials stay rejected: every spending redeemer does
+	// `expect Some(vk) = address_to_verification_key(...)`, so a script
+	// participant would permanently brick the escrow.
+	if (addressType === AddressType.EnterpriseKey) {
+		return mPubKeyAddress(resolvePaymentKeyHash(address));
+	}
+	if (addressType !== AddressType.BasePaymentKeyStakeKey) {
+		throw new Error(`${fieldName} must be a Cardano base or enterprise address with a payment key credential`);
+	}
+
+	return mPubKeyAddress(resolvePaymentKeyHash(address), resolveStakeKeyHash(address));
+}
+
 function getDatum({
 	buyerAddress,
 	sellerAddress,
@@ -262,8 +285,8 @@ function getDatum({
 	newCooldownTimeBuyer: bigint;
 	state: SmartContractState;
 }) {
-	const buyerPubKeyAddress = mPubKeyAddress(resolvePaymentKeyHash(buyerAddress), resolveStakeKeyHash(buyerAddress));
-	const sellerPubKeyAddress = mPubKeyAddress(resolvePaymentKeyHash(sellerAddress), resolveStakeKeyHash(sellerAddress));
+	const buyerPubKeyAddress = getPubKeyAddressDatum(buyerAddress, 'buyerAddress');
+	const sellerPubKeyAddress = getPubKeyAddressDatum(sellerAddress, 'sellerAddress');
 	if (!validateHexString(referenceKey)) {
 		throw new Error('Reference key is not a valid hex string');
 	}

--- a/packages/payment-source-v2/src/contract-generator.spec.ts
+++ b/packages/payment-source-v2/src/contract-generator.spec.ts
@@ -1,0 +1,75 @@
+import { SmartContractState } from '@masumi/payment-core';
+import { getDatumV2 } from './contract-generator';
+
+const PREPROD_BASE_ADDRESS =
+	'addr_test1qq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0czhmdlpagxe5n8ppnrf6424tt8gwweumrtg2q7234x2p2qzjenfx';
+// Same payment key hash as PREPROD_BASE_ADDRESS, no stake credential.
+const PREPROD_ENTERPRISE_ADDRESS = 'addr_test1vq0e6dy7cehm9zfqurcf8mwwg9te9nszsx5gy5q4eclpd0c75xvdu';
+const PREPROD_SCRIPT_ADDRESS = 'addr_test1wz7j4kmg2cs7yf92uat3ed4a3u97kr7axxr4avaz0lhwdsqukgwfm';
+const PAYMENT_KEY_HASH = '1f9d349ec66fb28920e0f093edce415792ce0281a8825015ce3e16bf';
+
+type MConstr = { alternative: number; fields: unknown[] };
+
+function buildDatum(overrides: { buyerAddress?: string; sellerAddress?: string } = {}) {
+	return getDatumV2({
+		buyerAddress: overrides.buyerAddress ?? PREPROD_BASE_ADDRESS,
+		sellerAddress: overrides.sellerAddress ?? PREPROD_BASE_ADDRESS,
+		referenceKey: 'aa'.repeat(32),
+		referenceSignature: 'bb'.repeat(16),
+		sellerNonce: 'cc'.repeat(32),
+		buyerNonce: 'dd'.repeat(32),
+		agentIdentifier: 'ee'.repeat(16),
+		collateralReturnLovelace: 0n,
+		inputHash: null,
+		resultHash: null,
+		payByTime: 1_000n,
+		resultTime: 2_000n,
+		unlockTime: 3_000n,
+		externalDisputeUnlockTime: 4_000n,
+		newCooldownTimeSeller: 0n,
+		newCooldownTimeBuyer: 0n,
+		state: SmartContractState.FundsLocked,
+	});
+}
+
+function addressField(datum: ReturnType<typeof buildDatum>, index: number): MConstr {
+	return (datum.value as unknown as MConstr).fields[index] as MConstr;
+}
+
+describe('getDatumV2 participant address encoding', () => {
+	it('encodes a base address with an inline stake credential (Some)', () => {
+		const buyer = addressField(buildDatum(), 0);
+		expect(buyer.alternative).toBe(0);
+		const payment = buyer.fields[0] as MConstr;
+		expect(payment.alternative).toBe(0);
+		expect(payment.fields[0]).toBe(PAYMENT_KEY_HASH);
+		const stakeOption = buyer.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(0); // Some(Inline(cred))
+		expect(stakeOption.fields).toHaveLength(1);
+	});
+
+	it('encodes an enterprise address with stake credential None', () => {
+		const buyer = addressField(buildDatum({ buyerAddress: PREPROD_ENTERPRISE_ADDRESS }), 0);
+		expect(buyer.alternative).toBe(0);
+		const payment = buyer.fields[0] as MConstr;
+		expect(payment.fields[0]).toBe(PAYMENT_KEY_HASH);
+		const stakeOption = buyer.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(1); // None
+		expect(stakeOption.fields).toHaveLength(0);
+	});
+
+	it('accepts an enterprise seller as well', () => {
+		const seller = addressField(buildDatum({ sellerAddress: PREPROD_ENTERPRISE_ADDRESS }), 2);
+		const stakeOption = seller.fields[1] as MConstr;
+		expect(stakeOption.alternative).toBe(1);
+	});
+
+	it('rejects script-credential participant addresses', () => {
+		expect(() => buildDatum({ buyerAddress: PREPROD_SCRIPT_ADDRESS })).toThrow(
+			'buyerAddress must be a Cardano base or enterprise address with a payment key credential',
+		);
+		expect(() => buildDatum({ sellerAddress: PREPROD_SCRIPT_ADDRESS })).toThrow(
+			'sellerAddress must be a Cardano base or enterprise address with a payment key credential',
+		);
+	});
+});

--- a/packages/payment-source-v2/src/contract-generator.ts
+++ b/packages/payment-source-v2/src/contract-generator.ts
@@ -117,10 +117,23 @@ export function getRegistryScriptV2(network: Network) {
 	return Promise.resolve({ script, policyId, smartContractAddress });
 }
 
-function getPubKeyBaseAddressDatum(address: string, fieldName: string) {
+function getPubKeyAddressDatum(address: string, fieldName: string) {
 	const parsedAddress = deserializeAddress(address);
-	if (parsedAddress.getType() !== AddressType.BasePaymentKeyStakeKey) {
-		throw new Error(`${fieldName} must be a Cardano base address with payment and stake key credentials`);
+	const addressType = parsedAddress.getType();
+	// The vested_pay validator only reads the payment credential of datum
+	// addresses (`address_to_verification_key`); payouts compare the full
+	// address, stake part included, exactly as encoded here. Enterprise
+	// (stake-less) pubkey addresses are therefore spendable — mesh encodes the
+	// omitted stake credential as Plutus `None` (`Constr 1 []`), which the
+	// decoder in src/utils/converter/string-datum-convert already handles.
+	// Script payment credentials stay rejected: every spending redeemer does
+	// `expect Some(vk) = address_to_verification_key(...)`, so a script
+	// participant would permanently brick the escrow.
+	if (addressType === AddressType.EnterpriseKey) {
+		return mPubKeyAddress(resolvePaymentKeyHash(address));
+	}
+	if (addressType !== AddressType.BasePaymentKeyStakeKey) {
+		throw new Error(`${fieldName} must be a Cardano base or enterprise address with a payment key credential`);
 	}
 
 	return mPubKeyAddress(resolvePaymentKeyHash(address), resolveStakeKeyHash(address));
@@ -136,7 +149,7 @@ function getOptionalPubKeyAddressDatum(address: string | null | undefined, field
 
 	return {
 		alternative: 0,
-		fields: [getPubKeyBaseAddressDatum(address, fieldName)],
+		fields: [getPubKeyAddressDatum(address, fieldName)],
 	};
 }
 
@@ -265,9 +278,9 @@ export function getDatumV2({
 		value: {
 			alternative: 0,
 			fields: [
-				getPubKeyBaseAddressDatum(buyerAddress, 'buyerAddress'),
+				getPubKeyAddressDatum(buyerAddress, 'buyerAddress'),
 				getOptionalPubKeyAddressDatum(buyerReturnAddress, 'buyerReturnAddress'),
-				getPubKeyBaseAddressDatum(sellerAddress, 'sellerAddress'),
+				getPubKeyAddressDatum(sellerAddress, 'sellerAddress'),
 				getOptionalPubKeyAddressDatum(sellerReturnAddress, 'sellerReturnAddress'),
 				referenceKey,
 				referenceSignature,

--- a/src/routes/api/payments/index.ts
+++ b/src/routes/api/payments/index.ts
@@ -35,7 +35,7 @@ import {
 } from './schemas';
 import { getPaymentsForQuery, resolvePaymentPaymentSourceTypeFilter } from './queries';
 import { serializePaymentsResponse } from './serializers';
-import { isCardanoPubKeyBaseAddressForNetwork } from '@/types/payment-source';
+import { isCardanoPubKeyAddressForNetwork } from '@/types/payment-source';
 
 export {
 	createPaymentSchemaOutput,
@@ -231,12 +231,11 @@ export const paymentInitPost = payAuthenticatedEndpointFactory.build({
 		assertHotWalletInScope(ctx.walletScopeIds, sellingWallet.id);
 		const sellerReturnAddress = input.sellerReturnAddress ?? sellingWallet.collectionAddress;
 		const isV2 = specifiedPaymentContract.paymentSourceType === PaymentSourceType.Web3CardanoV2;
-		if (
-			isV2 &&
-			sellerReturnAddress != null &&
-			!isCardanoPubKeyBaseAddressForNetwork(sellerReturnAddress, input.network)
-		) {
-			throw createHttpError(400, 'sellerReturnAddress must be a Cardano base address with a stake credential');
+		if (isV2 && sellerReturnAddress != null && !isCardanoPubKeyAddressForNetwork(sellerReturnAddress, input.network)) {
+			throw createHttpError(
+				400,
+				'sellerReturnAddress must be a Cardano base or enterprise address with a payment key credential',
+			);
 		}
 		const sellerCUID = createId();
 		const sellerId = generateSHA256Hash(sellerCUID) + input.agentIdentifier;

--- a/src/routes/api/payments/x402/index.ts
+++ b/src/routes/api/payments/x402/index.ts
@@ -15,7 +15,7 @@ import { PaymentSourceType } from '@/generated/prisma/client';
 import { assertNever } from '@/utils/assert-never';
 import { createAuthenticatedRateLimitMiddleware } from '@/utils/middleware/rate-limit';
 import { buildX402TxSchemaInput, buildX402TxSchemaOutput } from './schemas';
-import { isCardanoPubKeyBaseAddressForNetwork } from '@/types/payment-source';
+import { isCardanoPubKeyAddressForNetwork } from '@/types/payment-source';
 
 export { buildX402TxSchemaInput, buildX402TxSchemaOutput };
 
@@ -87,34 +87,36 @@ export const buildX402TxPost = x402BuildEndpointFactory.build({
 		// — no `Withdraw`, no `WithdrawRefund`, no `WithdrawDisputed`. Reject
 		// at the API boundary before broadcasting the lock tx. (The same
 		// restriction is enforced in V1 for symmetry; V1's principal-vkey
-		// dereference is structurally similar.)
-		if (!isCardanoPubKeyBaseAddressForNetwork(input.buyerAddress, input.network)) {
+		// dereference is structurally similar.) Base and enterprise pubkey
+		// addresses are both fine — the validator never reads the stake part.
+		if (!isCardanoPubKeyAddressForNetwork(input.buyerAddress, input.network)) {
 			throw createHttpError(
 				400,
-				'buyerAddress must be a Cardano base address with a verification-key payment credential. Script-credential addresses (smart wallets, multisig wrappers) cannot interact with the escrow contract; locked funds would be permanently unspendable.',
+				'buyerAddress must be a Cardano base or enterprise address with a verification-key payment credential. Script-credential addresses (smart wallets, multisig wrappers) cannot interact with the escrow contract; locked funds would be permanently unspendable.',
 			);
 		}
 
 		// Re-validate the STORED sellerReturnAddress before it flows into the
 		// V2 funds-locking tx. The create-payment handler (payments/index.ts)
-		// only enforces pubkey-base for rows it creates; `payment.sellerReturnAddress`
-		// here is read back from the DB and may predate that check (legacy row),
-		// have been written by another path, or — the original bug — have passed
-		// the looser create-time schema refine (isCardanoAddressForNetwork, which
-		// accepts enterprise/script addresses) and been returned via the
-		// idempotency-replay branch without re-validation. The V2 contract can
-		// only pay out to a pubkey base address; locking against an
-		// enterprise/script address strands the funds at an address the contract
-		// cannot resolve. Fail closed (V2 only — V1 has no such datum requirement).
+		// only enforces pubkey credentials for rows it creates;
+		// `payment.sellerReturnAddress` here is read back from the DB and may
+		// predate that check (legacy row), have been written by another path,
+		// or — the original bug — have passed the looser create-time schema
+		// refine (isCardanoAddressForNetwork, which accepts script addresses)
+		// and been returned via the idempotency-replay branch without
+		// re-validation. The datum builder only encodes pubkey base/enterprise
+		// addresses; a script-credential address would strand payouts at an
+		// address the contract cannot resolve. Fail closed (V2 only — V1 has
+		// no such datum requirement).
 		const isV2Payment = payment.PaymentSource.paymentSourceType === PaymentSourceType.Web3CardanoV2;
 		if (
 			isV2Payment &&
 			payment.sellerReturnAddress != null &&
-			!isCardanoPubKeyBaseAddressForNetwork(payment.sellerReturnAddress, input.network)
+			!isCardanoPubKeyAddressForNetwork(payment.sellerReturnAddress, input.network)
 		) {
 			throw createHttpError(
 				409,
-				'Stored sellerReturnAddress is not a Cardano base address with a stake credential; this payment cannot be locked on the V2 contract. Recreate the payment with a valid base address.',
+				'Stored sellerReturnAddress is not a Cardano base or enterprise address with a payment key credential; this payment cannot be locked on the V2 contract. Recreate the payment with a valid address.',
 			);
 		}
 

--- a/src/routes/api/purchases/index.ts
+++ b/src/routes/api/purchases/index.ts
@@ -26,7 +26,7 @@ import {
 } from './schemas';
 import { getPurchasesForQuery, resolvePurchasePaymentSourceTypeFilter } from './queries';
 import { serializePurchasesResponse } from './serializers';
-import { isCardanoPubKeyBaseAddressForNetwork } from '@/types/payment-source';
+import { isCardanoPubKeyAddressForNetwork } from '@/types/payment-source';
 
 export {
 	createPurchaseInitSchemaInput,
@@ -329,12 +329,18 @@ export const createPurchaseInitPost = payAuthenticatedEndpointFactory.build({
 			if (isV2) {
 				if (
 					input.buyerReturnAddress != null &&
-					!isCardanoPubKeyBaseAddressForNetwork(input.buyerReturnAddress, input.network)
+					!isCardanoPubKeyAddressForNetwork(input.buyerReturnAddress, input.network)
 				) {
-					throw createHttpError(400, 'buyerReturnAddress must be a Cardano base address with a stake credential');
+					throw createHttpError(
+						400,
+						'buyerReturnAddress must be a Cardano base or enterprise address with a payment key credential',
+					);
 				}
-				if (sellerReturnAddress != null && !isCardanoPubKeyBaseAddressForNetwork(sellerReturnAddress, input.network)) {
-					throw createHttpError(400, 'sellerReturnAddress must be a Cardano base address with a stake credential');
+				if (sellerReturnAddress != null && !isCardanoPubKeyAddressForNetwork(sellerReturnAddress, input.network)) {
+					throw createHttpError(
+						400,
+						'sellerReturnAddress must be a Cardano base or enterprise address with a payment key credential',
+					);
 				}
 			}
 			// V2 contract trap: `address_to_verification_key(seller)` returns None
@@ -344,10 +350,10 @@ export const createPurchaseInitPost = payAuthenticatedEndpointFactory.build({
 			// referencing the seller principal would fail and funds locked
 			// against this seller would be permanently unspendable. Reject
 			// before constructing the purchase request.
-			if (isV2 && !isCardanoPubKeyBaseAddressForNetwork(sellerAddress, input.network)) {
+			if (isV2 && !isCardanoPubKeyAddressForNetwork(sellerAddress, input.network)) {
 				throw createHttpError(
 					400,
-					'Seller principal address (resolved from agent NFT holder) must be a Cardano base address with a verification-key payment credential. Script-credential addresses (smart wallets, multisig wrappers) cannot interact with the escrow contract; the seller must move the agent NFT to a verification-key address before purchases can be processed.',
+					'Seller principal address (resolved from agent NFT holder) must be a Cardano base or enterprise address with a verification-key payment credential. Script-credential addresses (smart wallets, multisig wrappers) cannot interact with the escrow contract; the seller must move the agent NFT to a verification-key address before purchases can be processed.',
 				);
 			}
 

--- a/src/types/payment-source.ts
+++ b/src/types/payment-source.ts
@@ -2,7 +2,7 @@ export {
 	MAX_SUPPORTED_PAYMENT_SOURCES,
 	SupportedPaymentSourceChain,
 	isCardanoAddressForNetwork,
-	isCardanoPubKeyBaseAddressForNetwork,
+	isCardanoPubKeyAddressForNetwork,
 	parseSupportedPaymentSourcesFromMetadata,
 	supportedPaymentSourceSchema,
 	supportedPaymentSourceMetadataSchema,


### PR DESCRIPTION
Widen participant-address validation from pubkey base only to pubkey base or enterprise across the shared validator, the V1 and V2 datum builders, and the payments/purchases/x402 routes. The vested_pay validators (V1 and V2) only read the payment credential (address_to_verification_key) and payouts compare the full address, so a stake-less datum address is safe on-chain; mesh encodes the omitted stake credential as Plutus None, which the datum decoder already handles. Script payment credentials, script-stake, pointer and reward addresses stay rejected.

Side effect: V1's datum builder previously had no explicit address-type check and relied on resolveStakeKeyHash throwing; malformed participant addresses now fail with an explicit error instead of a mesh internal throw.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
