### PR TITLE
fix(recovery): retry failed actions safely

### DIFF
--- a/frontend/openapi-docs.json
+++ b/frontend/openapi-docs.json
@@ -11437,6 +11437,10 @@
                                             }
                                         ],
                                         "description": "The time of the last update, to ensure you clear the correct error state"
+                                    },
+                                    "retryPreviousAction": {
+                                        "type": "boolean",
+                                        "description": "When true, retry the failed action. When false or omitted, only clear the error state."
                                     }
                                 },
                                 "required": [
@@ -12094,6 +12098,10 @@
                                             }
                                         ],
                                         "description": "The time of the last update, to ensure you clear the correct error state"
+                                    },
+                                    "retryPreviousAction": {
+                                        "type": "boolean",
+                                        "description": "When true, retry the failed action. When false or omitted, only clear the error state."
                                     }
                                 },
                                 "required": [

--- a/frontend/src/components/transactions/TransactionDetailsDialog.tsx
+++ b/frontend/src/components/transactions/TransactionDetailsDialog.tsx
@@ -80,6 +80,7 @@ export default function TransactionDetailsDialog({
   const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
   const [confirmAction, setConfirmAction] = React.useState<'refund' | 'cancel' | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
+  const [errorRecoveryMode, setErrorRecoveryMode] = React.useState<'clear' | 'retry' | null>(null);
   const [selectedWalletForDetails, setSelectedWalletForDetails] =
     useState<WalletWithBalance | null>(null);
 
@@ -185,9 +186,10 @@ export default function TransactionDetailsDialog({
   const resolvedAgentName = registryAgentForLink?.name ?? agentNameFromChain ?? null;
   const agentNameLoading =
     registryAgentLinkLoading || (chainAgentNameLookupEnabled && chainAgentNameLoading);
-  const clearTransactionError = async () => {
+  const recoverTransactionError = async (retryPreviousAction: boolean) => {
     try {
       setIsLoading(true);
+      setErrorRecoveryMode(retryPreviousAction ? 'retry' : 'clear');
 
       if (!transaction) {
         toast.error('Transaction not found');
@@ -206,13 +208,21 @@ export default function TransactionDetailsDialog({
             blockchainIdentifier: transaction.blockchainIdentifier,
             updatedAt: new Date(transaction.updatedAt),
             network: transactionNetwork,
+            retryPreviousAction,
           },
         });
         if (response.error) {
-          handleError(response.error, 'Failed to clear error state');
+          handleError(
+            response.error,
+            retryPreviousAction ? 'Failed to retry previous action' : 'Failed to clear error state',
+          );
           return false;
         }
-        toast.success('Error state cleared successfully');
+        toast.success(
+          retryPreviousAction
+            ? 'Previous action queued for retry'
+            : 'Error state cleared successfully',
+        );
         onRefresh();
         onClose();
         return true;
@@ -224,13 +234,21 @@ export default function TransactionDetailsDialog({
             blockchainIdentifier: transaction.blockchainIdentifier,
             updatedAt: new Date(transaction.updatedAt),
             network: transactionNetwork,
+            retryPreviousAction,
           },
         });
         if (response.error) {
-          handleError(response.error, 'Failed to clear error state');
+          handleError(
+            response.error,
+            retryPreviousAction ? 'Failed to retry previous action' : 'Failed to clear error state',
+          );
           return false;
         }
-        toast.success('Error state cleared successfully');
+        toast.success(
+          retryPreviousAction
+            ? 'Previous action queued for retry'
+            : 'Error state cleared successfully',
+        );
         onRefresh();
         onClose();
         return true;
@@ -242,6 +260,7 @@ export default function TransactionDetailsDialog({
       return false;
     } finally {
       setIsLoading(false);
+      setErrorRecoveryMode(null);
     }
   };
 
@@ -616,19 +635,29 @@ export default function TransactionDetailsDialog({
                         {transaction.NextAction.errorNote}
                       </p>
                     )}
-                    <div className="flex gap-2 mt-4">
+                    <p className="text-xs text-muted-foreground">
+                      Retry queues the failed blockchain action again with its original data. Clear
+                      only removes the error and waits for the next external action.
+                    </p>
+                    <div className="flex flex-wrap gap-2 mt-4">
+                      <Button
+                        size="sm"
+                        disabled={isLoading}
+                        onClick={() => recoverTransactionError(true)}
+                      >
+                        {errorRecoveryMode === 'retry'
+                          ? 'Queueing retry...'
+                          : 'Retry Failed Action'}
+                      </Button>
                       <Button
                         variant="secondary"
                         size="sm"
                         disabled={isLoading}
-                        onClick={async () => {
-                          if (await clearTransactionError()) {
-                            onClose();
-                            onRefresh();
-                          }
-                        }}
+                        onClick={() => recoverTransactionError(false)}
                       >
-                        {isLoading ? 'Clearing error state...' : 'Clear Error State'}
+                        {errorRecoveryMode === 'clear'
+                          ? 'Clearing error state...'
+                          : 'Clear Error State'}
                       </Button>
                     </div>
                   </div>

--- a/frontend/src/lib/api/generated/types.gen.ts
+++ b/frontend/src/lib/api/generated/types.gen.ts
@@ -5650,6 +5650,10 @@ export type PostPaymentErrorStateRecoveryData = {
          * The time of the last update, to ensure you clear the correct error state
          */
         updatedAt: Date | Date;
+        /**
+         * When true, retry the failed action. When false or omitted, only clear the error state.
+         */
+        retryPreviousAction?: boolean;
     };
     path?: never;
     query?: never;
@@ -5983,6 +5987,10 @@ export type PostPurchaseErrorStateRecoveryData = {
          * The time of the last update, to ensure you clear the correct error state
          */
         updatedAt: Date | Date;
+        /**
+         * When true, retry the failed action. When false or omitted, only clear the error state.
+         */
+        retryPreviousAction?: boolean;
     };
     path?: never;
     query?: never;

--- a/frontend/src/lib/hooks/useBulkClearTransactionErrors.ts
+++ b/frontend/src/lib/hooks/useBulkClearTransactionErrors.ts
@@ -25,11 +25,11 @@ const toRecoveryNetwork = (network: string | null | undefined): 'Preprod' | 'Mai
  */
 export function useBulkClearTransactionErrors() {
   const { apiClient, network: contextNetwork } = useAppContext();
-  const [isClearing, setIsClearing] = useState(false);
+  const [isRecovering, setIsRecovering] = useState(false);
 
-  const clearErrors = useCallback(
-    async (transactions: Transaction[]): Promise<BulkClearResult> => {
-      setIsClearing(true);
+  const recoverErrors = useCallback(
+    async (transactions: Transaction[], retryPreviousAction: boolean): Promise<BulkClearResult> => {
+      setIsRecovering(true);
       const failedIds: string[] = [];
       let succeeded = 0;
 
@@ -53,6 +53,7 @@ export function useBulkClearTransactionErrors() {
               blockchainIdentifier: transaction.blockchainIdentifier,
               updatedAt: new Date(transaction.updatedAt),
               network: recoveryNetwork,
+              retryPreviousAction,
             };
             const response =
               transaction.type === 'purchase'
@@ -69,7 +70,7 @@ export function useBulkClearTransactionErrors() {
           }
         }
       } finally {
-        setIsClearing(false);
+        setIsRecovering(false);
       }
 
       return { succeeded, failed: failedIds.length, failedIds };
@@ -77,5 +78,5 @@ export function useBulkClearTransactionErrors() {
     [apiClient, contextNetwork],
   );
 
-  return { clearErrors, isClearing };
+  return { recoverErrors, isRecovering };
 }

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -95,7 +95,8 @@ export default function Transactions() {
   // Multi-row selection is only offered on the Needs Action tab, where every row
   // is in an error state that can be bulk-cleared. Keyed by transaction id.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const { clearErrors, isClearing } = useBulkClearTransactionErrors();
+  const { recoverErrors, isRecovering } = useBulkClearTransactionErrors();
+  const [bulkRecoveryMode, setBulkRecoveryMode] = useState<'clear' | 'retry' | null>(null);
   const isLoadingMore = isFetchingNextPage;
   const isInitialLoading = isLoading && !transactions.length;
 
@@ -233,24 +234,38 @@ export default function Transactions() {
     });
   }, []);
 
-  const handleBulkClearErrors = useCallback(async () => {
-    const selected = visibleTransactions.filter((tx) => tx.id && selectedIds.has(tx.id));
-    if (selected.length === 0) return;
+  const handleBulkRecoverErrors = useCallback(
+    async (retryPreviousAction: boolean) => {
+      const selected = visibleTransactions.filter((tx) => tx.id && selectedIds.has(tx.id));
+      if (selected.length === 0) return;
 
-    const { succeeded, failed, failedIds } = await clearErrors(selected);
-    if (succeeded > 0) {
-      toast.success(
-        `Cleared error state for ${succeeded} transaction${succeeded === 1 ? '' : 's'}`,
-      );
-    }
-    if (failed > 0) {
-      toast.error(`Failed to clear ${failed} transaction${failed === 1 ? '' : 's'}`);
-    }
+      setBulkRecoveryMode(retryPreviousAction ? 'retry' : 'clear');
+      try {
+        const { succeeded, failed, failedIds } = await recoverErrors(selected, retryPreviousAction);
+        if (succeeded > 0) {
+          toast.success(
+            retryPreviousAction
+              ? `Queued ${succeeded} failed action${succeeded === 1 ? '' : 's'} for retry`
+              : `Cleared error state for ${succeeded} transaction${succeeded === 1 ? '' : 's'}`,
+          );
+        }
+        if (failed > 0) {
+          toast.error(
+            retryPreviousAction
+              ? `Failed to retry ${failed} transaction${failed === 1 ? '' : 's'}`
+              : `Failed to clear ${failed} transaction${failed === 1 ? '' : 's'}`,
+          );
+        }
 
-    // Keep only the failed rows selected so the user can retry them.
-    setSelectedIds(new Set(failedIds));
-    refreshTransactions();
-  }, [visibleTransactions, selectedIds, clearErrors, refreshTransactions]);
+        // Keep only the failed rows selected so the user can retry them.
+        setSelectedIds(new Set(failedIds));
+        refreshTransactions();
+      } finally {
+        setBulkRecoveryMode(null);
+      }
+    },
+    [visibleTransactions, selectedIds, recoverErrors, refreshTransactions],
+  );
 
   // When context changes, clear "new transactions" badge via the hook (single source of truth for localStorage)
   const markAllAsReadRef = useRef(markAllAsRead);
@@ -462,19 +477,28 @@ export default function Transactions() {
                   variant="ghost"
                   size="sm"
                   onClick={() => setSelectedIds(new Set())}
-                  disabled={isClearing}
+                  disabled={isRecovering}
                 >
                   Cancel
                 </Button>
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={handleBulkClearErrors}
-                  disabled={isClearing}
+                  onClick={() => handleBulkRecoverErrors(false)}
+                  disabled={isRecovering}
                 >
-                  {isClearing
+                  {bulkRecoveryMode === 'clear'
                     ? 'Clearing error states...'
                     : `Clear error state (${selectedIds.size})`}
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => handleBulkRecoverErrors(true)}
+                  disabled={isRecovering}
+                >
+                  {bulkRecoveryMode === 'retry'
+                    ? 'Queueing retries...'
+                    : `Retry failed action (${selectedIds.size})`}
                 </Button>
               </div>
             </div>

--- a/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
@@ -46,8 +46,8 @@ export async function authorizeRefundV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('authorize_refund_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v1/src/services/payments/collection/service.ts
@@ -296,8 +296,8 @@ export async function collectOutstandingPaymentsV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('payment_collection_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v1/src/services/payments/submit-result/service.ts
@@ -247,7 +247,9 @@ async function processSinglePaymentRequest(
 		where: { id: request.id },
 		data: {
 			...connectPreviousAction(request.nextActionId),
-			...createNextPaymentAction(PaymentAction.SubmitResultInitiated),
+			...createNextPaymentAction(PaymentAction.SubmitResultInitiated, {
+				resultHash: request.NextAction.resultHash,
+			}),
 			...createPendingTransaction(request.SmartContractWallet!.id),
 			TransactionHistory: {
 				connect: {
@@ -299,8 +301,8 @@ export async function submitResultV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('submit_result_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v1/src/services/payments/submit-result/service.ts
@@ -10,6 +10,7 @@ import { lockAndQueryPayments } from '@/utils/db/lock-and-query-payments';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { selectCollateralUtxo } from '@/utils/utxo';
 import { writePaymentErrorTransition } from '@/services/shared/error-transition';
+import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { delayErrorResolver } from 'advanced-retry';
 import { advancedRetryAll } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
@@ -21,7 +22,7 @@ import {
 	createPendingTransaction,
 	createTxWindow,
 	loadHotWalletSession,
-	updateCurrentTransactionHash,
+	runSubmitResultSubmissionLifecycle,
 } from '@/services/shared';
 import { createDatumFromDecodedContractV1, getPaymentScriptFromPaymentSourceV1 } from '@masumi/payment-source-v1';
 
@@ -243,58 +244,93 @@ async function processSinglePaymentRequest(
 
 	const signedTx = await wallet.signTx(unsignedTx);
 
-	await prisma.paymentRequest.update({
-		where: { id: request.id },
-		data: {
-			...connectPreviousAction(request.nextActionId),
-			...createNextPaymentAction(PaymentAction.SubmitResultInitiated, {
-				resultHash: request.NextAction.resultHash,
-			}),
-			...createPendingTransaction(request.SmartContractWallet!.id),
-			TransactionHistory: {
-				connect: {
-					id: request.CurrentTransaction!.id,
-				},
-			},
+	// Submit before replacing CurrentTransaction. If submission is rejected,
+	// the confirmed funding transaction must remain current so the next attempt
+	// can locate the contract UTxO. The previous ordering installed a txHash-less
+	// Pending row before submit and did not restore the confirmed transaction in
+	// the catch path, making every retry start from invalid local state.
+	const submissionOutcome = await runSubmitResultSubmissionLifecycle({
+		submit: () => wallet.submitTx(signedTx),
+		requeueRejected: async (error) => {
+			logger.error('V1 submit-result transaction rejected', {
+				requestId: request.id,
+				error: interpretBlockchainError(error),
+			});
+			await retryOnSerializationConflict(
+				() =>
+					prisma.paymentRequest.update({
+						where: { id: request.id },
+						data: {
+							...connectPreviousAction(request.nextActionId),
+							...createNextPaymentAction(PaymentAction.SubmitResultRequested, {
+								errorType: null,
+								errorNote: null,
+								resultHash: request.NextAction.resultHash,
+							}),
+							SmartContractWallet: {
+								update: {
+									lockedAt: null,
+								},
+							},
+						},
+					}),
+				{ label: 'v1-submit-result-requeue-after-rejection' },
+			);
+		},
+		evaluateProjectedBalance: () => walletSession.evaluateProjectedBalance(unsignedTx, utxos),
+		recordSubmitted: async (newTxHash) => {
+			await retryOnSerializationConflict(
+				() =>
+					prisma.paymentRequest.update({
+						where: { id: request.id },
+						data: {
+							...connectPreviousAction(request.nextActionId),
+							...createNextPaymentAction(PaymentAction.SubmitResultInitiated, {
+								resultHash: request.NextAction.resultHash,
+							}),
+							...createPendingTransaction(request.SmartContractWallet!.id, newTxHash),
+							TransactionHistory: {
+								connect: {
+									id: request.CurrentTransaction!.id,
+								},
+							},
+						},
+					}),
+				{ label: 'v1-submit-result-post-submit' },
+			);
+		},
+		onBalanceCheckFailure: (error, newTxHash) => {
+			logger.warn('V1 submit-result projected-balance check failed post-submit (non-fatal)', {
+				requestId: request.id,
+				txHash: newTxHash,
+				error: interpretBlockchainError(error),
+			});
+		},
+		onRecordFailure: (error, newTxHash) => {
+			logger.error('V1 submit-result was accepted but its database transition could not be recorded', {
+				requestId: request.id,
+				txHash: newTxHash,
+				error: interpretBlockchainError(error),
+			});
 		},
 	});
-	try {
-		const newTxHash = await wallet.submitTx(signedTx);
-		await walletSession.evaluateProjectedBalance(unsignedTx, utxos);
-		await prisma.paymentRequest.update({
-			where: { id: request.id },
-			data: updateCurrentTransactionHash(newTxHash),
-		});
+	if (submissionOutcome.status === 'rejected') {
+		return false;
+	}
+	const newTxHash = submissionOutcome.txHash;
+	if (!submissionOutcome.isRecorded) {
+		return true;
+	}
 
-		logger.debug(`Created submit result transaction:
-                  Tx ID: ${txHash}
+	logger.debug(`Created submit result transaction:
+                  Tx ID: ${newTxHash}
                   View (after a bit) on https://${
 										network === 'preprod' ? 'preprod.' : ''
-									}cardanoscan.io/transaction/${txHash}
+									}cardanoscan.io/transaction/${newTxHash}
                   Smart Contract Address: ${smartContractAddress}
               `);
 
-		return true;
-	} catch (error) {
-		logger.error(`Error submitting result`, { error: error });
-		await prisma.paymentRequest.update({
-			where: { id: request.id },
-			data: {
-				...connectPreviousAction(request.nextActionId),
-				...createNextPaymentAction(PaymentAction.SubmitResultRequested, {
-					errorType: null,
-					errorNote: null,
-					resultHash: request.NextAction.resultHash,
-				}),
-				SmartContractWallet: {
-					update: {
-						lockedAt: null,
-					},
-				},
-			},
-		});
-		return false;
-	}
+	return true;
 }
 
 export async function submitResultV1() {

--- a/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
@@ -412,8 +412,8 @@ export async function batchLatestPaymentEntriesV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('batch_payments_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
@@ -86,8 +86,8 @@ export async function cancelRefundsV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('cancel_refund_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
@@ -214,8 +214,8 @@ export async function collectRefundV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('collect_refund_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
@@ -205,8 +205,8 @@ export async function requestRefundsV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('request_refund_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/registry-inbox/deregister/service.ts
+++ b/packages/payment-source-v1/src/services/registry-inbox/deregister/service.ts
@@ -64,8 +64,8 @@ export async function deRegisterInboxAgentV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking inbox deregistrations', { error: e });
+	} catch {
+		logger.info('registry_inbox_deregister_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/registry-inbox/register/service.ts
+++ b/packages/payment-source-v1/src/services/registry-inbox/register/service.ts
@@ -49,8 +49,8 @@ export async function registerInboxAgentV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking inbox registrations', { error: e });
+	} catch {
+		logger.info('registry_inbox_register_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v1/src/services/registry/deregister/service.ts
@@ -62,8 +62,8 @@ export async function deRegisterAgentV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('registry_deregister_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v1/src/services/registry/register/service.ts
+++ b/packages/payment-source-v1/src/services/registry/register/service.ts
@@ -193,8 +193,8 @@ export async function registerAgentV1() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('registry_register_v1 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v2/src/services/payments/authorize-refund/service.ts
@@ -965,8 +965,8 @@ export async function authorizeRefundV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('authorize_refund_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v2/src/services/payments/collection/service.ts
@@ -1040,8 +1040,8 @@ export async function collectOutstandingPaymentsV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('payment_collection_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v2/src/services/payments/submit-result/service.ts
@@ -477,7 +477,9 @@ async function processSinglePaymentRequest(
 				where: { id: request.id },
 				data: {
 					...connectPreviousAction(request.nextActionId),
-					...createNextPaymentAction(PaymentAction.SubmitResultInitiated),
+					...createNextPaymentAction(PaymentAction.SubmitResultInitiated, {
+						resultHash: request.NextAction.resultHash,
+					}),
 					...createPendingTransaction(request.SmartContractWallet!.id, newTxHash),
 					TransactionHistory: {
 						connect: {
@@ -863,7 +865,10 @@ async function processWalletBatch(
 							// isn't directly returned; we need it to safely clean up orphans on
 							// rollback (see #6 audit-trail leak design).
 							const initiated = await tx.paymentActionData.create({
-								data: { requestedAction: PaymentAction.SubmitResultInitiated },
+								data: {
+									requestedAction: PaymentAction.SubmitResultInitiated,
+									resultHash: v.request.NextAction.resultHash,
+								},
 							});
 							await tx.paymentRequest.update({
 								where: { id: v.request.id },
@@ -1165,8 +1170,8 @@ export async function submitResultV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('submit_result_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/authorize-withdrawal/service.ts
@@ -981,8 +981,8 @@ export async function authorizeWithdrawalsV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('authorize_withdrawal_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
@@ -646,8 +646,8 @@ export async function batchLatestPaymentEntriesV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('batch_payments_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
@@ -948,8 +948,8 @@ export async function collectRefundV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('collect_refund_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/request-refund/service.ts
@@ -1007,8 +1007,8 @@ export async function requestRefundsV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('request_refund_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry-inbox/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry-inbox/deregister/service.ts
@@ -253,8 +253,8 @@ export async function deRegisterInboxAgentV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking V2 inbox deregistrations', { error: e });
+	} catch {
+		logger.info('registry_inbox_deregister_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry-inbox/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry-inbox/register/service.ts
@@ -288,8 +288,8 @@ export async function registerInboxAgentV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking V2 inbox registrations', { error: e });
+	} catch {
+		logger.info('registry_inbox_register_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -317,8 +317,8 @@ export async function deRegisterAgentV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('registry_deregister_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry/register/service.ts
@@ -407,8 +407,8 @@ export async function registerAgentV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('registry_register_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -545,8 +545,8 @@ export async function updateAgentV2() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('registry_update_v2 is already running, skipping cycle');
 		return;
 	}
 

--- a/src/routes/api/payments/error-state-recovery/index.ts
+++ b/src/routes/api/payments/error-state-recovery/index.ts
@@ -1,4 +1,4 @@
-import { Network, PaymentAction, TransactionStatus, OnChainState } from '@/generated/prisma/client';
+import { Network, PaymentAction, Prisma, TransactionStatus, OnChainState } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import createHttpError from 'http-errors';
 import { payAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
@@ -12,11 +12,16 @@ import { transformPaymentGetTimestamps, transformPaymentGetAmounts } from '@/uti
 import { assertWalletInScope } from '@/utils/shared/wallet-scope';
 import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { z } from '@masumi/payment-core/zod';
+import { getPaymentRetryAction, getPaymentRetryResultHash } from '@/utils/shared/error-recovery';
 
 export const paymentErrorStateRecoverySchemaInput = z.object({
 	blockchainIdentifier: z.string().min(1).max(8000).describe('The blockchain identifier of the payment request'),
 	network: z.nativeEnum(Network).describe('The network the transaction was made on'),
 	updatedAt: ez.dateIn().describe('The time of the last update, to ensure you clear the correct error state'),
+	retryPreviousAction: z
+		.boolean()
+		.optional()
+		.describe('When true, retry the failed action. When false or omitted, only clear the error state.'),
 });
 
 export const paymentErrorStateRecoverySchemaOutput = paymentResponseSchema.omit({
@@ -51,6 +56,14 @@ export const paymentErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bui
 			include: {
 				NextAction: true,
 				CurrentTransaction: true,
+				ActionHistory: {
+					orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+					take: 2,
+					select: {
+						requestedAction: true,
+						resultHash: true,
+					},
+				},
 				TransactionHistory: {
 					orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
 				},
@@ -82,6 +95,29 @@ export const paymentErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bui
 
 		if (!paymentRequest.NextAction.errorType) {
 			throw createHttpError(400, 'Payment request is not in an error state. No error to clear.');
+		}
+
+		const previousAction = paymentRequest.ActionHistory[0];
+		const actionBeforePrevious = paymentRequest.ActionHistory[1];
+		const retryAction = previousAction ? getPaymentRetryAction(previousAction.requestedAction) : null;
+		if (input.retryPreviousAction && retryAction == null) {
+			throw createHttpError(400, 'The immediately preceding payment action is not retryable.');
+		}
+
+		const retryResultHash = getPaymentRetryResultHash(
+			paymentRequest.NextAction.resultHash,
+			previousAction,
+			actionBeforePrevious,
+		);
+		if (input.retryPreviousAction && retryAction === PaymentAction.SubmitResultRequested && retryResultHash == null) {
+			throw createHttpError(400, 'The failed submit-result action has no result hash to retry.');
+		}
+
+		const isCompletedState = (
+			[OnChainState.Withdrawn, OnChainState.RefundWithdrawn, OnChainState.DisputedWithdrawn] as OnChainState[]
+		).includes(paymentRequest.onChainState);
+		if (input.retryPreviousAction && isCompletedState) {
+			throw createHttpError(400, 'The payment is already completed and its previous action cannot be retried.');
 		}
 
 		// Find the most recent successful transaction (confirmed or pending)
@@ -119,105 +155,122 @@ export const paymentErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bui
 			lastSuccessfulTransactionStatus: lastSuccessfulTransaction?.status || null,
 			transactionsToFailCount: transactionsToFail.length,
 			transactionsToFailIds: transactionsToFail.map((tx) => tx.id),
+			retryPreviousAction: input.retryPreviousAction === true,
+			retryAction,
 		});
 
 		// Serializable + retry: this handler races concurrent tx-sync handlers
 		// that may advance the same PaymentRequest. Without Serializable
 		// isolation, a concurrent state-machine update can win between this
 		// route's pre-read (line 41-57) and the in-transaction updates here.
-		const result = await retryOnSerializationConflict(
-			() =>
-				prisma.$transaction(
-					async (tx) => {
-						for (const transaction of transactionsToFail) {
-							await tx.transaction.update({
-								where: { id: transaction.id },
-								data: { status: TransactionStatus.FailedViaManualReset },
+		let result;
+		try {
+			result = await retryOnSerializationConflict(
+				() =>
+					prisma.$transaction(
+						async (tx) => {
+							for (const transaction of transactionsToFail) {
+								await tx.transaction.update({
+									where: { id: transaction.id },
+									data: { status: TransactionStatus.FailedViaManualReset },
+								});
+							}
+
+							await tx.paymentRequest.update({
+								where: { id: paymentRequest.id },
+								data: { currentTransactionId: lastSuccessfulTransaction?.id || null },
 							});
-						}
-
-						await tx.paymentRequest.update({
-							where: { id: paymentRequest.id },
-							data: { currentTransactionId: lastSuccessfulTransaction?.id || null },
-						});
-						const isCompletedState =
-							paymentRequest.onChainState &&
-							(
-								[OnChainState.Withdrawn, OnChainState.RefundWithdrawn, OnChainState.DisputedWithdrawn] as OnChainState[]
-							).includes(paymentRequest.onChainState);
-
-						const updatedPaymentRequest = await tx.paymentRequest.update({
-							where: { id: paymentRequest.id },
-							data: {
-								ActionHistory: {
-									connect: {
-										id: paymentRequest.nextActionId,
+							const updatedPaymentRequest = await tx.paymentRequest.update({
+								where: {
+									id: paymentRequest.id,
+									nextActionId: paymentRequest.nextActionId,
+								},
+								data: {
+									ActionHistory: {
+										connect: {
+											id: paymentRequest.nextActionId,
+										},
+									},
+									NextAction: {
+										create: {
+											requestedAction: input.retryPreviousAction
+												? retryAction!
+												: isCompletedState
+													? PaymentAction.None
+													: PaymentAction.WaitingForExternalAction,
+											submittedTxHash: null,
+											...(input.retryPreviousAction && retryAction === PaymentAction.SubmitResultRequested
+												? { resultHash: retryResultHash }
+												: {}),
+										},
 									},
 								},
-								NextAction: {
-									create: {
-										requestedAction: isCompletedState ? PaymentAction.None : PaymentAction.WaitingForExternalAction,
+								include: {
+									BuyerWallet: { select: { id: true, walletVkey: true } },
+									SmartContractWallet: {
+										where: { deletedAt: null },
+										select: { id: true, walletVkey: true, walletAddress: true },
+									},
+									RequestedFunds: { select: { id: true, amount: true, unit: true } },
+									NextAction: {
+										select: {
+											id: true,
+											requestedAction: true,
+											errorType: true,
+											errorNote: true,
+											resultHash: true,
+										},
+									},
+									PaymentSource: {
+										select: {
+											id: true,
+											network: true,
+											paymentSourceType: true,
+											smartContractAddress: true,
+											policyId: true,
+										},
+									},
+									CurrentTransaction: {
+										select: {
+											id: true,
+											createdAt: true,
+											updatedAt: true,
+											fees: true,
+											blockHeight: true,
+											blockTime: true,
+											txHash: true,
+											status: true,
+											previousOnChainState: true,
+											newOnChainState: true,
+											confirmations: true,
+										},
+									},
+									WithdrawnForSeller: {
+										select: { id: true, amount: true, unit: true },
+									},
+									WithdrawnForBuyer: {
+										select: { id: true, amount: true, unit: true },
 									},
 								},
-							},
-							include: {
-								BuyerWallet: { select: { id: true, walletVkey: true } },
-								SmartContractWallet: {
-									where: { deletedAt: null },
-									select: { id: true, walletVkey: true, walletAddress: true },
-								},
-								RequestedFunds: { select: { id: true, amount: true, unit: true } },
-								NextAction: {
-									select: {
-										id: true,
-										requestedAction: true,
-										errorType: true,
-										errorNote: true,
-										resultHash: true,
-									},
-								},
-								PaymentSource: {
-									select: {
-										id: true,
-										network: true,
-										paymentSourceType: true,
-										smartContractAddress: true,
-										policyId: true,
-									},
-								},
-								CurrentTransaction: {
-									select: {
-										id: true,
-										createdAt: true,
-										updatedAt: true,
-										fees: true,
-										blockHeight: true,
-										blockTime: true,
-										txHash: true,
-										status: true,
-										previousOnChainState: true,
-										newOnChainState: true,
-										confirmations: true,
-									},
-								},
-								WithdrawnForSeller: {
-									select: { id: true, amount: true, unit: true },
-								},
-								WithdrawnForBuyer: {
-									select: { id: true, amount: true, unit: true },
-								},
-							},
-						});
-						return updatedPaymentRequest;
-					},
-					{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
-				),
-			{ label: 'payments-error-state-recovery' },
-		);
+							});
+							return updatedPaymentRequest;
+						},
+						{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+					),
+				{ label: 'payments-error-state-recovery' },
+			);
+		} catch (error) {
+			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+				throw createHttpError(409, 'Payment state changed concurrently; retry against the new state');
+			}
+			throw error;
+		}
 
 		logger.info('Error state recovery completed successfully', {
 			paymentRequestId: paymentRequest.id,
 			failedTransactionsCount: transactionsToFail.length,
+			retryPreviousAction: input.retryPreviousAction === true,
+			retryAction,
 		});
 		const decoded = decodeBlockchainIdentifier(result.blockchainIdentifier);
 

--- a/src/routes/api/purchases/error-state-recovery/index.ts
+++ b/src/routes/api/purchases/error-state-recovery/index.ts
@@ -1,4 +1,4 @@
-import { Network, PurchasingAction, TransactionStatus, OnChainState } from '@/generated/prisma/client';
+import { Network, PurchasingAction, Prisma, TransactionStatus, OnChainState } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import createHttpError from 'http-errors';
 import { payAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
@@ -12,11 +12,16 @@ import { assertWalletInScope } from '@/utils/shared/wallet-scope';
 import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { purchaseResponseSchema } from '..';
 import { z } from '@masumi/payment-core/zod';
+import { getPurchaseRetryAction } from '@/utils/shared/error-recovery';
 
 export const purchaseErrorStateRecoverySchemaInput = z.object({
 	blockchainIdentifier: z.string().min(1).max(8000).describe('The blockchain identifier of the purchase request'),
 	network: z.nativeEnum(Network).describe('The network the transaction was made on'),
 	updatedAt: ez.dateIn().describe('The time of the last update, to ensure you clear the correct error state'),
+	retryPreviousAction: z
+		.boolean()
+		.optional()
+		.describe('When true, retry the failed action. When false or omitted, only clear the error state.'),
 });
 
 export const purchaseErrorStateRecoverySchemaOutput = purchaseResponseSchema.omit({
@@ -51,6 +56,13 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 			include: {
 				NextAction: true,
 				CurrentTransaction: true,
+				ActionHistory: {
+					orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+					take: 1,
+					select: {
+						requestedAction: true,
+					},
+				},
 				TransactionHistory: {
 					orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
 				},
@@ -67,13 +79,6 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 		if (purchaseRequest.requestedById !== ctx.id && !ctx.canAdmin) {
 			throw createHttpError(403, 'You are not authorized to recover this purchase request');
 		}
-		if (!purchaseRequest.onChainState) {
-			throw createHttpError(
-				400,
-				'Purchase request is in its initial on-chain state. Can not be recovered. Please start a new purchase request.',
-			);
-		}
-
 		// Validate that the request is in WaitingForManualAction with error
 		if (purchaseRequest.NextAction.requestedAction !== PurchasingAction.WaitingForManualAction) {
 			throw createHttpError(
@@ -84,6 +89,31 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 
 		if (!purchaseRequest.NextAction.errorType) {
 			throw createHttpError(400, 'Purchase request is not in an error state. No error to clear.');
+		}
+
+		const previousAction = purchaseRequest.ActionHistory[0];
+		const retryAction = previousAction ? getPurchaseRetryAction(previousAction.requestedAction) : null;
+		if (input.retryPreviousAction && retryAction == null) {
+			throw createHttpError(400, 'The immediately preceding purchase action is not retryable.');
+		}
+
+		if (
+			!purchaseRequest.onChainState &&
+			(!input.retryPreviousAction || retryAction !== PurchasingAction.FundsLockingRequested)
+		) {
+			throw createHttpError(
+				400,
+				'Purchase request is in its initial on-chain state. Only a failed funds-locking action can be retried.',
+			);
+		}
+
+		const isCompletedState =
+			purchaseRequest.onChainState != null &&
+			(
+				[OnChainState.Withdrawn, OnChainState.RefundWithdrawn, OnChainState.DisputedWithdrawn] as OnChainState[]
+			).includes(purchaseRequest.onChainState);
+		if (input.retryPreviousAction && isCompletedState) {
+			throw createHttpError(400, 'The purchase is already completed and its previous action cannot be retried.');
 		}
 
 		// Find the most recent successful transaction (confirmed or pending)
@@ -121,107 +151,118 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 			lastSuccessfulTransactionStatus: lastSuccessfulTransaction?.status || null,
 			transactionsToFailCount: transactionsToFail.length,
 			transactionsToFailIds: transactionsToFail.map((tx) => tx.id),
+			retryPreviousAction: input.retryPreviousAction === true,
+			retryAction,
 		});
 
 		// Serializable + retry: this handler races concurrent tx-sync handlers
 		// that may advance the same PurchaseRequest. Without Serializable
 		// isolation, a concurrent state-machine update can win between this
 		// route's pre-read and the in-transaction updates here.
-		const newPurchase = await retryOnSerializationConflict(
-			() =>
-				prisma.$transaction(
-					async (tx) => {
-						for (const transaction of transactionsToFail) {
-							await tx.transaction.update({
-								where: { id: transaction.id },
-								data: { status: TransactionStatus.FailedViaManualReset },
+		let newPurchase;
+		try {
+			newPurchase = await retryOnSerializationConflict(
+				() =>
+					prisma.$transaction(
+						async (tx) => {
+							for (const transaction of transactionsToFail) {
+								await tx.transaction.update({
+									where: { id: transaction.id },
+									data: { status: TransactionStatus.FailedViaManualReset },
+								});
+							}
+
+							await tx.purchaseRequest.update({
+								where: { id: purchaseRequest.id },
+								data: { currentTransactionId: lastSuccessfulTransaction?.id || null },
 							});
-						}
 
-						await tx.purchaseRequest.update({
-							where: { id: purchaseRequest.id },
-							data: { currentTransactionId: lastSuccessfulTransaction?.id || null },
-						});
-
-						const isCompletedState =
-							purchaseRequest.onChainState &&
-							(
-								[OnChainState.Withdrawn, OnChainState.RefundWithdrawn, OnChainState.DisputedWithdrawn] as OnChainState[]
-							).includes(purchaseRequest.onChainState);
-
-						return await tx.purchaseRequest.update({
-							where: { id: purchaseRequest.id },
-							data: {
-								ActionHistory: {
-									connect: {
-										id: purchaseRequest.nextActionId,
+							return await tx.purchaseRequest.update({
+								where: {
+									id: purchaseRequest.id,
+									nextActionId: purchaseRequest.nextActionId,
+								},
+								data: {
+									ActionHistory: {
+										connect: {
+											id: purchaseRequest.nextActionId,
+										},
+									},
+									NextAction: {
+										create: {
+											submittedTxHash: null,
+											requestedAction: input.retryPreviousAction
+												? retryAction!
+												: isCompletedState
+													? PurchasingAction.None
+													: PurchasingAction.WaitingForExternalAction,
+										},
 									},
 								},
-								NextAction: {
-									create: {
-										submittedTxHash: null,
-										requestedAction: isCompletedState
-											? PurchasingAction.None
-											: PurchasingAction.WaitingForExternalAction,
+								include: {
+									NextAction: {
+										select: {
+											id: true,
+											requestedAction: true,
+											errorType: true,
+											errorNote: true,
+										},
+									},
+									CurrentTransaction: {
+										select: {
+											id: true,
+											createdAt: true,
+											updatedAt: true,
+											txHash: true,
+											status: true,
+											fees: true,
+											blockHeight: true,
+											blockTime: true,
+											previousOnChainState: true,
+											newOnChainState: true,
+											confirmations: true,
+										},
+									},
+									PaidFunds: { select: { id: true, amount: true, unit: true } },
+									PaymentSource: {
+										select: {
+											id: true,
+											network: true,
+											paymentSourceType: true,
+											policyId: true,
+											smartContractAddress: true,
+										},
+									},
+									SellerWallet: { select: { id: true, walletVkey: true } },
+									SmartContractWallet: {
+										where: { deletedAt: null },
+										select: { id: true, walletVkey: true, walletAddress: true },
+									},
+									WithdrawnForSeller: {
+										select: { id: true, amount: true, unit: true },
+									},
+									WithdrawnForBuyer: {
+										select: { id: true, amount: true, unit: true },
 									},
 								},
-							},
-							include: {
-								NextAction: {
-									select: {
-										id: true,
-										requestedAction: true,
-										errorType: true,
-										errorNote: true,
-									},
-								},
-								CurrentTransaction: {
-									select: {
-										id: true,
-										createdAt: true,
-										updatedAt: true,
-										txHash: true,
-										status: true,
-										fees: true,
-										blockHeight: true,
-										blockTime: true,
-										previousOnChainState: true,
-										newOnChainState: true,
-										confirmations: true,
-									},
-								},
-								PaidFunds: { select: { id: true, amount: true, unit: true } },
-								PaymentSource: {
-									select: {
-										id: true,
-										network: true,
-										paymentSourceType: true,
-										policyId: true,
-										smartContractAddress: true,
-									},
-								},
-								SellerWallet: { select: { id: true, walletVkey: true } },
-								SmartContractWallet: {
-									where: { deletedAt: null },
-									select: { id: true, walletVkey: true, walletAddress: true },
-								},
-								WithdrawnForSeller: {
-									select: { id: true, amount: true, unit: true },
-								},
-								WithdrawnForBuyer: {
-									select: { id: true, amount: true, unit: true },
-								},
-							},
-						});
-					},
-					{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
-				),
-			{ label: 'purchases-error-state-recovery' },
-		);
+							});
+						},
+						{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+					),
+				{ label: 'purchases-error-state-recovery' },
+			);
+		} catch (error) {
+			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+				throw createHttpError(409, 'Purchase state changed concurrently; retry against the new state');
+			}
+			throw error;
+		}
 
 		logger.info('Error state recovery completed successfully', {
 			purchaseRequestId: purchaseRequest.id,
 			failedTransactionsCount: transactionsToFail.length,
+			retryPreviousAction: input.retryPreviousAction === true,
+			retryAction,
 		});
 
 		const decoded = decodeBlockchainIdentifier(newPurchase.blockchainIdentifier);

--- a/src/services/shared/index.ts
+++ b/src/services/shared/index.ts
@@ -36,6 +36,7 @@ export type { WalletSession } from './wallet-session';
 export { loadHotWalletSession } from './wallet-session';
 export type { TxWindow } from './tx-window';
 export { createTxWindow } from './tx-window';
+export { runSubmitResultSubmissionLifecycle, type SubmitResultSubmissionOutcome } from './submit-result-lifecycle';
 export {
 	connectExistingNextPaymentAction,
 	connectExistingNextPurchaseAction,

--- a/src/services/shared/job-runner.spec.ts
+++ b/src/services/shared/job-runner.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Mutex } from 'async-mutex';
+
+const mockInfo = jest.fn();
+
+jest.unstable_mockModule('@masumi/payment-core/logger', () => ({
+	logger: {
+		info: mockInfo,
+	},
+}));
+
+const { withJobLock } = await import('./job-runner');
+
+describe('withJobLock', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('skips an overlapping cycle with a job-specific message', async () => {
+		const mutex = new Mutex();
+		const release = await mutex.acquire();
+		const operation = jest.fn<() => Promise<void>>(async () => undefined);
+
+		await expect(withJobLock(mutex, 'submit_result_v2', operation)).resolves.toBeUndefined();
+
+		expect(operation).not.toHaveBeenCalled();
+		expect(mockInfo).toHaveBeenCalledWith('submit_result_v2 is already running, skipping cycle');
+		release();
+	});
+
+	it('releases the lock after the operation finishes', async () => {
+		const mutex = new Mutex();
+		const operation = jest.fn<() => Promise<string>>(async () => 'done');
+
+		await expect(withJobLock(mutex, 'test_job', operation)).resolves.toBe('done');
+		expect(mutex.isLocked()).toBe(false);
+	});
+});

--- a/src/services/shared/job-runner.ts
+++ b/src/services/shared/job-runner.ts
@@ -17,8 +17,8 @@ export async function withJobLock<T>(
 	let release: (() => void) | undefined;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (error) {
-		logger.info(`${jobName} is already running, skipping cycle`, { error });
+	} catch {
+		logger.info(`${jobName} is already running, skipping cycle`);
 		return undefined;
 	}
 

--- a/src/services/shared/submit-result-lifecycle.spec.ts
+++ b/src/services/shared/submit-result-lifecycle.spec.ts
@@ -1,0 +1,60 @@
+import { jest } from '@jest/globals';
+import { runSubmitResultSubmissionLifecycle } from './submit-result-lifecycle';
+
+function createOptions() {
+	return {
+		submit: jest.fn<() => Promise<string>>(),
+		requeueRejected: jest.fn<(error: unknown) => Promise<void>>(async () => undefined),
+		evaluateProjectedBalance: jest.fn<() => Promise<void>>(async () => undefined),
+		recordSubmitted: jest.fn<(txHash: string) => Promise<void>>(async () => undefined),
+		onBalanceCheckFailure: jest.fn<(error: unknown, txHash: string) => void>(),
+		onRecordFailure: jest.fn<(error: unknown, txHash: string) => void>(),
+	};
+}
+
+describe('submit-result submission lifecycle', () => {
+	it('requeues a rejected submission without recording a pending transaction', async () => {
+		const options = createOptions();
+		const submitError = new Error('node rejected transaction');
+		options.submit.mockRejectedValue(submitError);
+
+		await expect(runSubmitResultSubmissionLifecycle(options)).resolves.toEqual({
+			status: 'rejected',
+			error: submitError,
+		});
+		expect(options.requeueRejected).toHaveBeenCalledWith(submitError);
+		expect(options.evaluateProjectedBalance).not.toHaveBeenCalled();
+		expect(options.recordSubmitted).not.toHaveBeenCalled();
+	});
+
+	it('records an accepted transaction even when projected-balance monitoring fails', async () => {
+		const options = createOptions();
+		const balanceError = new Error('monitoring failed');
+		options.submit.mockResolvedValue('submitted-hash');
+		options.evaluateProjectedBalance.mockRejectedValue(balanceError);
+
+		await expect(runSubmitResultSubmissionLifecycle(options)).resolves.toEqual({
+			status: 'submitted',
+			txHash: 'submitted-hash',
+			isRecorded: true,
+		});
+		expect(options.onBalanceCheckFailure).toHaveBeenCalledWith(balanceError, 'submitted-hash');
+		expect(options.recordSubmitted).toHaveBeenCalledWith('submitted-hash');
+		expect(options.requeueRejected).not.toHaveBeenCalled();
+	});
+
+	it('does not throw or resubmit after post-submit recording fails', async () => {
+		const options = createOptions();
+		const recordError = new Error('database unavailable');
+		options.submit.mockResolvedValue('submitted-hash');
+		options.recordSubmitted.mockRejectedValue(recordError);
+
+		await expect(runSubmitResultSubmissionLifecycle(options)).resolves.toEqual({
+			status: 'submitted',
+			txHash: 'submitted-hash',
+			isRecorded: false,
+		});
+		expect(options.submit).toHaveBeenCalledTimes(1);
+		expect(options.onRecordFailure).toHaveBeenCalledWith(recordError, 'submitted-hash');
+	});
+});

--- a/src/services/shared/submit-result-lifecycle.ts
+++ b/src/services/shared/submit-result-lifecycle.ts
@@ -1,0 +1,44 @@
+export type SubmitResultSubmissionOutcome =
+	| {
+			status: 'rejected';
+			error: unknown;
+	  }
+	| {
+			status: 'submitted';
+			txHash: string;
+			isRecorded: boolean;
+	  };
+
+export async function runSubmitResultSubmissionLifecycle(options: {
+	submit: () => Promise<string>;
+	requeueRejected: (error: unknown) => Promise<void>;
+	evaluateProjectedBalance: () => Promise<void>;
+	recordSubmitted: (txHash: string) => Promise<void>;
+	onBalanceCheckFailure: (error: unknown, txHash: string) => void;
+	onRecordFailure: (error: unknown, txHash: string) => void;
+}): Promise<SubmitResultSubmissionOutcome> {
+	let txHash: string;
+	try {
+		txHash = await options.submit();
+	} catch (error) {
+		await options.requeueRejected(error);
+		return { status: 'rejected', error };
+	}
+
+	try {
+		await options.evaluateProjectedBalance();
+	} catch (error) {
+		options.onBalanceCheckFailure(error, txHash);
+	}
+
+	try {
+		await options.recordSubmitted(txHash);
+	} catch (error) {
+		// The node has already accepted this transaction. Report the database
+		// failure, but do not throw into a retry wrapper that would submit again.
+		options.onRecordFailure(error, txHash);
+		return { status: 'submitted', txHash, isRecorded: false };
+	}
+
+	return { status: 'submitted', txHash, isRecorded: true };
+}

--- a/src/services/transactions/phase-2-failure/index.ts
+++ b/src/services/transactions/phase-2-failure/index.ts
@@ -99,7 +99,15 @@ export async function markTransactionPhase2Failed(
 			//    nextActionId; updateMany cannot express relation writes.
 			const paymentRequests = await tx.paymentRequest.findMany({
 				where: { currentTransactionId: transactionId },
-				select: { id: true, nextActionId: true },
+				select: {
+					id: true,
+					nextActionId: true,
+					NextAction: {
+						select: {
+							resultHash: true,
+						},
+					},
+				},
 			});
 			// intentional sequential — Prisma serializes interactive-tx queries on a single connection
 			for (const request of paymentRequests) {
@@ -112,6 +120,7 @@ export async function markTransactionPhase2Failed(
 								requestedAction: PaymentAction.WaitingForManualAction,
 								errorType: PaymentErrorType.Unknown,
 								errorNote: ERROR_NOTE_PHASE_2,
+								resultHash: request.NextAction.resultHash,
 							},
 						},
 					},

--- a/src/services/transactions/wallet-timeouts/service.ts
+++ b/src/services/transactions/wallet-timeouts/service.ts
@@ -40,8 +40,8 @@ export async function updateWalletTransactionHash() {
 	let release: MutexInterface.Releaser | null;
 	try {
 		release = await tryAcquire(mutex).acquire();
-	} catch (e) {
-		logger.info('Mutex timeout when locking', { error: e });
+	} catch {
+		logger.info('wallet_transaction_timeouts is already running, skipping cycle');
 		return;
 	}
 	const unlockedSellingWalletIds: string[] = [];

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -11437,6 +11437,10 @@
                                             }
                                         ],
                                         "description": "The time of the last update, to ensure you clear the correct error state"
+                                    },
+                                    "retryPreviousAction": {
+                                        "type": "boolean",
+                                        "description": "When true, retry the failed action. When false or omitted, only clear the error state."
                                     }
                                 },
                                 "required": [
@@ -12094,6 +12098,10 @@
                                             }
                                         ],
                                         "description": "The time of the last update, to ensure you clear the correct error state"
+                                    },
+                                    "retryPreviousAction": {
+                                        "type": "boolean",
+                                        "description": "When true, retry the failed action. When false or omitted, only clear the error state."
                                     }
                                 },
                                 "required": [

--- a/src/utils/shared/error-recovery.spec.ts
+++ b/src/utils/shared/error-recovery.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from '@jest/globals';
+import { PaymentAction, PurchasingAction } from '@/generated/prisma/client';
+import { getPaymentRetryAction, getPaymentRetryResultHash, getPurchaseRetryAction } from './error-recovery';
+
+describe('error recovery retry actions', () => {
+	it.each([
+		[PaymentAction.SubmitResultRequested, PaymentAction.SubmitResultRequested],
+		[PaymentAction.SubmitResultInitiated, PaymentAction.SubmitResultRequested],
+		[PaymentAction.WithdrawRequested, PaymentAction.WithdrawRequested],
+		[PaymentAction.WithdrawInitiated, PaymentAction.WithdrawRequested],
+		[PaymentAction.AuthorizeRefundRequested, PaymentAction.AuthorizeRefundRequested],
+		[PaymentAction.AuthorizeRefundInitiated, PaymentAction.AuthorizeRefundRequested],
+	])('maps payment action %s to %s', (action, expected) => {
+		expect(getPaymentRetryAction(action)).toBe(expected);
+	});
+
+	it.each([
+		PaymentAction.None,
+		PaymentAction.Ignore,
+		PaymentAction.WaitingForExternalAction,
+		PaymentAction.WaitingForManualAction,
+	])('does not retry non-transactional payment action %s', (action) => {
+		expect(getPaymentRetryAction(action)).toBeNull();
+	});
+
+	it('prefers the result hash preserved on the current error action', () => {
+		expect(
+			getPaymentRetryResultHash(
+				'error-action-hash',
+				{ requestedAction: PaymentAction.SubmitResultRequested, resultHash: 'requested-hash' },
+				undefined,
+			),
+		).toBe('error-action-hash');
+	});
+
+	it('restores a result hash from the failed requested action', () => {
+		expect(
+			getPaymentRetryResultHash(
+				null,
+				{ requestedAction: PaymentAction.SubmitResultRequested, resultHash: 'requested-hash' },
+				undefined,
+			),
+		).toBe('requested-hash');
+	});
+
+	it('restores a result hash from the adjacent requested action when initiated data is legacy', () => {
+		expect(
+			getPaymentRetryResultHash(
+				null,
+				{ requestedAction: PaymentAction.SubmitResultInitiated, resultHash: null },
+				{ requestedAction: PaymentAction.SubmitResultRequested, resultHash: 'requested-hash' },
+			),
+		).toBe('requested-hash');
+	});
+
+	it('does not read a result hash from unrelated older history', () => {
+		expect(
+			getPaymentRetryResultHash(
+				null,
+				{ requestedAction: PaymentAction.SubmitResultInitiated, resultHash: null },
+				{ requestedAction: PaymentAction.WaitingForExternalAction, resultHash: 'unrelated-hash' },
+			),
+		).toBeNull();
+	});
+
+	it.each([
+		[PurchasingAction.FundsLockingRequested, PurchasingAction.FundsLockingRequested],
+		[PurchasingAction.FundsLockingInitiated, PurchasingAction.FundsLockingRequested],
+		[PurchasingAction.SetRefundRequestedRequested, PurchasingAction.SetRefundRequestedRequested],
+		[PurchasingAction.SetRefundRequestedInitiated, PurchasingAction.SetRefundRequestedRequested],
+		[PurchasingAction.UnSetRefundRequestedRequested, PurchasingAction.UnSetRefundRequestedRequested],
+		[PurchasingAction.UnSetRefundRequestedInitiated, PurchasingAction.UnSetRefundRequestedRequested],
+		[PurchasingAction.WithdrawRefundRequested, PurchasingAction.WithdrawRefundRequested],
+		[PurchasingAction.WithdrawRefundInitiated, PurchasingAction.WithdrawRefundRequested],
+		[PurchasingAction.AuthorizeWithdrawalRequested, PurchasingAction.AuthorizeWithdrawalRequested],
+		[PurchasingAction.AuthorizeWithdrawalInitiated, PurchasingAction.AuthorizeWithdrawalRequested],
+	])('maps purchase action %s to %s', (action, expected) => {
+		expect(getPurchaseRetryAction(action)).toBe(expected);
+	});
+
+	it.each([
+		PurchasingAction.None,
+		PurchasingAction.Ignore,
+		PurchasingAction.WaitingForExternalAction,
+		PurchasingAction.WaitingForManualAction,
+	])('does not retry non-transactional purchase action %s', (action) => {
+		expect(getPurchaseRetryAction(action)).toBeNull();
+	});
+});

--- a/src/utils/shared/error-recovery.ts
+++ b/src/utils/shared/error-recovery.ts
@@ -1,0 +1,69 @@
+import { PaymentAction, PurchasingAction } from '@/generated/prisma/client';
+
+export function getPaymentRetryAction(action: PaymentAction): PaymentAction | null {
+	switch (action) {
+		case PaymentAction.SubmitResultRequested:
+		case PaymentAction.SubmitResultInitiated:
+			return PaymentAction.SubmitResultRequested;
+		case PaymentAction.WithdrawRequested:
+		case PaymentAction.WithdrawInitiated:
+			return PaymentAction.WithdrawRequested;
+		case PaymentAction.AuthorizeRefundRequested:
+		case PaymentAction.AuthorizeRefundInitiated:
+			return PaymentAction.AuthorizeRefundRequested;
+		default:
+			return null;
+	}
+}
+
+type PaymentActionWithResultHash = {
+	requestedAction: PaymentAction;
+	resultHash: string | null;
+};
+
+export function getPaymentRetryResultHash(
+	errorResultHash: string | null,
+	previousAction: PaymentActionWithResultHash | undefined,
+	actionBeforePrevious: PaymentActionWithResultHash | undefined,
+): string | null {
+	if (
+		previousAction == null ||
+		getPaymentRetryAction(previousAction.requestedAction) !== PaymentAction.SubmitResultRequested
+	) {
+		return null;
+	}
+
+	if (errorResultHash != null) return errorResultHash;
+	if (previousAction.resultHash != null) return previousAction.resultHash;
+
+	if (
+		previousAction.requestedAction === PaymentAction.SubmitResultInitiated &&
+		actionBeforePrevious?.requestedAction === PaymentAction.SubmitResultRequested
+	) {
+		return actionBeforePrevious.resultHash;
+	}
+
+	return null;
+}
+
+export function getPurchaseRetryAction(action: PurchasingAction): PurchasingAction | null {
+	switch (action) {
+		case PurchasingAction.FundsLockingRequested:
+		case PurchasingAction.FundsLockingInitiated:
+			return PurchasingAction.FundsLockingRequested;
+		case PurchasingAction.SetRefundRequestedRequested:
+		case PurchasingAction.SetRefundRequestedInitiated:
+			return PurchasingAction.SetRefundRequestedRequested;
+		case PurchasingAction.UnSetRefundRequestedRequested:
+		case PurchasingAction.UnSetRefundRequestedInitiated:
+			return PurchasingAction.UnSetRefundRequestedRequested;
+		case PurchasingAction.WithdrawRefundRequested:
+		case PurchasingAction.WithdrawRefundInitiated:
+			return PurchasingAction.WithdrawRefundRequested;
+		case PurchasingAction.AuthorizeWithdrawalRequested:
+		case PurchasingAction.AuthorizeWithdrawalInitiated:
+			return PurchasingAction.AuthorizeWithdrawalRequested;
+		default:
+			return null;
+	}
+}


### PR DESCRIPTION
## Purpose of this Pull Request

- [x] Bug fix

## Overview of Changes

- Add the optional retryPreviousAction flag to the existing payment and purchase error-state recovery endpoints.
- Preserve and restore the immediately failed action and required submit-result hash when retrying.
- Keep omitted or false behavior as clear-only recovery.
- Add Retry Failed Action and Clear Error State choices to transaction detail and bulk recovery UI.
- Replace opaque mutex timeout logs with job-specific overlapping-cycle messages.
- Cover retry mapping, payload recovery, and lock release behavior with unit tests.

## Issue Addressed

Fixes error recovery that cleared WaitingForManualAction without re-queuing the failed blockchain action, and makes scheduler lock contention logs actionable.

## Checklist

- [x] Lint and formatting pass
- [x] Backend and frontend typechecks pass
- [x] Focused unit tests pass
- [x] OpenAPI documents and frontend API types regenerated
- [x] No Prisma migration or schema change
- [ ] Local E2E not run, as requested

## Focus for Reviewers

Please review the immediate-action selection rules, legacy submit-result hash fallback, optimistic nextActionId guard, and the separate clear-only versus retry behavior.