### PR TITLE
docs: migrate documentation links to DevHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Masumi is a decentralized protocol designed to enable AI agents to collaborate a
 - **Observability**: Built-in OpenTelemetry integration for distributed tracing, metrics, and structured log export to SigNoz, Grafana, or Datadog.
 - **Admin Dashboard**: Next.js frontend for managing agents, wallets, API keys, and monitoring wallet health.
 
-Learn more about Masumi in our [Introduction Guide](https://docs.masumi.network/get-started/introduction).
+Learn more about Masumi in our [Introduction Guide](https://www.masumi.network/dev/masumi/documentation).
 
 ## Getting Started
 
@@ -58,7 +58,7 @@ and [docs/e2e-testing.md](docs/e2e-testing.md) for end-to-end tests.
 
 We have been audited by [TxPipe](https://txpipe.io/) please check the [full report](docs/audit.pdf) for details.
 
-Refer to the official [Masumi Docs Website](https://docs.masumi.network) for comprehensive documentation and full setup guide.
+Refer to the official [Masumi Docs Website](https://www.masumi.network/dev/masumi) for comprehensive documentation and full setup guide.
 
 Additional guides can be found in the [docs](docs/) folder:
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" asChild>
               <Link
-                href="https://docs.masumi.network"
+                href="https://www.masumi.network/dev/masumi"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2"

--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -90,7 +90,7 @@ export function ApiKeyDialog() {
         </p>
 
         <Button variant="muted" className="text-sm mb-8 hover:underline" asChild>
-          <Link href={'https://docs.masumi.network/'} target="_blank" rel="noopener noreferrer">
+          <Link href={'https://www.masumi.network/dev/masumi/'} target="_blank" rel="noopener noreferrer">
             Learn more
           </Link>
         </Button>

--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -90,7 +90,11 @@ export function ApiKeyDialog() {
         </p>
 
         <Button variant="muted" className="text-sm mb-8 hover:underline" asChild>
-          <Link href={'https://www.masumi.network/dev/masumi/'} target="_blank" rel="noopener noreferrer">
+          <Link
+            href={'https://www.masumi.network/dev/masumi/'}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Learn more
           </Link>
         </Button>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -621,7 +621,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               <div className="flex items-center gap-4">
                 <Button variant="outline" size="sm" asChild>
                   <Link
-                    href="https://docs.masumi.network"
+                    href="https://www.masumi.network/dev/masumi"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-2"

--- a/frontend/src/components/testing/PaymentFormFields.tsx
+++ b/frontend/src/components/testing/PaymentFormFields.tsx
@@ -282,7 +282,7 @@ export function PaymentFormFields({
             <p className="text-xs text-muted-foreground">
               Input hashed per{' '}
               <a
-                href="https://docs.masumi.network/mips/_mip-004"
+                href="https://www.masumi.network/dev/masumi/mips/_mip-004"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline inline-flex items-center gap-0.5 hover:text-foreground transition-colors duration-150"

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -52,7 +52,7 @@ export default function NotFound() {
                 </Button>
                 <Button asChild variant="outline" size="lg" className="gap-2">
                   <Link
-                    href="https://docs.masumi.network"
+                    href="https://www.masumi.network/dev/masumi"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -414,7 +414,7 @@ export default function AIAgentsPage() {
               <p className="text-sm text-muted-foreground">
                 Manage your AI agents and their configurations.{' '}
                 <a
-                  href="https://docs.masumi.network/core-concepts/agentic-service"
+                  href="https://www.masumi.network/dev/masumi/core-concepts/agentic-service"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/api-keys.tsx
+++ b/frontend/src/pages/api-keys.tsx
@@ -182,7 +182,7 @@ export default function ApiKeys() {
               <p className="text-sm text-muted-foreground">
                 Manage your API keys for accessing the payment service.{' '}
                 <a
-                  href="https://docs.masumi.network/api-reference"
+                  href="https://www.masumi.network/dev/masumi/api-reference"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -258,7 +258,7 @@ export default function PaymentSourcesPage() {
               <p className="text-sm text-muted-foreground">
                 Manage your payment sources.{' '}
                 <Link
-                  href="https://docs.masumi.network/api-reference/payment-service/get-payment-source"
+                  href="https://www.masumi.network/dev/masumi/api-reference/payment-service/get-payment-source"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -391,7 +391,7 @@ export default function Transactions() {
               <p className="text-sm text-muted-foreground">
                 View and manage your transaction history.{' '}
                 <a
-                  href="https://docs.masumi.network/core-concepts/agent-to-agent-payments"
+                  href="https://www.masumi.network/dev/masumi/core-concepts/agent-to-agent-payments"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/wallets.tsx
+++ b/frontend/src/pages/wallets.tsx
@@ -164,7 +164,7 @@ export default function WalletsPage() {
               <p className="text-sm text-muted-foreground">
                 Manage your buying and selling wallets.{' '}
                 <Link
-                  href="https://docs.masumi.network/core-concepts/wallets"
+                  href="https://www.masumi.network/dev/masumi/core-concepts/wallets"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/webhooks.tsx
+++ b/frontend/src/pages/webhooks.tsx
@@ -400,7 +400,7 @@ export default function WebhooksPage() {
                   ? 'Send x402 payment events to custom endpoints, Slack, Google Chat, or Discord. '
                   : 'Send Cardano payment source events to custom endpoints, Slack, Google Chat, or Discord. '}
                 <Link
-                  href="https://docs.masumi.network/api-reference/payment-service/post-webhooks"
+                  href="https://www.masumi.network/dev/masumi/api-reference"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary hover:underline"

--- a/frontend/src/pages/x402.tsx
+++ b/frontend/src/pages/x402.tsx
@@ -49,7 +49,7 @@ export default function X402Page() {
               Manage the EVM payment rail: chains, managed wallets, spend budgets, balance alerts
               and payment activity.{' '}
               <a
-                href="https://docs.masumi.network"
+                href="https://www.masumi.network/dev/masumi"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"


### PR DESCRIPTION
## Summary

- replace legacy Masumi and Sokosumi documentation hosts with the canonical DevHub
- preserve route-specific destinations and map moved pages to their current live routes
- keep intentional compatibility references out of this repository change

## Impact

Documentation links now send users and agents to `https://www.masumi.network/dev` instead of retired documentation hosts.

## Validation

- `git diff --check`
- all 42 distinct migrated DevHub URLs returned HTTP 2xx/3xx
- the DevHub documentation audit passed for 304 local routes