### PR TITLE
fix(escrow): balance UTxOs and queue errors

### DIFF
--- a/packages/payment-core/src/blockchain-error-interpreter.spec.ts
+++ b/packages/payment-core/src/blockchain-error-interpreter.spec.ts
@@ -24,7 +24,7 @@ describe('interpretBlockchainError', () => {
 		it('should match exact message', () => {
 			const result = interpretBlockchainError(new Error('UTxO Fully Depleted'));
 			expect(result).toContain('. Hint:');
-			expect(result).toContain('no UTxOs available');
+			expect(result).toContain('wallet may have enough total ADA');
 		});
 
 		it('should match case-insensitively', () => {
@@ -34,7 +34,7 @@ describe('interpretBlockchainError', () => {
 		it('should match inside a JSON Blockfrost error object', () => {
 			const result = interpretBlockchainError({ status_code: 400, message: 'UTxO Fully Depleted' });
 			expect(result).toContain('. Hint:');
-			expect(result).toContain('no UTxOs available');
+			expect(result).toContain('wallet may have enough total ADA');
 		});
 	});
 

--- a/packages/payment-core/src/blockchain-error-interpreter.spec.ts
+++ b/packages/payment-core/src/blockchain-error-interpreter.spec.ts
@@ -236,7 +236,8 @@ describe('interpretBlockchainError', () => {
 		it('should match "collateral utxo not found"', () => {
 			const result = interpretBlockchainError(new Error('Collateral UTXO not found'));
 			expect(result).toContain('. Hint:');
-			expect(result).toContain('pure-ADA UTxO');
+			expect(result).toContain('at least 5 ADA');
+			expect(result).toContain('native tokens');
 		});
 	});
 
@@ -254,7 +255,7 @@ describe('interpretBlockchainError', () => {
 
 		it('should NOT match pattern 17 (collateral) for plain UTXO not found', () => {
 			const result = interpretBlockchainError(new Error('UTXO not found'));
-			expect(result).not.toContain('pure-ADA UTxO');
+			expect(result).not.toContain('native tokens');
 		});
 	});
 

--- a/packages/payment-core/src/blockchain-error-interpreter.ts
+++ b/packages/payment-core/src/blockchain-error-interpreter.ts
@@ -78,7 +78,7 @@ const BLOCKCHAIN_ERROR_PATTERNS: ErrorPattern[] = [
 	},
 	{
 		test: (msg) => msg.includes('collateral utxo not found'),
-		hint: 'No suitable collateral UTxO was found. Ensure the wallet has a pure-ADA UTxO of at least 5 ADA.',
+		hint: 'No suitable collateral UTxO was found. Ensure the wallet has a UTxO with at least 5 ADA; native tokens on that UTxO are supported.',
 	},
 	{
 		test: (msg) => msg.includes('utxo not found'),

--- a/packages/payment-core/src/blockchain-error-interpreter.ts
+++ b/packages/payment-core/src/blockchain-error-interpreter.ts
@@ -8,7 +8,7 @@ interface ErrorPattern {
 const BLOCKCHAIN_ERROR_PATTERNS: ErrorPattern[] = [
 	{
 		test: (msg) => msg.includes('utxo fully depleted'),
-		hint: 'The wallet has no UTxOs available to cover this transaction. Ensure the wallet has sufficient ADA and UTxOs before retrying.',
+		hint: 'The selected inputs cannot produce valid transaction outputs and change. The wallet may have enough total ADA but need a larger or additional spendable UTxO; retry after consolidating UTxOs or contact support.',
 	},
 	{
 		test: (msg) =>

--- a/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
@@ -1,4 +1,4 @@
-import { OnChainState, PaymentAction, PaymentErrorType, PaymentSourceType } from '@/generated/prisma/client';
+import { OnChainState, PaymentAction, PaymentSourceType } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { deserializeDatum } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -9,7 +9,8 @@ import { decodeV1ContractDatum, newCooldownTime } from '@/utils/converter/string
 import { lockAndQueryPayments } from '@/utils/db/lock-and-query-payments';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { advancedRetryAll, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePaymentErrorTransition } from '@/services/shared/error-transition';
 import { Mutex, tryAcquire, MutexInterface } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
@@ -165,7 +166,7 @@ export async function authorizeRefundV1() {
 							constrainBeforeMs: Number(decodedContract.sellerCooldownTime),
 						});
 
-						const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
+						const collateralUtxo = selectCollateralUtxo(utxos);
 
 						const unsignedTx = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
 							'AuthorizeRefund',
@@ -174,8 +175,8 @@ export async function authorizeRefundV1() {
 							script,
 							address,
 							utxo,
-							limitedFilteredUtxos[0],
-							limitedFilteredUtxos,
+							collateralUtxo,
+							utxos,
 							datum.value,
 							invalidBefore,
 							invalidAfter,
@@ -199,7 +200,7 @@ export async function authorizeRefundV1() {
 						});
 						//submit the transaction to the blockchain
 						const newTxHash = await wallet.submitTx(signedTx);
-						await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+						await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 						await prisma.paymentRequest.update({
 							where: { id: request.id },
 							data: updateCurrentTransactionHash(newTxHash),
@@ -223,21 +224,13 @@ export async function authorizeRefundV1() {
 						logger.error(`Error authorizing refund ${request.id}`, {
 							error: error,
 						});
-						await prisma.paymentRequest.update({
-							where: { id: request.id },
-							data: {
-								...connectPreviousAction(request.nextActionId),
-								...createNextPaymentAction(PaymentAction.WaitingForManualAction, {
-									errorType: PaymentErrorType.Unknown,
-									errorNote: 'Authorizing refund failed: ' + interpretBlockchainError(error),
-								}),
-								SmartContractWallet: {
-									update: {
-										lockedAt: null,
-									},
-								},
-							},
-						});
+						await prisma.$transaction((tx) =>
+							writePaymentErrorTransition(tx, {
+								requestId: request.id,
+								nextActionId: request.nextActionId,
+								errorNote: 'Authorizing refund failed: ' + interpretBlockchainError(error),
+							}),
+						);
 					}
 					index++;
 				}

--- a/packages/payment-source-v1/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v1/src/services/payments/collection/service.ts
@@ -1,11 +1,4 @@
-import {
-	OnChainState,
-	PaymentAction,
-	PaymentErrorType,
-	PaymentSourceType,
-	TransactionStatus,
-	Prisma,
-} from '@/generated/prisma/client';
+import { OnChainState, PaymentAction, PaymentSourceType, TransactionStatus, Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { Asset, BlockfrostProvider, deserializeDatum } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -15,7 +8,8 @@ import { convertNetwork } from '@masumi/payment-core/network';
 import { lockAndQueryPayments } from '@/utils/db/lock-and-query-payments';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { advancedRetryAll, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePaymentErrorTransition } from '@/services/shared/error-transition';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractWithdrawTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import { CONSTANTS } from '@masumi/payment-core/config';
@@ -218,11 +212,7 @@ async function processSinglePaymentCollection(
 		collectionAddress = request.SmartContractWallet.walletAddress;
 	}
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
-	if (collateralUtxo == null) {
-		throw new Error('Collateral UTXO not found');
-	}
+	const collateralUtxo = selectCollateralUtxo(utxos);
 	const feeReceiverAddress = paymentContract.FeeReceiverNetworkWallet?.walletAddress ?? collectionAddress;
 	const shouldIncludeFeeOutput =
 		paymentContract.paymentSourceType !== PaymentSourceType.Web3CardanoV2 && Object.values(feeAssets).length > 0;
@@ -235,7 +225,7 @@ async function processSinglePaymentCollection(
 		address,
 		utxo,
 		collateralUtxo,
-		limitedFilteredUtxos,
+		utxos,
 		{
 			collectAssets: Object.values(remainingAssets),
 			collectionAddress: collectionAddress,
@@ -286,7 +276,7 @@ async function processSinglePaymentCollection(
 	});
 	//submit the transaction to the blockchain
 	const newTxHash = await wallet.submitTx(signedTx);
-	await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+	await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 
 	await prisma.paymentRequest.update({
 		where: { id: request.id },
@@ -361,21 +351,13 @@ export async function collectOutstandingPaymentsV1() {
 						logger.error(`Error collecting payments ${request.id}`, {
 							error: error,
 						});
-						await prisma.paymentRequest.update({
-							where: { id: request.id },
-							data: {
-								...connectPreviousAction(request.nextActionId),
-								...createNextPaymentAction(PaymentAction.WaitingForManualAction, {
-									errorType: PaymentErrorType.Unknown,
-									errorNote: 'Collecting payments failed: ' + interpretBlockchainError(error),
-								}),
-								SmartContractWallet: {
-									update: {
-										lockedAt: null,
-									},
-								},
-							},
-						});
+						await prisma.$transaction((tx) =>
+							writePaymentErrorTransition(tx, {
+								requestId: request.id,
+								nextActionId: request.nextActionId,
+								errorNote: 'Collecting payments failed: ' + interpretBlockchainError(error),
+							}),
+						);
 					}
 					index++;
 				}

--- a/packages/payment-source-v1/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v1/src/services/payments/submit-result/service.ts
@@ -89,7 +89,7 @@ async function handlePaymentRequestResults(
 		// its deadline passes.
 		if (result.success === false) {
 			logger.error(`Error submitting result ${request.id}`, {
-				error: result.error,
+				error: interpretBlockchainError(result.error),
 			});
 
 			await prisma.$transaction((tx) =>

--- a/packages/payment-source-v1/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v1/src/services/payments/submit-result/service.ts
@@ -1,4 +1,4 @@
-import { PaymentAction, PaymentErrorType, PaymentSourceType, Prisma } from '@/generated/prisma/client';
+import { PaymentAction, PaymentSourceType, Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { BlockfrostProvider, deserializeDatum, UTxO } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -8,7 +8,8 @@ import { convertNetwork } from '@masumi/payment-core/network';
 import { DecodedV1ContractDatum, decodeV1ContractDatum, newCooldownTime } from '@/utils/converter/string-datum-convert';
 import { lockAndQueryPayments } from '@/utils/db/lock-and-query-payments';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePaymentErrorTransition } from '@/services/shared/error-transition';
 import { delayErrorResolver } from 'advanced-retry';
 import { advancedRetryAll } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
@@ -91,21 +92,14 @@ async function handlePaymentRequestResults(
 				error: result.error,
 			});
 
-			await prisma.paymentRequest.update({
-				where: { id: request.id },
-				data: {
-					...connectPreviousAction(request.nextActionId),
-					...createNextPaymentAction(PaymentAction.WaitingForManualAction, {
-						errorType: PaymentErrorType.Unknown,
-						errorNote: 'Submitting result failed: ' + interpretBlockchainError(result.error),
-					}),
-					SmartContractWallet: {
-						update: {
-							lockedAt: null,
-						},
-					},
-				},
-			});
+			await prisma.$transaction((tx) =>
+				writePaymentErrorTransition(tx, {
+					requestId: request.id,
+					nextActionId: request.nextActionId,
+					errorNote: 'Submitting result failed: ' + interpretBlockchainError(result.error),
+					resultHash: request.NextAction.resultHash,
+				}),
+			);
 		}
 	}
 }
@@ -230,7 +224,7 @@ async function processSinglePaymentRequest(
 		constrainBeforeMs: Number(decodedContract.sellerCooldownTime),
 	});
 
-	const limitedUtxos = sortAndLimitUtxos(utxos, 8000000);
+	const collateralUtxo = selectCollateralUtxo(utxos);
 
 	const unsignedTx = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
 		'SubmitResult',
@@ -239,8 +233,8 @@ async function processSinglePaymentRequest(
 		script,
 		address,
 		utxo,
-		limitedUtxos[0],
-		limitedUtxos,
+		collateralUtxo,
+		utxos,
 		datum.value,
 		invalidBefore,
 		invalidAfter,
@@ -264,7 +258,7 @@ async function processSinglePaymentRequest(
 	});
 	try {
 		const newTxHash = await wallet.submitTx(signedTx);
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 		await prisma.paymentRequest.update({
 			where: { id: request.id },
 			data: updateCurrentTransactionHash(newTxHash),

--- a/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
@@ -1,4 +1,4 @@
-import { OnChainState, PaymentSourceType, PurchaseErrorType, PurchasingAction } from '@/generated/prisma/client';
+import { OnChainState, PaymentSourceType, PurchasingAction } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { deserializeDatum, UTxO } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -9,7 +9,8 @@ import { DecodedV1ContractDatum, decodeV1ContractDatum, newCooldownTime } from '
 import { lockAndQueryPurchases } from '@/utils/db/lock-and-query-purchases';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { advancedRetryAll, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePurchaseErrorTransition } from '@/services/shared/error-transition';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
@@ -182,7 +183,7 @@ export async function cancelRefundsV1() {
 						const { invalidBefore, invalidAfter } = createTxWindow(network, {
 							constrainBeforeMs: Number(decodedContract.buyerCooldownTime),
 						});
-						const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
+						const collateralUtxo = selectCollateralUtxo(utxos);
 
 						const unsignedTx = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
 							'CancelRefund',
@@ -191,8 +192,8 @@ export async function cancelRefundsV1() {
 							script,
 							address,
 							utxo,
-							limitedFilteredUtxos[0],
-							limitedFilteredUtxos,
+							collateralUtxo,
+							utxos,
 							datum.value,
 							invalidBefore,
 							invalidAfter,
@@ -211,7 +212,7 @@ export async function cancelRefundsV1() {
 						});
 
 						const newTxHash = await wallet.submitTx(signedTx);
-						await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+						await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 						await prisma.purchaseRequest.update({
 							where: { id: request.id },
 							data: updateCurrentTransactionHash(newTxHash),
@@ -232,17 +233,13 @@ export async function cancelRefundsV1() {
 					if (result.success == false || result.result != true) {
 						const error = result.error;
 						logger.error(`Error cancelling V1 refund ${request.id}`, { error });
-						await prisma.purchaseRequest.update({
-							where: { id: request.id },
-							data: {
-								...connectPreviousAction(request.nextActionId),
-								...createNextPurchaseAction(PurchasingAction.WaitingForManualAction, {
-									errorType: PurchaseErrorType.Unknown,
-									errorNote: 'Cancelling refund failed: ' + interpretBlockchainError(error),
-								}),
-								SmartContractWallet: { update: { lockedAt: null } },
-							},
-						});
+						await prisma.$transaction((tx) =>
+							writePurchaseErrorTransition(tx, {
+								requestId: request.id,
+								nextActionId: request.nextActionId,
+								errorNote: 'Cancelling refund failed: ' + interpretBlockchainError(error),
+							}),
+						);
 					}
 					index++;
 				}

--- a/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
@@ -1,7 +1,6 @@
 import {
 	OnChainState,
 	PaymentSourceType,
-	PurchaseErrorType,
 	PurchasingAction,
 	TransactionStatus,
 	Prisma,
@@ -15,7 +14,8 @@ import { convertNetwork } from '@masumi/payment-core/network';
 import { lockAndQueryPurchases } from '@/utils/db/lock-and-query-purchases';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { advancedRetryAll, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePurchaseErrorTransition } from '@/services/shared/error-transition';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractWithdrawTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
@@ -138,11 +138,7 @@ async function processSingleRefundCollection(
 
 	const { invalidBefore, invalidAfter } = createTxWindow(network);
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
-	if (collateralUtxo == null) {
-		throw new Error('Collateral UTXO not found');
-	}
+	const collateralUtxo = selectCollateralUtxo(utxos);
 
 	const unsignedTx = await generateMasumiSmartContractWithdrawTransactionAutomaticFees(
 		'CollectRefund',
@@ -152,7 +148,7 @@ async function processSingleRefundCollection(
 		address,
 		utxo,
 		collateralUtxo,
-		limitedFilteredUtxos,
+		utxos,
 		{
 			collectAssets: utxo.output.amount,
 			// buyerReturnAddress validated at route via src/routes/api/purchases/schemas.ts (isCardanoAddressForNetwork superRefine)
@@ -195,7 +191,7 @@ async function processSingleRefundCollection(
 
 	//submit the transaction to the blockchain
 	const newTxHash = await wallet.submitTx(signedTx);
-	await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+	await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 
 	await prisma.purchaseRequest.update({
 		where: { id: request.id },
@@ -275,21 +271,13 @@ export async function collectRefundV1() {
 						logger.error(`Error collecting refund ${request.id}`, {
 							error: error,
 						});
-						await prisma.purchaseRequest.update({
-							where: { id: request.id },
-							data: {
-								...connectPreviousAction(request.nextActionId),
-								...createNextPurchaseAction(PurchasingAction.WaitingForManualAction, {
-									errorType: PurchaseErrorType.Unknown,
-									errorNote: 'Collecting refund failed: ' + interpretBlockchainError(error),
-								}),
-								SmartContractWallet: {
-									update: {
-										lockedAt: null,
-									},
-								},
-							},
-						});
+						await prisma.$transaction((tx) =>
+							writePurchaseErrorTransition(tx, {
+								requestId: request.id,
+								nextActionId: request.nextActionId,
+								errorNote: 'Collecting refund failed: ' + interpretBlockchainError(error),
+							}),
+						);
 					}
 					index++;
 				}

--- a/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
@@ -1,4 +1,4 @@
-import { PaymentSourceType, PurchasingAction, PurchaseErrorType, Prisma } from '@/generated/prisma/client';
+import { PaymentSourceType, PurchasingAction, Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { BlockfrostProvider, deserializeDatum } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -9,7 +9,8 @@ import { decodeV1ContractDatum, newCooldownTime } from '@/utils/converter/string
 import { lockAndQueryPurchases } from '@/utils/db/lock-and-query-purchases';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { advancedRetryAll, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { selectCollateralUtxo } from '@/utils/utxo';
+import { writePurchaseErrorTransition } from '@/services/shared/error-transition';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
@@ -149,11 +150,7 @@ async function processSinglePurchaseRequest(
 		constrainBeforeMs: Number(decodedContract.buyerCooldownTime),
 	});
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
-	if (collateralUtxo == null) {
-		throw new Error('Collateral UTXO not found');
-	}
+	const collateralUtxo = selectCollateralUtxo(utxos);
 
 	const unsignedTx = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
 		'RequestRefund',
@@ -162,8 +159,8 @@ async function processSinglePurchaseRequest(
 		script,
 		address,
 		utxo,
-		limitedFilteredUtxos[0],
-		limitedFilteredUtxos,
+		collateralUtxo,
+		utxos,
 		datum.value,
 		invalidBefore,
 		invalidAfter,
@@ -188,7 +185,7 @@ async function processSinglePurchaseRequest(
 
 	//submit the transaction to the blockchain
 	const newTxHash = await wallet.submitTx(signedTx);
-	await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+	await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	await prisma.purchaseRequest.update({
 		where: { id: request.id },
 		data: updateCurrentTransactionHash(newTxHash),
@@ -268,21 +265,13 @@ export async function requestRefundsV1() {
 						logger.error(`Error requesting refund ${request.id}`, {
 							error: error,
 						});
-						await prisma.purchaseRequest.update({
-							where: { id: request.id },
-							data: {
-								...connectPreviousAction(request.nextActionId),
-								...createNextPurchaseAction(PurchasingAction.WaitingForManualAction, {
-									errorType: PurchaseErrorType.Unknown,
-									errorNote: 'Requesting refund failed: ' + interpretBlockchainError(error),
-								}),
-								SmartContractWallet: {
-									update: {
-										lockedAt: null,
-									},
-								},
-							},
-						});
+						await prisma.$transaction((tx) =>
+							writePurchaseErrorTransition(tx, {
+								requestId: request.id,
+								nextActionId: request.nextActionId,
+								errorNote: 'Requesting refund failed: ' + interpretBlockchainError(error),
+							}),
+						);
 					}
 					index++;
 				}

--- a/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/batch-helpers.test.ts
@@ -3,6 +3,7 @@ import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
 	computeCollateralFromExUnits,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	isTxSizeWithinLimit,
 	MAX_SAFE_TX_BYTES,
@@ -184,6 +185,19 @@ describe('pickBatchCollateral', () => {
 		];
 		const picked = pickBatchCollateral(utxos, []);
 		expect(picked?.input.txHash).toBe('empty-unit');
+	});
+});
+
+describe('getWalletUtxosForSelection', () => {
+	it('keeps collateral available while excluding script spending inputs', () => {
+		const collateral = makeUtxo({ txHash: 'collateral', lovelace: '8000000' });
+		const scriptInput = makeUtxo({ txHash: 'script', lovelace: '7000000' });
+		const funding = makeUtxo({ txHash: 'funding', lovelace: '6000000' });
+
+		expect(getWalletUtxosForSelection([collateral, scriptInput, funding], [scriptInput.input])).toEqual([
+			collateral,
+			funding,
+		]);
 	});
 });
 

--- a/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const builders: MockMeshTxBuilder[] = [];
+
+class MockMeshTxBuilder {
+	serializer = {
+		deserializer: {
+			key: {
+				deserializeAddress: jest.fn(() => ({ pubKeyHash: 'wallet-key-hash' })),
+			},
+		},
+	};
+	protocolParams = jest.fn(() => this);
+	spendingPlutusScript = jest.fn(() => this);
+	txIn = jest.fn(() => this) as jest.Mock;
+	txInScript = jest.fn(() => this);
+	txInRedeemerValue = jest.fn(() => this);
+	txInInlineDatumPresent = jest.fn(() => this);
+	txInCollateral = jest.fn(() => this) as jest.Mock;
+	setTotalCollateral = jest.fn(() => this);
+	txOut = jest.fn(() => this);
+	txOutInlineDatumValue = jest.fn(() => this);
+	selectUtxosFrom = jest.fn(() => this) as jest.Mock;
+	changeAddress = jest.fn(() => this);
+	invalidBefore = jest.fn(() => this);
+	invalidHereafter = jest.fn(() => this);
+	requiredSignerHash = jest.fn(() => this);
+	setNetwork = jest.fn(() => this);
+	metadataValue = jest.fn(() => this);
+	complete = jest.fn(async () => `unsigned-tx-${builders.indexOf(this) + 1}`);
+
+	constructor() {
+		builders.push(this);
+	}
+}
+
+jest.unstable_mockModule('@meshsdk/core', () => ({
+	MeshTxBuilder: MockMeshTxBuilder,
+	mOutputReference: jest.fn(),
+}));
+
+jest.unstable_mockModule('@meshsdk/core-cst', () => ({
+	resolvePlutusScriptAddress: jest.fn(() => 'addr_test1_contract'),
+}));
+
+jest.unstable_mockModule('@masumi/payment-core', () => ({
+	convertNetworkToId: jest.fn(() => 0),
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/logger', () => ({
+	logger: {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	},
+}));
+
+jest.unstable_mockModule('@/utils/min-utxo', () => ({
+	calculateMinUtxo: jest.fn(() => ({ minUtxoLovelace: 1_000_000n })),
+	getLovelaceFromAmounts: jest.fn(() => 7_000_000n),
+	getNativeTokenCount: jest.fn(() => 1),
+	calculateTopUpAmount: jest.fn(() => 0n),
+}));
+
+jest.unstable_mockModule('@/utils/mesh-cost-model-sync', () => ({
+	getCachedChainProtocolParameters: jest.fn(() => null),
+}));
+
+jest.unstable_mockModule('../../utils/mesh-cost-model-sync', () => ({
+	syncMeshCostModelsFromChainV2: jest.fn(),
+}));
+
+const { generateMasumiSmartContractInteractionTransactionAutomaticFees } = await import('../single-interaction');
+
+function createUtxo(txHash: string, lovelace: string) {
+	return {
+		input: {
+			txHash,
+			outputIndex: 0,
+		},
+		output: {
+			address: 'addr_test1_wallet',
+			amount: [{ unit: 'lovelace', quantity: lovelace }],
+		},
+	};
+}
+
+describe('V2 single-item smart-contract input selection', () => {
+	beforeEach(() => {
+		builders.length = 0;
+	});
+
+	it('offers all non-collateral UTxOs to Mesh in both fee passes', async () => {
+		const collateralUtxo = createUtxo('collateral', '8281874');
+		const smallUtxo = createUtxo('small', '3336392');
+		const largeUtxo = createUtxo('large', '485435616');
+		const smartContractUtxo = {
+			...createUtxo('contract', '7331310'),
+			output: {
+				...createUtxo('contract', '7331310').output,
+				address: 'addr_test1_contract',
+			},
+		};
+		const evaluateTx = jest.fn(async () => [{ budget: { mem: 100, steps: 200 } }]);
+		const blockchainProvider = {
+			fetchProtocolParameters: jest.fn(async () => ({ coinsPerUtxoSize: 4310 })),
+			evaluateTx,
+		};
+
+		await generateMasumiSmartContractInteractionTransactionAutomaticFees(
+			'SubmitResult',
+			blockchainProvider as never,
+			'preprod',
+			{ version: 'V3', code: 'script-cbor' },
+			'addr_test1_wallet',
+			smartContractUtxo as never,
+			collateralUtxo as never,
+			[collateralUtxo, smallUtxo, largeUtxo] as never,
+			{ alternative: 1, fields: [] },
+			100,
+			200,
+			undefined,
+			5_000_000n,
+		);
+
+		expect(builders).toHaveLength(2);
+		for (const builder of builders) {
+			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
+			expect(builder.txIn).toHaveBeenCalledTimes(1);
+		}
+	});
+});

--- a/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
@@ -91,7 +91,7 @@ describe('V2 single-item smart-contract input selection', () => {
 		builders.length = 0;
 	});
 
-	it('offers all non-collateral UTxOs to Mesh in both fee passes', async () => {
+	it('offers every wallet UTxO to Mesh in both fee passes, including collateral', async () => {
 		const collateralUtxo = createUtxo('collateral', '8281874');
 		const smallUtxo = createUtxo('small', '3336392');
 		const largeUtxo = createUtxo('large', '485435616');
@@ -127,7 +127,7 @@ describe('V2 single-item smart-contract input selection', () => {
 		expect(builders).toHaveLength(2);
 		for (const builder of builders) {
 			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
-			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([collateralUtxo, smallUtxo, largeUtxo]);
 			expect(builder.txIn).toHaveBeenCalledTimes(1);
 		}
 	});

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -9,11 +9,11 @@ import { logger } from '@masumi/payment-core/logger';
 /**
  * Lovelace amount routed into a CONDITIONAL "splitter" output that V2 batch
  * builders emit back to the funding wallet ONLY when the wallet has
- * exactly ONE fee-eligible UTxO (`walletUtxos.length === 1`, after
- * excluding the collateral input and any forced script/asset inputs).
+ * exactly ONE non-collateral wallet UTxO after excluding forced script/asset
+ * inputs. The collateral remains in Mesh's regular-input candidate list; it
+ * is excluded here only when deciding whether the optional splitter is useful.
  *
- * Per-length analysis — `walletUtxos` here is the FEE-ELIGIBLE UTxO count
- * (collateral excluded, mandatory script/asset inputs excluded):
+ * Per-length analysis — this is the non-collateral wallet UTxO count:
  *
  *   - `length === 0` → tx cannot build (no fee input); splitter would not
  *     help and the build failure is the correct operational signal.
@@ -55,11 +55,9 @@ import { logger } from '@masumi/payment-core/logger';
  * UTxOs across many txs — the splitter is a single-use second-UTxO
  * reservoir that fires only at the genuine trap-risk threshold.
  *
- * Cross-builder semantic invariant: every splitter call site MUST count
- * `walletUtxos` as collateral-excluded + mandatory-inputs-excluded.
- * batch-interaction.ts relies on the service-layer filter; batch-registry.ts
- * filters internally via `inputRefs.add(refKey(collateralUtxo))` before
- * deriving `walletUtxosForSelection` (see `generateRegistryBatchMintTransaction`).
+ * Splitter decisions deliberately count the collateral separately from
+ * ordinary wallet candidates. Coin selection does not: payment interaction
+ * builders pass the complete wallet list to Mesh.
  */
 export const WALLET_SPLITTER_LOVELACE = 5_000_000n;
 
@@ -145,6 +143,21 @@ function isPureLovelace(utxo: UTxO): boolean {
 /** Canonical reference string for a UTxO — must match the format the builders use. */
 function refKey(input: { txHash: string; outputIndex: number }): string {
 	return `${input.txHash}#${input.outputIndex}`;
+}
+
+/**
+ * Keeps every payment-key wallet candidate available to Mesh while excluding
+ * only inputs that the transaction already spends as scripts.
+ *
+ * In particular, callers must not exclude the declared collateral: CIP-40
+ * allows a VKey UTxO to appear in both regular and collateral input sets.
+ */
+export function getWalletUtxosForSelection(
+	utxos: UTxO[],
+	scriptSpendingInputs: Array<{ txHash: string; outputIndex: number }>,
+): UTxO[] {
+	const scriptInputKeys = new Set(scriptSpendingInputs.map(refKey));
+	return utxos.filter((utxo) => !scriptInputKeys.has(refKey(utxo.input)));
 }
 
 /**

--- a/packages/payment-source-v2/src/builders/batch-interaction.ts
+++ b/packages/payment-source-v2/src/builders/batch-interaction.ts
@@ -84,6 +84,11 @@ function refKey(utxo: UTxO): string {
 	return `${utxo.input.txHash}#${utxo.input.outputIndex}`;
 }
 
+function countNonCollateralWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): number {
+	const collateralKey = refKey(collateralUtxo);
+	return walletUtxos.filter((utxo) => refKey(utxo) !== collateralKey).length;
+}
+
 function assertDistinctRefs<T extends { smartContractUtxo: UTxO }>(items: T[]): void {
 	const seen = new Set<string>();
 	for (const item of items) {
@@ -264,6 +269,7 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 	}
 
 	const sortedItems = sortItemsCanonical(items);
+	const nonCollateralWalletUtxoCount = countNonCollateralWalletUtxos(walletUtxos, collateralUtxo);
 
 	async function buildTwoPass(includeWalletSplitter: boolean): Promise<string> {
 		const evaluationTx = await buildBatchInteractionTx(
@@ -318,7 +324,7 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 	} catch (error) {
 		if (
 			!shouldRetryWithoutOptionalWalletSplitter({
-				walletUtxoCount: walletUtxos.length,
+				walletUtxoCount: nonCollateralWalletUtxoCount,
 				includeWalletSplitter: true,
 				error,
 			})
@@ -326,7 +332,7 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 			throw error;
 		}
 		logger.warn('V2 batch interaction optional wallet splitter depleted fee input; retrying without splitter', {
-			walletUtxoCount: walletUtxos.length,
+			walletUtxoCount: nonCollateralWalletUtxoCount,
 			itemCount: sortedItems.length,
 			error: error instanceof Error ? { name: error.name, message: error.message } : error,
 		});
@@ -455,19 +461,20 @@ async function buildBatchInteractionTx(
 		txBuilder.txOut(smartContractAddress, outputAmount).txOutInlineDatumValue(item.newInlineDatum);
 	}
 
+	const nonCollateralWalletUtxoCount = countNonCollateralWalletUtxos(walletUtxos, collateralUtxo);
+
 	// Conditional wallet "splitter" output: an explicit pure-ADA self-send
-	// emitted ONLY when the wallet has exactly ONE fee-eligible UTxO (the
-	// genuine trap-risk floor). Threshold rationale:
+	// emitted ONLY when the wallet has exactly ONE non-collateral wallet UTxO
+	// (the genuine trap-risk floor). Threshold rationale:
 	//
-	//   - `walletUtxos.length === 0` → tx cannot build; splitter would not
-	//     help and the build failure is the correct signal.
-	//   - `walletUtxos.length === 1` → mesh consumes the one fee input,
+	//   - count === 0 → the collateral is the only wallet candidate.
+	//   - count === 1 → mesh may consume the one ordinary fee input,
 	//     emits one change. Without splitter the wallet ends at
 	//     [collateral, change] = exactly the 2-UTxO floor — any phase-2
 	//     failure or external consolidation drops below 2 and re-triggers
 	//     `ensureCollateralReady` prep. Splitter adds a 3rd UTxO so the
 	//     wallet has a buffer.
-	//   - `walletUtxos.length >= 2` → mesh's natural behavior post-tx is
+	//   - count >= 2 → mesh's natural behavior post-tx is
 	//     at least [collateral, change] = 2 UTxOs regardless of how many
 	//     fee inputs it picks. Splitter is over-emission; firing it adds
 	//     an extra output that competes with the script continuation
@@ -475,25 +482,22 @@ async function buildBatchInteractionTx(
 	//     `[batch-fallback]` on dense batches (the regression that
 	//     surfaced the `<= 2` threshold being too loose).
 	//
-	// The collateral input is excluded from `walletUtxos` by the service
-	// layer (each service's `.filter(...)` walk removes `collateralUtxo`
-	// before passing here), so `walletUtxos.length` is the count of
-	// FEE-ELIGIBLE wallet UTxOs.
+	// `walletUtxos` includes the declared collateral because CIP-40 permits a
+	// payment-key UTxO to appear in both input sets. Mesh performs the final
+	// regular-input selection from this complete candidate list.
 	//
 	// See `batch-helpers.ts WALLET_SPLITTER_LOVELACE` for the lifecycle
 	// rationale and the cross-module invariant
 	// `WALLET_SPLITTER_LOVELACE >= COLLATERAL_RESERVE_LOVELACE`.
-	if ((options.includeWalletSplitter ?? true) && walletUtxos.length === 1) {
+	if ((options.includeWalletSplitter ?? true) && nonCollateralWalletUtxoCount === 1) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: WALLET_SPLITTER_LOVELACE.toString() }]);
 	}
 
 	// Hand the candidate wallet UTxOs to Mesh's coin selector instead of
-	// force-adding every one. Force-adding (a) blows tx size on fragmented
-	// wallets and (b) bypasses caller-supplied exclusion lists (e.g.
-	// `pickBatchCollateral`'s `excludeSpendingInputs`) — the service layer
-	// pre-filters `walletUtxos` to exclude collateral + spending refs so
-	// passing the full list to `selectUtxosFrom` is safe and lets Mesh pick
-	// only what's needed for fees + change.
+	// force-adding every one. Force-adding blows tx size on fragmented
+	// wallets. The service layer only excludes script-spending refs; it keeps
+	// collateral available because the ledger allows regular VKey overlap.
+	// Mesh then picks only what's needed for fees + change.
 	txBuilder.selectUtxosFrom(walletUtxos);
 
 	return await txBuilder
@@ -687,9 +691,9 @@ async function buildBatchWithdrawTx(
 	}
 
 	// Conditional wallet "splitter" output — same rationale as in
-	// buildBatchInteractionTx. Emit ONLY when wallet has exactly one
-	// fee-eligible UTxO (the genuine trap-risk floor).
-	if (walletUtxos.length === 1) {
+	// buildBatchInteractionTx. Emit only when there is exactly one
+	// non-collateral wallet UTxO.
+	if (countNonCollateralWalletUtxos(walletUtxos, collateralUtxo) === 1) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: WALLET_SPLITTER_LOVELACE.toString() }]);
 	}
 

--- a/packages/payment-source-v2/src/builders/single-interaction.ts
+++ b/packages/payment-source-v2/src/builders/single-interaction.ts
@@ -55,13 +55,6 @@ function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	}
 }
 
-function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
-	return walletUtxos.filter(
-		(utxo) =>
-			utxo.input.txHash !== collateralUtxo.input.txHash || utxo.input.outputIndex !== collateralUtxo.input.outputIndex,
-	);
-}
-
 export async function generateMasumiSmartContractInteractionTransactionAutomaticFees(
 	type: V2SingleInteractionType,
 	blockchainProvider: BlockfrostProvider,
@@ -268,9 +261,10 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	// Keep collateral dedicated and let Mesh add only the wallet inputs needed
-	// after balancing the script continuation, splitter, fee, and change.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	// Keep every wallet UTxO available to Mesh's final balancing pass. The
+	// declared collateral may also be the input Mesh needs to cover the script
+	// continuation, splitter, fee, and change.
+	txBuilder.selectUtxosFrom(walletUtxos);
 
 	return await txBuilder
 		.changeAddress(walletAddress)
@@ -470,7 +464,7 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(walletUtxos);
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/packages/payment-source-v2/src/builders/single-interaction.ts
+++ b/packages/payment-source-v2/src/builders/single-interaction.ts
@@ -55,6 +55,13 @@ function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	}
 }
 
+function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
+	return walletUtxos.filter(
+		(utxo) =>
+			utxo.input.txHash !== collateralUtxo.input.txHash || utxo.input.outputIndex !== collateralUtxo.input.outputIndex,
+	);
+}
+
 export async function generateMasumiSmartContractInteractionTransactionAutomaticFees(
 	type: V2SingleInteractionType,
 	blockchainProvider: BlockfrostProvider,
@@ -253,10 +260,6 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		.txOut(smartContractAddress, outputAmount)
 		.txOutInlineDatumValue(newInlineDatum);
 
-	for (const utxo of walletUtxos) {
-		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
-	}
-
 	// Optional self-send splitter for V2 single-item callers. See docstring
 	// on the public AutomaticFees entry point. Emitted BEFORE
 	// `.changeAddress(...)` so mesh's coin selection accounts for it as a
@@ -264,6 +267,10 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 	if (walletSplitterLovelace != null) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
+
+	// Keep collateral dedicated and let Mesh add only the wallet inputs needed
+	// after balancing the script continuation, splitter, fee, and change.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)
@@ -441,10 +448,6 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		);
 	}
 
-	for (const utxo of walletUtxos) {
-		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
-	}
-
 	if (fee) {
 		const outputReference = mOutputReference(fee.txHash, fee.outputIndex);
 		txBuilder.txOut(fee.feeAddress, fee.feeAssets).txOutInlineDatumValue(outputReference);
@@ -466,6 +469,8 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 	if (walletSplitterLovelace != null) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
+
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
@@ -17,7 +17,6 @@ import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-cla
 import { makeHotWalletUnlocker, makePaymentRequestFailureMarker } from '../../request-failure';
 import { findMatchingPaymentUtxo } from '../../utxo-matching';
 import { advancedRetry, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { Mutex, tryAcquire, MutexInterface } from 'async-mutex';
 // V2-pinned single-item builder. MUST NOT use the root V1-mesh generator
 // (@/utils/generator/transaction-generator) — that bundles the V1 cost models
@@ -247,15 +246,7 @@ async function processSinglePaymentRequest(
 	const { invalidBefore, invalidAfter } = createTxWindow(network, {
 		constrainBeforeMs: decodedContract.sellerCooldownTime,
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedFilteredUtxos
-	// is sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA
-	// reserve, so this normally succeeds. Fall back to [0] only if the wallet has
-	// nothing larger (no worse than the previous behaviour).
-	const collateralUtxo = pickBatchCollateral(limitedFilteredUtxos, [utxo.input]) ?? limitedFilteredUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [utxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -272,7 +263,7 @@ async function processSinglePaymentRequest(
 				address,
 				utxo,
 				collateralUtxo,
-				limitedFilteredUtxos,
+				utxos,
 				datum.value,
 				invalidBefore,
 				invalidAfter,
@@ -314,7 +305,7 @@ async function processSinglePaymentRequest(
 	// Non-fatal: the tx is already on-chain. A projection failure must NOT
 	// propagate to advancedRetry and rebuild+resubmit an already-broadcast tx.
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (projectionError) {
 		logger.warn('V2 authorize-refund single-item: post-submit balance projection failed (non-fatal)', {
 			txHash: newTxHash,
@@ -559,8 +550,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };
@@ -629,7 +618,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -899,7 +888,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 authorize-refund batch projected balance evaluation failed (non-fatal)', { error: balanceError });
 	}

--- a/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
@@ -40,6 +40,7 @@ import { decodeV2ContractDatum } from '@/utils/converter/string-datum-convert';
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -540,16 +541,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };

--- a/packages/payment-source-v2/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v2/src/services/payments/collection/service.ts
@@ -17,7 +17,6 @@ import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-cla
 import { makeHotWalletUnlocker, makePaymentRequestFailureMarker } from '../../request-failure';
 import { findMatchingPaymentUtxo } from '../../utxo-matching';
 import { advancedRetry, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 // V2-pinned single-item builder. MUST NOT use the root V1-mesh generator
 // (@/utils/generator/transaction-generator) — that bundles the V1 cost models
@@ -304,16 +303,7 @@ async function processSinglePaymentCollection(
 	const { script, smartContractAddress } = await getPaymentScriptFromPaymentSourceV2(paymentContract);
 	const validated = await validateAndBuildItem(request, blockchainProvider, network, smartContractAddress);
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedFilteredUtxos
-	// is sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA
-	// reserve, so this normally succeeds. Fall back to [0] only if the wallet has
-	// nothing larger (no worse than the previous behaviour).
-	const collateralUtxo =
-		pickBatchCollateral(limitedFilteredUtxos, [validated.smartContractUtxo.input]) ?? limitedFilteredUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [validated.smartContractUtxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -331,7 +321,7 @@ async function processSinglePaymentCollection(
 				address,
 				validated.smartContractUtxo,
 				collateralUtxo,
-				limitedFilteredUtxos,
+				utxos,
 				{
 					collectAssets: validated.collectAssets,
 					collectionAddress: validated.collectionAddress,
@@ -391,7 +381,7 @@ async function processSinglePaymentCollection(
 	// outer advancedRetry and trigger a rebuild+resubmit of an already-broadcast
 	// tx. Parity with the batch path, which wraps the identical call "(non-fatal)".
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (projectionError) {
 		logger.warn('V2 collection single-item: post-submit balance projection failed (non-fatal)', {
 			paymentRequestId: request.id,
@@ -640,8 +630,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };
@@ -718,7 +706,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -975,7 +963,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 collection batch projected balance evaluation failed (non-fatal)', { error: balanceError });
 	}

--- a/packages/payment-source-v2/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v2/src/services/payments/collection/service.ts
@@ -40,6 +40,7 @@ import { decodeV2ContractDatum } from '@/utils/converter/string-datum-convert';
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -620,16 +621,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };

--- a/packages/payment-source-v2/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v2/src/services/payments/submit-result/service.ts
@@ -39,6 +39,7 @@ import { createDatumFromDecodedContractV2, getPaymentScriptFromPaymentSourceV2 }
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -702,16 +703,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	// Constraints applied progressively: validity-window intersection then
 	// no-collateral-overlap. tx-size is checked after the build pass.
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {

--- a/packages/payment-source-v2/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v2/src/services/payments/submit-result/service.ts
@@ -15,7 +15,6 @@ import { DecodedV1ContractDatum, newCooldownTime } from '@/utils/converter/strin
 import { lockAndQueryPayments } from '@/utils/db/lock-and-query-payments';
 import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { withMeshCostModelLock } from '@/utils/mesh-cost-model-sync';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { delayErrorResolver } from 'advanced-retry';
 import { advancedRetry } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
@@ -375,15 +374,7 @@ async function processSinglePaymentRequest(
 		constrainBeforeMs: decodedContract.sellerCooldownTime,
 	});
 
-	const limitedUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedUtxos is
-	// sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA
-	// reserve, so this normally succeeds. Fall back to [0] only if the wallet has
-	// nothing larger (no worse than the previous behaviour).
-	const collateralUtxo = pickBatchCollateral(limitedUtxos, [utxo.input]) ?? limitedUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [utxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -401,7 +392,7 @@ async function processSinglePaymentRequest(
 				address,
 				utxo,
 				collateralUtxo,
-				limitedUtxos,
+				utxos,
 				datum.value,
 				invalidBefore,
 				invalidAfter,
@@ -463,7 +454,7 @@ async function processSinglePaymentRequest(
 	// with the successful tx's hash never recorded. The batch path already wraps
 	// the identical call this way.
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 submit-result single-item: projected-balance check failed post-submit (non-fatal)', {
 			requestId: request.id,
@@ -721,8 +712,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	// Constraints applied progressively: validity-window intersection then
 	// no-collateral-overlap. tx-size is checked after the build pass.
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
@@ -800,7 +789,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -1088,7 +1077,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 submit-result batch projected balance evaluation failed (non-fatal)', {
 			error:

--- a/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
@@ -43,6 +43,7 @@ import { decodeV2ContractDatum } from '@/utils/converter/string-datum-convert';
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -462,8 +463,9 @@ async function processWalletBatch(
 	}
 
 	// See ensureCollateralReady module note: Cardano allows VKey wallet
-	// collateral/input overlap, but the current V2 builders maintain a
-	// separate collateral reserve for predictable next-tick readiness. If the
+	// collateral/input overlap. The readiness helper retains an additional
+	// confirmed UTxO for predictable next-tick readiness, while Mesh may use
+	// the declared collateral for regular funding. If the
 	// wallet has collapsed to a single UTxO, the helper submits a self-send
 	// prep tx and returns 'deferred'; we leave items queued for the next tick (the
 	// wallet stays locked until tx-sync / wallet-timeouts releases it).
@@ -560,16 +562,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };

--- a/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
@@ -23,7 +23,6 @@ import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-cla
 import { makeHotWalletUnlocker, makePurchaseRequestFailureMarker } from '../../request-failure';
 import { findMatchingPurchaseUtxo } from '../../utxo-matching';
 import { advancedRetry, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 // V2-pinned single-item builder. MUST NOT use the root V1-mesh generator (@/utils/generator/transaction-generator) — that bundles the V1 cost models and CBOR serializer, which produce a script-data-hash the ledger rejects for V2 scripts (PPViewHashesDontMatch). See docs/adr/0005.
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '../../../builders/single-interaction';
@@ -271,15 +270,7 @@ async function processSinglePurchaseRequest(
 	const { invalidBefore, invalidAfter } = createTxWindow(network, {
 		constrainBeforeMs: decodedContract.buyerCooldownTime,
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedFilteredUtxos
-	// is sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA reserve,
-	// so this normally succeeds. Fall back to [0] only if the wallet has nothing
-	// larger (no worse than the previous behaviour).
-	const collateralUtxo = pickBatchCollateral(limitedFilteredUtxos, [utxo.input]) ?? limitedFilteredUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [utxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -297,7 +288,7 @@ async function processSinglePurchaseRequest(
 				address,
 				utxo,
 				collateralUtxo,
-				limitedFilteredUtxos,
+				utxos,
 				datum.value,
 				invalidBefore,
 				invalidAfter,
@@ -334,7 +325,7 @@ async function processSinglePurchaseRequest(
 	// Non-fatal: the tx is already on-chain. A projection failure must NOT
 	// propagate to advancedRetry and rebuild+resubmit an already-broadcast tx.
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (projectionError) {
 		logger.warn('V2 authorize-withdrawal single-item: post-submit balance projection failed (non-fatal)', {
 			txHash: newTxHash,
@@ -579,8 +570,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };
@@ -651,7 +640,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -909,7 +898,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 authorize-withdrawal batch projected balance evaluation failed (non-fatal)', {
 			error:

--- a/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
@@ -23,7 +23,6 @@ import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-cla
 import { makeHotWalletUnlocker, makePurchaseRequestFailureMarker } from '../../request-failure';
 import { findMatchingPurchaseUtxo } from '../../utxo-matching';
 import { advancedRetry, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 // V2-pinned single-item builder. MUST NOT use the root V1-mesh generator (@/utils/generator/transaction-generator) — that bundles the V1 cost models and CBOR serializer, which produce a script-data-hash the ledger rejects for V2 scripts (PPViewHashesDontMatch). See docs/adr/0005.
 import { generateMasumiSmartContractWithdrawTransactionAutomaticFees } from '../../../builders/single-interaction';
@@ -231,16 +230,7 @@ async function processSingleRefundCollection(
 	const { script, smartContractAddress } = await getPaymentScriptFromPaymentSourceV2(paymentContract);
 	const validated = await validateAndBuildItem(request, blockchainProvider, network, smartContractAddress, address);
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedFilteredUtxos
-	// is sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA reserve,
-	// so this normally succeeds. Fall back to [0] only if the wallet has nothing
-	// larger (no worse than the previous behaviour).
-	const collateralUtxo =
-		pickBatchCollateral(limitedFilteredUtxos, [validated.smartContractUtxo.input]) ?? limitedFilteredUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [validated.smartContractUtxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -258,7 +248,7 @@ async function processSingleRefundCollection(
 				address,
 				validated.smartContractUtxo,
 				collateralUtxo,
-				limitedFilteredUtxos,
+				utxos,
 				{
 					collectAssets: validated.collectAssets,
 					collectionAddress: validated.buyerRefundAddress,
@@ -301,7 +291,7 @@ async function processSingleRefundCollection(
 	// Non-fatal: the tx is already on-chain. A projection failure must NOT
 	// propagate to advancedRetry and rebuild+resubmit an already-broadcast tx.
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (projectionError) {
 		logger.warn('V2 collect-refund single-item: post-submit balance projection failed (non-fatal)', {
 			txHash: newTxHash,
@@ -549,8 +539,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };
@@ -627,7 +615,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -882,7 +870,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 collect-refund batch projected balance evaluation failed (non-fatal)', { error: balanceError });
 	}

--- a/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
@@ -43,6 +43,7 @@ import { decodeV2ContractDatum } from '@/utils/converter/string-datum-convert';
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -431,8 +432,9 @@ async function processWalletBatch(
 	}
 
 	// See ensureCollateralReady module note: Cardano allows VKey wallet
-	// collateral/input overlap, but the current V2 builders maintain a
-	// separate collateral reserve for predictable next-tick readiness. If the
+	// collateral/input overlap. The readiness helper retains an additional
+	// confirmed UTxO for predictable next-tick readiness, while Mesh may use
+	// the declared collateral for regular funding. If the
 	// wallet has collapsed to a single UTxO, submit a self-send prep tx and
 	// defer the batch to the next tick. The helper leaves the wallet locked via
 	// its shared Tx row when status != 'ready'; wallet-timeouts /
@@ -529,16 +531,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };

--- a/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
@@ -23,7 +23,6 @@ import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-cla
 import { makeHotWalletUnlocker, makePurchaseRequestFailureMarker } from '../../request-failure';
 import { findMatchingPurchaseUtxo } from '../../utxo-matching';
 import { advancedRetry, delayErrorResolver } from 'advanced-retry';
-import { sortAndLimitUtxos } from '@/utils/utxo';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 // V2-pinned single-item builder. MUST NOT use the root V1-mesh generator (@/utils/generator/transaction-generator) — that bundles the V1 cost models and CBOR serializer, which produce a script-data-hash the ledger rejects for V2 scripts (PPViewHashesDontMatch). See docs/adr/0005.
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '../../../builders/single-interaction';
@@ -278,15 +277,7 @@ async function processSinglePurchaseRequest(
 		constrainBeforeMs: decodedContract.buyerCooldownTime,
 	});
 
-	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	// Collateral must cover the pinned 3 ADA total_collateral. limitedFilteredUtxos
-	// is sorted by ASCENDING asset bloat, so [0] can be a pure-ADA DUST UTxO (< 3
-	// ADA) → deterministic phase-1 InsufficientCollateral. Prefer the smallest
-	// qualifying >= 5 ADA UTxO (the same floor the batch path enforces via
-	// pickBatchCollateral); ensureCollateralReady above provisions a 5 ADA
-	// reserve, so this normally succeeds. Fall back to [0] only if the wallet has
-	// nothing larger (no worse than the previous behaviour).
-	const collateralUtxo = pickBatchCollateral(limitedFilteredUtxos, [utxo.input]) ?? limitedFilteredUtxos[0];
+	const collateralUtxo = pickBatchCollateral(utxos, [utxo.input]);
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}
@@ -304,7 +295,7 @@ async function processSinglePurchaseRequest(
 				address,
 				utxo,
 				collateralUtxo,
-				limitedFilteredUtxos,
+				utxos,
 				datum.value,
 				invalidBefore,
 				invalidAfter,
@@ -338,7 +329,7 @@ async function processSinglePurchaseRequest(
 	// Non-fatal: the tx is already on-chain. A projection failure must NOT
 	// propagate to advancedRetry and rebuild+resubmit an already-broadcast tx.
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (projectionError) {
 		logger.warn('V2 request-refund single-item: post-submit balance projection failed (non-fatal)', {
 			txHash: newTxHash,
@@ -590,8 +581,6 @@ async function processWalletBatch(
 		if (spendingUtxoKeys.has(key)) return false;
 		return true;
 	});
-	const limitedFilteredUtxos = sortAndLimitUtxos(walletUtxos, 8000000);
-
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };
@@ -675,7 +664,7 @@ async function processWalletBatch(
 					script,
 					address,
 					collateralUtxo,
-					limitedFilteredUtxos,
+					walletUtxos,
 					items,
 					composed.invalidBefore,
 					composed.invalidAfter,
@@ -941,7 +930,7 @@ async function processWalletBatch(
 	}
 
 	try {
-		await walletSession.evaluateProjectedBalance(unsignedTx, limitedFilteredUtxos);
+		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
 	} catch (balanceError) {
 		logger.warn('V2 request-refund batch projected balance evaluation failed (non-fatal)', { error: balanceError });
 	}

--- a/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
@@ -43,6 +43,7 @@ import { decodeV2ContractDatum } from '@/utils/converter/string-datum-convert';
 import {
 	assertNoCollateralOverlap,
 	assertTxSizeWithinLimit,
+	getWalletUtxosForSelection,
 	intersectTxWindows,
 	pickBatchCollateral,
 	shrinkBatchToFit,
@@ -469,10 +470,10 @@ async function processWalletBatch(
 
 	// Cardano allows a VKey wallet UTxO to appear in both `inputs` and
 	// `collateral_inputs`; only script-locked UTxOs are invalid collateral.
-	// The current V2 builders still maintain a separate collateral reserve for
-	// predictable next-tick readiness. If the wallet has collapsed to a single
-	// UTxO, submit a self-send prep tx to restore that service invariant and
-	// defer the batch to the next tick. ensureCollateralReady leaves
+	// The readiness helper still keeps an additional confirmed UTxO for
+	// predictable next-tick readiness, while Mesh may use the declared
+	// collateral for regular funding. If the wallet has collapsed to a single
+	// UTxO, submit a self-send prep tx and defer the batch. ensureCollateralReady leaves
 	// the wallet locked (via its shared Tx row) when it returns
 	// 'deferred' or 'failed'; wallet-timeouts / tx-sync will release the
 	// lock once the prep tx confirms or times out.
@@ -571,16 +572,10 @@ async function processWalletBatch(
 		return;
 	}
 
-	const spendingUtxoKeys = new Set(
-		validated.map((v) => `${v.smartContractUtxo.input.txHash}#${v.smartContractUtxo.input.outputIndex}`),
+	const walletUtxos = getWalletUtxosForSelection(
+		utxos,
+		validated.map((v) => v.smartContractUtxo.input),
 	);
-	const collateralKey = `${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex}`;
-	const walletUtxos = utxos.filter((utxo) => {
-		const key = `${utxo.input.txHash}#${utxo.input.outputIndex}`;
-		if (key === collateralKey) return false;
-		if (spendingUtxoKeys.has(key)) return false;
-		return true;
-	});
 	const shrinkResult = shrinkBatchToFit(validated, (subset) => {
 		const window = intersectTxWindows(subset.map((v) => v.window));
 		if (window == null) return { ok: false, reason: 'window' };

--- a/packages/payment-source-v2/src/services/request-failure.ts
+++ b/packages/payment-source-v2/src/services/request-failure.ts
@@ -1,15 +1,7 @@
-import { PaymentAction, PaymentErrorType, PurchaseErrorType, PurchasingAction } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { logger } from '@masumi/payment-core/logger';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
-// Import from the concrete module, not the '@/services/shared' barrel: the
-// barrel transitively imports this package back, and the resulting cycle makes
-// typed lint unable to resolve these call signatures.
-import {
-	connectPreviousAction,
-	createNextPaymentAction,
-	createNextPurchaseAction,
-} from '@/services/shared/transition-writer';
+import { writePaymentErrorTransition, writePurchaseErrorTransition } from '@/services/shared/error-transition';
 
 /**
  * Factories for the per-service `markRequestFailed` / `unlockHotWallet`
@@ -45,18 +37,15 @@ export function makePaymentRequestFailureMarker(config: PaymentFailureConfig) {
 		// release it instead.
 		const unlockWallet = options.unlockWallet ?? true;
 		logger.error(`${config.logMessage} ${request.id}`, { error });
-		await prisma.paymentRequest.update({
-			where: { id: request.id },
-			data: {
-				...connectPreviousAction(request.nextActionId),
-				...createNextPaymentAction(PaymentAction.WaitingForManualAction, {
-					...(config.carryResultHash ? { resultHash: request.NextAction?.resultHash ?? null } : {}),
-					errorType: PaymentErrorType.Unknown,
-					errorNote: config.errorNotePrefix + interpretBlockchainError(error),
-				}),
-				...(unlockWallet ? { SmartContractWallet: { update: { lockedAt: null } } } : {}),
-			},
-		});
+		await prisma.$transaction((tx) =>
+			writePaymentErrorTransition(tx, {
+				requestId: request.id,
+				nextActionId: request.nextActionId,
+				errorNote: config.errorNotePrefix + interpretBlockchainError(error),
+				unlockWallet,
+				...(config.carryResultHash ? { resultHash: request.NextAction?.resultHash ?? null } : {}),
+			}),
+		);
 	};
 }
 
@@ -71,17 +60,13 @@ export function makePurchaseRequestFailureMarker(config: PurchaseFailureConfig) 
 		error: unknown,
 	): Promise<void> {
 		logger.error(`${config.logMessage} ${request.id}`, { error });
-		await prisma.purchaseRequest.update({
-			where: { id: request.id },
-			data: {
-				...connectPreviousAction(request.nextActionId),
-				...createNextPurchaseAction(PurchasingAction.WaitingForManualAction, {
-					errorType: PurchaseErrorType.Unknown,
-					errorNote: config.errorNotePrefix + interpretBlockchainError(error),
-				}),
-				SmartContractWallet: { update: { lockedAt: null } },
-			},
-		});
+		await prisma.$transaction((tx) =>
+			writePurchaseErrorTransition(tx, {
+				requestId: request.id,
+				nextActionId: request.nextActionId,
+				errorNote: config.errorNotePrefix + interpretBlockchainError(error),
+			}),
+		);
 	};
 }
 

--- a/src/services/shared/error-transition.spec.ts
+++ b/src/services/shared/error-transition.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { PaymentAction, PurchasingAction } from '@/generated/prisma/client';
+
+const mockQueuePaymentOnError = jest.fn<(tx: object, requestId: string) => Promise<void>>(async () => undefined);
+const mockQueuePurchaseOnError = jest.fn<(tx: object, requestId: string) => Promise<void>>(async () => undefined);
+
+jest.unstable_mockModule('@/services/webhooks/events.service', () => ({
+	webhookEventsService: {
+		queuePaymentOnErrorInTransaction: mockQueuePaymentOnError,
+		queuePurchaseOnErrorInTransaction: mockQueuePurchaseOnError,
+	},
+}));
+
+const { writePaymentErrorTransition, writePurchaseErrorTransition } = await import('./error-transition');
+
+describe('transactional error transitions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('updates a payment and queues PAYMENT_ON_ERROR on the same transaction', async () => {
+		const paymentRequestUpdate = jest.fn<(args: { where: { id: string }; data: object }) => Promise<{ id: string }>>(
+			async () => ({ id: 'payment-1' }),
+		);
+		const tx = {
+			paymentRequest: {
+				update: paymentRequestUpdate,
+			},
+		};
+
+		await writePaymentErrorTransition(tx as never, {
+			requestId: 'payment-1',
+			nextActionId: 'action-1',
+			errorNote: 'Collecting payments failed',
+			resultHash: 'result-hash',
+		});
+
+		expect(paymentRequestUpdate).toHaveBeenCalledWith({
+			where: { id: 'payment-1' },
+			data: expect.objectContaining({
+				ActionHistory: { connect: { id: 'action-1' } },
+				NextAction: {
+					create: expect.objectContaining({
+						requestedAction: PaymentAction.WaitingForManualAction,
+						errorNote: 'Collecting payments failed',
+						resultHash: 'result-hash',
+					}),
+				},
+				SmartContractWallet: { update: { lockedAt: null } },
+			}),
+		});
+		expect(mockQueuePaymentOnError).toHaveBeenCalledWith(tx, 'payment-1');
+	});
+
+	it('updates a purchase and queues PURCHASE_ON_ERROR on the same transaction', async () => {
+		const purchaseRequestUpdate = jest.fn<(args: { where: { id: string }; data: object }) => Promise<{ id: string }>>(
+			async () => ({ id: 'purchase-1' }),
+		);
+		const tx = {
+			purchaseRequest: {
+				update: purchaseRequestUpdate,
+			},
+		};
+
+		await writePurchaseErrorTransition(tx as never, {
+			requestId: 'purchase-1',
+			nextActionId: 'action-2',
+			errorNote: 'Collecting refund failed',
+			unlockWallet: false,
+		});
+
+		expect(purchaseRequestUpdate).toHaveBeenCalledWith({
+			where: { id: 'purchase-1' },
+			data: expect.objectContaining({
+				ActionHistory: { connect: { id: 'action-2' } },
+				NextAction: {
+					create: expect.objectContaining({
+						requestedAction: PurchasingAction.WaitingForManualAction,
+						errorNote: 'Collecting refund failed',
+					}),
+				},
+			}),
+		});
+		expect(purchaseRequestUpdate.mock.calls[0]?.[0].data).not.toHaveProperty('SmartContractWallet');
+		expect(mockQueuePurchaseOnError).toHaveBeenCalledWith(tx, 'purchase-1');
+	});
+});

--- a/src/services/shared/error-transition.ts
+++ b/src/services/shared/error-transition.ts
@@ -1,0 +1,62 @@
+import {
+	PaymentAction,
+	PaymentErrorType,
+	Prisma,
+	PurchaseErrorType,
+	PurchasingAction,
+} from '@/generated/prisma/client';
+import { webhookEventsService } from '@/services/webhooks/events.service';
+import {
+	connectPreviousAction,
+	createNextPaymentAction,
+	createNextPurchaseAction,
+} from '@/services/shared/transition-writer';
+
+type ErrorTransitionParams<TErrorType> = {
+	requestId: string;
+	nextActionId: string;
+	errorNote: string;
+	errorType?: TErrorType;
+	unlockWallet?: boolean;
+};
+
+type PaymentErrorTransitionParams = ErrorTransitionParams<PaymentErrorType> & {
+	resultHash?: string | null;
+};
+
+export async function writePaymentErrorTransition(
+	tx: Prisma.TransactionClient,
+	params: PaymentErrorTransitionParams,
+): Promise<void> {
+	await tx.paymentRequest.update({
+		where: { id: params.requestId },
+		data: {
+			...connectPreviousAction(params.nextActionId),
+			...createNextPaymentAction(PaymentAction.WaitingForManualAction, {
+				errorType: params.errorType ?? PaymentErrorType.Unknown,
+				errorNote: params.errorNote,
+				...(params.resultHash !== undefined ? { resultHash: params.resultHash } : {}),
+			}),
+			...(params.unlockWallet === false ? {} : { SmartContractWallet: { update: { lockedAt: null } } }),
+		},
+	});
+	await webhookEventsService.queuePaymentOnErrorInTransaction(tx, params.requestId);
+}
+
+export async function writePurchaseErrorTransition(
+	tx: Prisma.TransactionClient,
+	params: ErrorTransitionParams<PurchaseErrorType>,
+): Promise<void> {
+	await tx.purchaseRequest.update({
+		where: { id: params.requestId },
+		data: {
+			...connectPreviousAction(params.nextActionId),
+			...createNextPurchaseAction(PurchasingAction.WaitingForManualAction, {
+				errorType: params.errorType ?? PurchaseErrorType.Unknown,
+				errorNote: params.errorNote,
+			}),
+			...(params.unlockWallet === false ? {} : { SmartContractWallet: { update: { lockedAt: null } } }),
+		},
+	});
+	await webhookEventsService.queuePurchaseOnErrorInTransaction(tx, params.requestId);
+}

--- a/src/services/webhooks/events.service.spec.ts
+++ b/src/services/webhooks/events.service.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { WebhookEventType } from '@/generated/prisma/client';
+
+const mockQueueWebhookInTransaction = jest.fn<
+	(
+		tx: object,
+		eventType: WebhookEventType,
+		payload: object,
+		entityId?: string,
+		paymentSourceId?: string,
+	) => Promise<void>
+>(async () => undefined);
+
+jest.unstable_mockModule('./queue.service', () => ({
+	webhookQueueService: {
+		queueWebhook: jest.fn(),
+		queueWebhookInTransaction: mockQueueWebhookInTransaction,
+	},
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/db', () => ({
+	prisma: {
+		paymentRequest: {
+			findUnique: jest.fn(),
+		},
+		purchaseRequest: {
+			findUnique: jest.fn(),
+		},
+	},
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/logger', () => ({
+	logger: {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	},
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/blockchain-identifier', () => ({
+	decodeBlockchainIdentifier: jest.fn(() => null),
+}));
+
+const { webhookEventsService } = await import('./events.service');
+
+describe('transactional error webhook events', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('loads the updated payment through the transaction and queues PAYMENT_ON_ERROR', async () => {
+		const payment = {
+			id: 'payment-1',
+			blockchainIdentifier: 'blockchain-1',
+			totalBuyerCardanoFees: 0n,
+			totalSellerCardanoFees: 0n,
+			submitResultTime: 1n,
+			sellerCoolDownTime: 2n,
+			buyerCoolDownTime: 3n,
+			payByTime: 4n,
+			unlockTime: 5n,
+			externalDisputeUnlockTime: 6n,
+			collateralReturnLovelace: 7n,
+			RequestedFunds: [],
+			WithdrawnForSeller: [],
+			WithdrawnForBuyer: [],
+			CurrentTransaction: null,
+			TransactionHistory: [],
+			PaymentSource: {
+				id: 'payment-source-1',
+			},
+		};
+		const paymentRequestFindUnique = jest.fn<(args: object) => Promise<typeof payment>>(async () => payment);
+		const tx = {
+			paymentRequest: {
+				findUnique: paymentRequestFindUnique,
+			},
+		};
+
+		await webhookEventsService.queuePaymentOnErrorInTransaction(tx as never, 'payment-1');
+
+		expect(paymentRequestFindUnique).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: 'payment-1' },
+			}),
+		);
+		expect(mockQueueWebhookInTransaction).toHaveBeenCalledWith(
+			tx,
+			WebhookEventType.PAYMENT_ON_ERROR,
+			expect.objectContaining({
+				id: 'payment-1',
+				blockchainIdentifier: 'blockchain-1',
+				collateralReturnLovelace: '7',
+			}),
+			'blockchain-1',
+			'payment-source-1',
+		);
+	});
+
+	it('rejects if the entity cannot be loaded so the state update also rolls back', async () => {
+		const paymentRequestFindUnique = jest.fn<(args: object) => Promise<null>>(async () => null);
+		const tx = {
+			paymentRequest: {
+				findUnique: paymentRequestFindUnique,
+			},
+		};
+
+		await expect(webhookEventsService.queuePaymentOnErrorInTransaction(tx as never, 'missing')).rejects.toThrow(
+			'Payment missing not found while queuing error webhook',
+		);
+		expect(mockQueueWebhookInTransaction).not.toHaveBeenCalled();
+	});
+});

--- a/src/services/webhooks/events.service.ts
+++ b/src/services/webhooks/events.service.ts
@@ -14,10 +14,12 @@ type WalletLowBalanceWebhookData = WebhookPayloadDataByEvent<'WALLET_LOW_BALANCE
 type X402PaymentWebhookEvent = 'X402_PAYMENT_SETTLED' | 'X402_PAYMENT_FAILED';
 type X402PaymentWebhookData = WebhookPayloadDataByEvent<X402PaymentWebhookEvent>;
 type X402WalletLowBalanceWebhookData = WebhookPayloadDataByEvent<'X402_WALLET_LOW_BALANCE'>;
+type PaymentWebhookQueryClient = Pick<Prisma.TransactionClient, 'paymentRequest'>;
+type PurchaseWebhookQueryClient = Pick<Prisma.TransactionClient, 'purchaseRequest'>;
 
 class WebhookEventsService {
-	private async queryPurchaseForWebhook(purchaseId: string) {
-		return prisma.purchaseRequest.findUnique({
+	private async queryPurchaseForWebhook(purchaseId: string, client: PurchaseWebhookQueryClient = prisma) {
+		return client.purchaseRequest.findUnique({
 			where: { id: purchaseId },
 			include: {
 				SellerWallet: true,
@@ -34,8 +36,8 @@ class WebhookEventsService {
 		});
 	}
 
-	private async queryPaymentForWebhook(paymentId: string) {
-		return prisma.paymentRequest.findUnique({
+	private async queryPaymentForWebhook(paymentId: string, client: PaymentWebhookQueryClient = prisma) {
+		return client.paymentRequest.findUnique({
 			where: { id: paymentId },
 			include: {
 				BuyerWallet: true,
@@ -204,6 +206,34 @@ class WebhookEventsService {
 
 	async triggerPaymentOnError(paymentId: string): Promise<void> {
 		await this.triggerGenericWebhook(WebhookEventType.PAYMENT_ON_ERROR, paymentId, 'payment');
+	}
+
+	async queuePurchaseOnErrorInTransaction(tx: Prisma.TransactionClient, purchaseId: string): Promise<void> {
+		const purchase = await this.queryPurchaseForWebhook(purchaseId, tx);
+		if (purchase == null) {
+			throw new Error(`Purchase ${purchaseId} not found while queuing error webhook`);
+		}
+		await webhookQueueService.queueWebhookInTransaction(
+			tx,
+			WebhookEventType.PURCHASE_ON_ERROR,
+			this.formatPurchaseForWebhook(purchase),
+			purchase.blockchainIdentifier,
+			purchase.PaymentSource.id,
+		);
+	}
+
+	async queuePaymentOnErrorInTransaction(tx: Prisma.TransactionClient, paymentId: string): Promise<void> {
+		const payment = await this.queryPaymentForWebhook(paymentId, tx);
+		if (payment == null) {
+			throw new Error(`Payment ${paymentId} not found while queuing error webhook`);
+		}
+		await webhookQueueService.queueWebhookInTransaction(
+			tx,
+			WebhookEventType.PAYMENT_ON_ERROR,
+			this.formatPaymentForWebhook(payment),
+			payment.blockchainIdentifier,
+			payment.PaymentSource.id,
+		);
 	}
 
 	// Fund-distribution lifecycle events are queued exclusively through the

--- a/src/utils/generator/transaction-generator/index.spec.ts
+++ b/src/utils/generator/transaction-generator/index.spec.ts
@@ -100,7 +100,7 @@ describe('V1 automatic smart-contract input selection', () => {
 		builders.length = 0;
 	});
 
-	it('balances both fee passes from all spendable inputs while keeping collateral dedicated', async () => {
+	it('offers every wallet UTxO to Mesh in both fee passes, including collateral', async () => {
 		const collateralUtxo = createUtxo('collateral', '8281874');
 		const smallUtxo = createUtxo('small', '3336392');
 		const largeUtxo = createUtxo('large', '485435616');
@@ -138,7 +138,7 @@ describe('V1 automatic smart-contract input selection', () => {
 		expect(builders).toHaveLength(2);
 		for (const builder of builders) {
 			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
-			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([collateralUtxo, smallUtxo, largeUtxo]);
 			expect(builder.txIn).toHaveBeenCalledTimes(1);
 			expect(builder.txIn).toHaveBeenCalledWith(
 				'contract',

--- a/src/utils/generator/transaction-generator/index.spec.ts
+++ b/src/utils/generator/transaction-generator/index.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const builders: MockMeshTxBuilder[] = [];
+
+class MockMeshTxBuilder {
+	serializer = {
+		deserializer: {
+			key: {
+				deserializeAddress: jest.fn(() => ({ pubKeyHash: 'wallet-key-hash' })),
+			},
+		},
+	};
+	protocolParams = jest.fn(() => this);
+	spendingPlutusScript = jest.fn(() => this);
+	txIn = jest.fn(() => this) as jest.Mock;
+	txInScript = jest.fn(() => this);
+	txInRedeemerValue = jest.fn(() => this);
+	txInInlineDatumPresent = jest.fn(() => this);
+	txInCollateral = jest.fn(() => this) as jest.Mock;
+	setTotalCollateral = jest.fn(() => this) as jest.Mock;
+	txOut = jest.fn(() => this);
+	txOutInlineDatumValue = jest.fn(() => this);
+	selectUtxosFrom = jest.fn(() => this) as jest.Mock;
+	changeAddress = jest.fn(() => this);
+	invalidBefore = jest.fn(() => this);
+	invalidHereafter = jest.fn(() => this);
+	requiredSignerHash = jest.fn(() => this);
+	setNetwork = jest.fn(() => this);
+	metadataValue = jest.fn(() => this);
+	complete = jest.fn(async () => `unsigned-tx-${builders.indexOf(this) + 1}`);
+
+	constructor() {
+		builders.push(this);
+	}
+}
+
+jest.unstable_mockModule('@meshsdk/core', () => ({
+	BlockfrostProvider: class {},
+	Data: {},
+	IFetcher: class {},
+	LanguageVersion: {},
+	MeshTxBuilder: MockMeshTxBuilder,
+	mOutputReference: jest.fn(),
+	Network: {},
+	UTxO: class {},
+}));
+
+jest.unstable_mockModule('@meshsdk/core-cst', () => ({
+	resolvePlutusScriptAddress: jest.fn(() => 'addr_test1_contract'),
+}));
+
+jest.unstable_mockModule('@/utils/converter/network-convert', () => ({
+	convertNetworkToId: jest.fn(() => 0),
+}));
+
+jest.unstable_mockModule('@/utils/min-utxo', () => ({
+	calculateMinUtxo: jest.fn(() => ({ minUtxoLovelace: 1_000_000n })),
+	getLovelaceFromAmounts: jest.fn(() => 7_000_000n),
+	getNativeTokenCount: jest.fn(() => 1),
+	calculateTopUpAmount: jest.fn(() => 0n),
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/config', () => ({
+	CONSTANTS: {
+		FALLBACK_COINS_PER_UTXO_SIZE: 4310,
+	},
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/logger', () => ({
+	logger: {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		debug: jest.fn(),
+	},
+}));
+
+jest.unstable_mockModule('@/utils/mesh-cost-model-sync', () => ({
+	getCachedChainProtocolParameters: jest.fn(() => null),
+	syncMeshCostModelsFromChain: jest.fn(),
+}));
+
+const { generateMasumiSmartContractInteractionTransactionAutomaticFees } = await import('./index');
+
+function createUtxo(txHash: string, lovelace: string) {
+	return {
+		input: {
+			txHash,
+			outputIndex: 0,
+		},
+		output: {
+			address: 'addr_test1_wallet',
+			amount: [{ unit: 'lovelace', quantity: lovelace }],
+		},
+	};
+}
+
+describe('V1 automatic smart-contract input selection', () => {
+	beforeEach(() => {
+		builders.length = 0;
+	});
+
+	it('balances both fee passes from all spendable inputs while keeping collateral dedicated', async () => {
+		const collateralUtxo = createUtxo('collateral', '8281874');
+		const smallUtxo = createUtxo('small', '3336392');
+		const largeUtxo = createUtxo('large', '485435616');
+		const smartContractUtxo = {
+			...createUtxo('contract', '7331310'),
+			output: {
+				...createUtxo('contract', '7331310').output,
+				address: 'addr_test1_contract',
+			},
+		};
+		const evaluateTx = jest.fn<(tx: string) => Promise<Array<{ budget: { mem: number; steps: number } }>>>(async () => [
+			{ budget: { mem: 100, steps: 200 } },
+		]);
+		const blockchainProvider = {
+			fetchProtocolParameters: jest.fn(async () => ({ coinsPerUtxoSize: 4310 })),
+			evaluateTx,
+		};
+
+		const result = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
+			'SubmitResult',
+			blockchainProvider as never,
+			'preprod',
+			{ version: 'V3', code: 'script-cbor' },
+			'addr_test1_wallet',
+			smartContractUtxo as never,
+			collateralUtxo as never,
+			[collateralUtxo, smallUtxo, largeUtxo] as never,
+			{ alternative: 1, fields: [] },
+			100,
+			200,
+		);
+
+		expect(result).toBe('unsigned-tx-2');
+		expect(evaluateTx).toHaveBeenCalledWith('unsigned-tx-1');
+		expect(builders).toHaveLength(2);
+		for (const builder of builders) {
+			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
+			expect(builder.txIn).toHaveBeenCalledTimes(1);
+			expect(builder.txIn).toHaveBeenCalledWith(
+				'contract',
+				0,
+				smartContractUtxo.output.amount,
+				'addr_test1_contract',
+				0,
+			);
+		}
+	});
+});

--- a/src/utils/generator/transaction-generator/index.ts
+++ b/src/utils/generator/transaction-generator/index.ts
@@ -16,7 +16,6 @@ import { logger } from '@masumi/payment-core/logger';
 import { calculateMinUtxo, getLovelaceFromAmounts, getNativeTokenCount, calculateTopUpAmount } from '@/utils/min-utxo';
 import { CONSTANTS } from '@masumi/payment-core/config';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
-import { isSameUtxo } from '@/utils/utxo';
 
 function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	switch (network) {
@@ -27,10 +26,6 @@ function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 		default:
 			throw new Error(`Unsupported network: ${network}`);
 	}
-}
-
-function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
-	return walletUtxos.filter((utxo) => !isSameUtxo(utxo, collateralUtxo));
 }
 
 export async function generateMasumiSmartContractInteractionTransactionAutomaticFees(
@@ -235,10 +230,11 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		.txOut(smartContractAddress, outputAmount)
 		.txOutInlineDatumValue(newInlineDatum);
 
-	// Give Mesh every spendable candidate so it can select additional inputs
-	// after accounting for fees, outputs, and minimum change. Keep collateral
-	// dedicated: a collateral input may not also be a regular spending input.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	// Keep every wallet UTxO available to Mesh's final balancing pass. Declaring
+	// one UTxO as collateral does not require removing it from regular input
+	// selection, and doing so can hide the only input large enough to fund the
+	// outputs, fees, and minimum change.
+	txBuilder.selectUtxosFrom(walletUtxos);
 
 	// Optional self-send splitter for V2 single-item callers. See docstring
 	// on the public AutomaticFees entry point. Emitted BEFORE
@@ -495,7 +491,7 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(walletUtxos);
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/src/utils/generator/transaction-generator/index.ts
+++ b/src/utils/generator/transaction-generator/index.ts
@@ -16,6 +16,7 @@ import { logger } from '@masumi/payment-core/logger';
 import { calculateMinUtxo, getLovelaceFromAmounts, getNativeTokenCount, calculateTopUpAmount } from '@/utils/min-utxo';
 import { CONSTANTS } from '@masumi/payment-core/config';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
+import { isSameUtxo } from '@/utils/utxo';
 
 function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	switch (network) {
@@ -26,6 +27,10 @@ function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 		default:
 			throw new Error(`Unsupported network: ${network}`);
 	}
+}
+
+function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
+	return walletUtxos.filter((utxo) => !isSameUtxo(utxo, collateralUtxo));
 }
 
 export async function generateMasumiSmartContractInteractionTransactionAutomaticFees(
@@ -230,9 +235,10 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		.txOut(smartContractAddress, outputAmount)
 		.txOutInlineDatumValue(newInlineDatum);
 
-	for (const utxo of walletUtxos) {
-		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
-	}
+	// Give Mesh every spendable candidate so it can select additional inputs
+	// after accounting for fees, outputs, and minimum change. Keep collateral
+	// dedicated: a collateral input may not also be a regular spending input.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	// Optional self-send splitter for V2 single-item callers. See docstring
 	// on the public AutomaticFees entry point. Emitted BEFORE
@@ -467,10 +473,6 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		);
 	}
 
-	for (const utxo of walletUtxos) {
-		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
-	}
-
 	if (fee) {
 		const outputReference = mOutputReference(fee.txHash, fee.outputIndex);
 		txBuilder.txOut(fee.feeAddress, fee.feeAssets).txOutInlineDatumValue(outputReference);
@@ -492,6 +494,8 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 	if (walletSplitterLovelace != null) {
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
+
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/src/utils/utxo/index.spec.ts
+++ b/src/utils/utxo/index.spec.ts
@@ -141,20 +141,32 @@ describe('selectCollateralUtxo', () => {
 		expect(selectCollateralUtxo([small, collateral, large]).input.txHash).toBe('collateral');
 	});
 
-	it('does not select a native-token UTxO as collateral', () => {
-		const tokenBearing = makeUtxo({
-			txHash: 'token-bearing',
+	it('prefers pure ADA over a smaller mixed-asset collateral candidate', () => {
+		const mixed = makeUtxo({
+			txHash: 'mixed',
+			amount: [lovelace(6_000_000), token(1)],
+		});
+		const pure = makeUtxo({ txHash: 'pure', amount: [lovelace(8_000_000)] });
+
+		expect(selectCollateralUtxo([mixed, pure]).input.txHash).toBe('pure');
+	});
+
+	it('falls back to mixed-asset collateral when no pure-ADA candidate qualifies', () => {
+		const largeMixed = makeUtxo({
+			txHash: 'large-mixed',
+			amount: [lovelace(12_000_000), token(1)],
+		});
+		const smallMixed = makeUtxo({
+			txHash: 'small-mixed',
 			amount: [lovelace(6_000_000), token(1)],
 		});
 
-		expect(() => selectCollateralUtxo([tokenBearing])).toThrow('Pure-ADA collateral UTxO not found');
+		expect(selectCollateralUtxo([largeMixed, smallMixed]).input.txHash).toBe('small-mixed');
 	});
 
-	it('requires at least five ADA of pure collateral', () => {
+	it('requires at least five ADA of collateral', () => {
 		const dust = makeUtxo({ txHash: 'dust', amount: [lovelace(4_999_999)] });
 
-		expect(() => selectCollateralUtxo([dust])).toThrow(
-			'Pure-ADA collateral UTxO not found with at least 5000000 lovelace',
-		);
+		expect(() => selectCollateralUtxo([dust])).toThrow('Collateral UTxO not found with at least 5000000 lovelace');
 	});
 });

--- a/src/utils/utxo/index.spec.ts
+++ b/src/utils/utxo/index.spec.ts
@@ -1,5 +1,5 @@
 import type { UTxO } from '@meshsdk/core';
-import { sortAndLimitUtxos, sortUtxosByLovelaceDesc } from './index';
+import { selectCollateralUtxo, sortAndLimitUtxos, sortUtxosByLovelaceDesc } from './index';
 
 type AssetSpec = { unit: string; quantity: string };
 
@@ -129,5 +129,32 @@ describe('sortUtxosByLovelaceDesc', () => {
 		];
 		const result = sortUtxosByLovelaceDesc(utxos);
 		expect(parseInt(result[0].output.amount.find((a) => a.unit === 'lovelace')?.quantity ?? '0')).toBe(5_000_000);
+	});
+});
+
+describe('selectCollateralUtxo', () => {
+	it('keeps the reported large ADA UTxO spendable by selecting the smaller qualifying collateral', () => {
+		const small = makeUtxo({ txHash: 'small', amount: [lovelace(3_336_392)] });
+		const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_281_874)] });
+		const large = makeUtxo({ txHash: 'large', amount: [lovelace(485_435_616)] });
+
+		expect(selectCollateralUtxo([small, collateral, large]).input.txHash).toBe('collateral');
+	});
+
+	it('does not select a native-token UTxO as collateral', () => {
+		const tokenBearing = makeUtxo({
+			txHash: 'token-bearing',
+			amount: [lovelace(6_000_000), token(1)],
+		});
+
+		expect(() => selectCollateralUtxo([tokenBearing])).toThrow('Pure-ADA collateral UTxO not found');
+	});
+
+	it('requires at least five ADA of pure collateral', () => {
+		const dust = makeUtxo({ txHash: 'dust', amount: [lovelace(4_999_999)] });
+
+		expect(() => selectCollateralUtxo([dust])).toThrow(
+			'Pure-ADA collateral UTxO not found with at least 5000000 lovelace',
+		);
 	});
 });

--- a/src/utils/utxo/index.ts
+++ b/src/utils/utxo/index.ts
@@ -16,12 +16,8 @@ export function getLovelaceFromUtxo(utxo: UTxO): bigint {
 	return BigInt(utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '')?.quantity ?? '0');
 }
 
-export function isSameUtxo(left: UTxO, right: UTxO): boolean {
-	return left.input.txHash === right.input.txHash && left.input.outputIndex === right.input.outputIndex;
-}
-
 /**
- * Selects a dedicated collateral input.
+ * Selects a collateral input.
  *
  * Prefer the smallest qualifying pure-ADA UTxO so native tokens do not need
  * a collateral-return output. If none exists, fall back to the smallest

--- a/src/utils/utxo/index.ts
+++ b/src/utils/utxo/index.ts
@@ -21,29 +21,34 @@ export function isSameUtxo(left: UTxO, right: UTxO): boolean {
 }
 
 /**
- * Selects a dedicated collateral input without consuming native tokens.
+ * Selects a dedicated collateral input.
  *
- * Prefer the smallest qualifying pure-ADA UTxO so larger UTxOs remain
- * available to Mesh for transaction fees, outputs, and change.
+ * Prefer the smallest qualifying pure-ADA UTxO so native tokens do not need
+ * a collateral-return output. If none exists, fall back to the smallest
+ * qualifying mixed-asset UTxO: Babbage/CIP-40 permits token-bearing
+ * collateral, and Mesh emits the required collateral-return output.
  */
 export function selectCollateralUtxo(utxos: UTxO[], minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE): UTxO {
-	const collateralUtxo = utxos
-		.filter(
-			(utxo) =>
-				utxo.output.amount.length > 0 &&
-				utxo.output.amount.every((asset) => asset.unit === 'lovelace' || asset.unit === '') &&
-				getLovelaceFromUtxo(utxo) >= minimumLovelace,
-		)
+	const qualifyingUtxos = utxos
+		.filter((utxo) => utxo.output.amount.length > 0 && getLovelaceFromUtxo(utxo) >= minimumLovelace)
+		.map((utxo) => ({
+			utxo,
+			isPureAda: utxo.output.amount.every((asset) => asset.unit === 'lovelace' || asset.unit === ''),
+			lovelace: getLovelaceFromUtxo(utxo),
+		}))
 		.sort((left, right) => {
-			const leftLovelace = getLovelaceFromUtxo(left);
-			const rightLovelace = getLovelaceFromUtxo(right);
-			if (leftLovelace < rightLovelace) return -1;
-			if (leftLovelace > rightLovelace) return 1;
+			if (left.isPureAda !== right.isPureAda) {
+				return left.isPureAda ? -1 : 1;
+			}
+			if (left.lovelace < right.lovelace) return -1;
+			if (left.lovelace > right.lovelace) return 1;
 			return 0;
-		})[0];
+		});
+
+	const collateralUtxo = qualifyingUtxos[0]?.utxo;
 
 	if (collateralUtxo == null) {
-		throw new Error(`Pure-ADA collateral UTxO not found with at least ${minimumLovelace.toString()} lovelace`);
+		throw new Error(`Collateral UTxO not found with at least ${minimumLovelace.toString()} lovelace`);
 	}
 
 	return collateralUtxo;

--- a/src/utils/utxo/index.ts
+++ b/src/utils/utxo/index.ts
@@ -1,5 +1,7 @@
 import { UTxO } from '@meshsdk/core';
 
+const DEFAULT_MIN_COLLATERAL_LOVELACE = 5_000_000n;
+
 /**
  * Reads the lovelace quantity off a UTxO as `bigint`.
  *
@@ -10,8 +12,41 @@ import { UTxO } from '@meshsdk/core';
  * truncation. Project rule (CLAUDE.md): use BigInt for all monetary
  * amounts; never use Number for lovelace values.
  */
-function getLovelaceFromUtxo(utxo: UTxO): bigint {
+export function getLovelaceFromUtxo(utxo: UTxO): bigint {
 	return BigInt(utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '')?.quantity ?? '0');
+}
+
+export function isSameUtxo(left: UTxO, right: UTxO): boolean {
+	return left.input.txHash === right.input.txHash && left.input.outputIndex === right.input.outputIndex;
+}
+
+/**
+ * Selects a dedicated collateral input without consuming native tokens.
+ *
+ * Prefer the smallest qualifying pure-ADA UTxO so larger UTxOs remain
+ * available to Mesh for transaction fees, outputs, and change.
+ */
+export function selectCollateralUtxo(utxos: UTxO[], minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE): UTxO {
+	const collateralUtxo = utxos
+		.filter(
+			(utxo) =>
+				utxo.output.amount.length > 0 &&
+				utxo.output.amount.every((asset) => asset.unit === 'lovelace' || asset.unit === '') &&
+				getLovelaceFromUtxo(utxo) >= minimumLovelace,
+		)
+		.sort((left, right) => {
+			const leftLovelace = getLovelaceFromUtxo(left);
+			const rightLovelace = getLovelaceFromUtxo(right);
+			if (leftLovelace < rightLovelace) return -1;
+			if (leftLovelace > rightLovelace) return 1;
+			return 0;
+		})[0];
+
+	if (collateralUtxo == null) {
+		throw new Error(`Pure-ADA collateral UTxO not found with at least ${minimumLovelace.toString()} lovelace`);
+	}
+
+	return collateralUtxo;
 }
 
 /**


### PR DESCRIPTION
Give Mesh the full spendable candidate set while keeping collateral dedicated. Queue error webhooks atomically with failure transitions.
