### PR TITLE
fix: false InsufficientFunds when wallets are busy with a pending transaction

### DIFF
--- a/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
@@ -777,24 +777,25 @@ export async function batchLatestPaymentEntriesV1() {
 					}
 					//only go into error state if we did not reach max batch size, as otherwise we might have enough funds in other wallets
 					if (paymentRequestsRemaining.length > 0 && maxBatchSizeReached == false) {
+						//count all existing wallets, including ones busy with a pending transaction or locked by
+						//a concurrent run: a busy wallet frees up with its funds intact, so it must suppress the
+						//permanent error state instead of being treated as nonexistent
 						const allWalletCount = await prisma.hotWallet.count({
 							where: {
 								deletedAt: null,
 								type: HotWalletType.Purchasing,
-								PendingTransaction: null,
 								PaymentSource: {
 									id: paymentContract.id,
 								},
 							},
 						});
-						//only go into error state if all eligible wallets were unlocked, otherwise we might have enough funds in other wallets
+						//only go into error state if all eligible wallets were evaluated this run, otherwise we might have enough funds in busy wallets
 						for (const paymentRequest of paymentRequestsRemaining) {
 							const eligibleWalletCount = paymentRequest.isLimitedToHotWallets
 								? await prisma.hotWallet.count({
 										where: {
 											deletedAt: null,
 											type: HotWalletType.Purchasing,
-											PendingTransaction: null,
 											PaymentSource: { id: paymentContract.id },
 											id: { in: paymentRequest.HotWalletLimit.map((hw) => hw.id) },
 										},
@@ -806,6 +807,8 @@ export async function batchLatestPaymentEntriesV1() {
 							if (eligibleWalletCount == eligiblePotentialCount) {
 								logger.warn('No wallets with funds found, going into error state for', {
 									purchaseRequestId: paymentRequest.id,
+									eligibleWalletCount,
+									eligiblePotentialCount,
 								});
 								await prisma.purchaseRequest.update({
 									where: { id: paymentRequest.id },

--- a/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
@@ -1179,24 +1179,25 @@ export async function batchLatestPaymentEntriesV2() {
 					}
 					//only go into error state if we did not reach max batch size, as otherwise we might have enough funds in other wallets
 					if (paymentRequestsRemaining.length > 0 && maxBatchSizeReached == false) {
+						//count all existing wallets, including ones busy with a pending transaction or locked by
+						//a concurrent run: a busy wallet frees up with its funds intact, so it must suppress the
+						//permanent error state instead of being treated as nonexistent
 						const allWalletCount = await prisma.hotWallet.count({
 							where: {
 								deletedAt: null,
 								type: HotWalletType.Purchasing,
-								PendingTransaction: null,
 								PaymentSource: {
 									id: paymentContract.id,
 								},
 							},
 						});
-						//only go into error state if all eligible wallets were unlocked, otherwise we might have enough funds in other wallets
+						//only go into error state if all eligible wallets were evaluated this run, otherwise we might have enough funds in busy wallets
 						for (const paymentRequest of paymentRequestsRemaining) {
 							const eligibleWalletCount = paymentRequest.isLimitedToHotWallets
 								? await prisma.hotWallet.count({
 										where: {
 											deletedAt: null,
 											type: HotWalletType.Purchasing,
-											PendingTransaction: null,
 											PaymentSource: { id: paymentContract.id },
 											id: { in: paymentRequest.HotWalletLimit.map((hw) => hw.id) },
 										},
@@ -1208,6 +1209,8 @@ export async function batchLatestPaymentEntriesV2() {
 							if (eligibleWalletCount == eligiblePotentialCount) {
 								logger.warn('No wallets with funds found, going into error state for', {
 									purchaseRequestId: paymentRequest.id,
+									eligibleWalletCount,
+									eligiblePotentialCount,
 								});
 								await prisma.purchaseRequest.update({
 									where: { id: paymentRequest.id },


### PR DESCRIPTION
## Problem

Purchase requests sporadically fail permanently with `InsufficientFunds` / "Not enough funds in wallets" even though wallets with sufficient funds exist.

## Root cause

The batch-payments guard decides whether to put leftover requests into a permanent error state by comparing two wallet counts:

- **evaluated wallets**: loaded with `PendingTransaction: null AND lockedAt: null` at claim time
- **eligible wallets**: a DB count filtered by `PendingTransaction: null`

A wallet that is mid-transaction (batch submitted, awaiting confirmation) is excluded from **both**, so the counts match and the guard concludes "all eligible wallets were checked". Requests that the remaining free wallets cannot cover are moved to `WaitingForManualAction` + `InsufficientFunds` — permanently — even though the busy wallet frees up minutes later with its funds intact.

Wallets locked via `lockedAt` (concurrent run) already suppressed the error correctly; only the `PendingTransaction` case was mishandled.

## Fix

Count **all existing** purchasing wallets of the payment source (drop the `PendingTransaction: null` filter from both guard counts, general + `isLimitedToHotWallets` path). A busy wallet now makes the counts differ, the error state is suppressed, and the request retries on the next cron run once the wallet is free.

- Genuine insufficiency still errors: on a run where every wallet is free and evaluated, the counts match as before.
- Backstop unchanged: requests past `payByTime` are invalidated by tx-sync (`FundsOrDatumInvalid`), so nothing waits forever.
- Also adds the two counts to the warn log for future diagnosis.

Applied identically to `payment-source-v1` and `payment-source-v2` (the guard was forked with the bug). The x402/EVM path is not affected (no wallet pooling; budget guard is an atomic decrement).

Same fix as previously validated on `codex/tmp-f7457d7-cost-model-sync` (`393341c7`).

## Testing

- `pnpm run typecheck:backend` clean
- ESLint + Prettier clean on both files
- `pnpm test`: 63 suites / 549 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)