### PR TITLE
fix(escrow): stop clobbering escrow tx hash and collateral reserve

### DIFF
--- a/packages/payment-core/package.json
+++ b/packages/payment-core/package.json
@@ -18,6 +18,7 @@
 		"./error-string-convert": "./src/error-string-convert.ts",
 		"./hex": "./src/hex.ts",
 		"./http-exists-error": "./src/http-exists-error.ts",
+		"./insufficient-balance-error": "./src/insufficient-balance-error.ts",
 		"./insufficient-funds-error": "./src/insufficient-funds-error.ts",
 		"./logger": "./src/logger.ts",
 		"./metrics": "./src/metrics.ts",

--- a/packages/payment-core/src/insufficient-balance-error.spec.ts
+++ b/packages/payment-core/src/insufficient-balance-error.spec.ts
@@ -1,0 +1,32 @@
+import { isInsufficientBalanceBuildError } from './insufficient-balance-error';
+
+describe('isInsufficientBalanceBuildError', () => {
+	it.each([
+		'UTxO Balance Insufficient',
+		'InputSelectionError: not enough funds',
+		'utxo fully depleted',
+		'Insufficient balance for the transaction',
+		'Not enough ADA to cover the outputs',
+		'not enough lovelace left for change',
+	])('matches the mesh coin-selection failure %p', (message) => {
+		expect(isInsufficientBalanceBuildError(new Error(message))).toBe(true);
+	});
+
+	// Must stay narrow — retrying these would mask the real failure.
+	it.each([
+		'PPViewHashesDontMatch',
+		'extraRedeemers',
+		'Collateral UTxO not found with at least 5000000 lovelace',
+		'Transaction hash not found',
+		'ValueNotConserved',
+		'BadInputsUTxO',
+	])('does not match the unrelated failure %p', (message) => {
+		expect(isInsufficientBalanceBuildError(new Error(message))).toBe(false);
+	});
+
+	it('handles non-Error values without throwing', () => {
+		expect(isInsufficientBalanceBuildError('utxo fully depleted')).toBe(true);
+		expect(isInsufficientBalanceBuildError(undefined)).toBe(false);
+		expect(isInsufficientBalanceBuildError(null)).toBe(false);
+	});
+});

--- a/packages/payment-core/src/insufficient-balance-error.ts
+++ b/packages/payment-core/src/insufficient-balance-error.ts
@@ -1,0 +1,28 @@
+import { errorToString } from './error-string-convert';
+
+/**
+ * Recognises a Mesh coin-selection failure — the tx could not be balanced from
+ * the candidate inputs it was given.
+ *
+ * Pure string matching on purpose: Mesh throws plain `Error`s from several
+ * layers (`InputSelectionError`, the balancer, the min-UTxO check) with no
+ * shared class or code to switch on. The vocabulary mirrors
+ * `shouldRetryWithoutOptionalWalletSplitter` in the V2 batch builder, which
+ * has been matching these strings in production.
+ *
+ * Used to decide whether holding the collateral UTxO back from coin selection
+ * made a transaction unbuildable, in which case the caller retries with the
+ * collateral available. This must stay narrow: a false positive would retry a
+ * genuinely broken build and mask the real error.
+ */
+export function isInsufficientBalanceBuildError(error: unknown): boolean {
+	const message = errorToString(error).toLowerCase();
+	return (
+		message.includes('utxo fully depleted') ||
+		message.includes('inputselectionerror') ||
+		message.includes('insufficient balance') ||
+		message.includes('utxo balance insufficient') ||
+		message.includes('not enough ada') ||
+		message.includes('not enough lovelace')
+	);
+}

--- a/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
+++ b/packages/payment-source-v1/src/services/payments/authorize-refund/service.ts
@@ -14,6 +14,7 @@ import { writePaymentErrorTransition } from '@/services/shared/error-transition'
 import { Mutex, tryAcquire, MutexInterface } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPaymentAction,
@@ -137,6 +138,8 @@ export async function authorizeRefundV1() {
 						if (!utxo) {
 							throw new Error('UTXO not found');
 						}
+
+						await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
 
 						const buyerAddress = request.BuyerWallet!.walletAddress;
 						const sellerAddress = request.SmartContractWallet!.walletAddress;

--- a/packages/payment-source-v1/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v1/src/services/payments/collection/service.ts
@@ -18,9 +18,9 @@ import {
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPaymentAction,
-	createPendingTransaction,
 	createTxWindow,
 	loadHotWalletSession,
+	resolveEscrowSpendTransactionWrite,
 	updateCurrentTransactionHash,
 } from '@/services/shared';
 import { getPaymentScriptFromPaymentSourceV1 } from '@masumi/payment-source-v1';
@@ -255,27 +255,28 @@ async function processSinglePaymentCollection(
 	);
 
 	const signedTx = await wallet.signTx(unsignedTx);
-	await prisma.paymentRequest.update({
-		where: { id: request.id },
-		data: {
-			...connectPreviousAction(request.nextActionId),
-			...createNextPaymentAction(PaymentAction.WithdrawInitiated),
-			// Create a NEW pending row rather than blanking the current one in
-			// place. The in-place update overwrote the confirmed escrow tx hash
-			// with null and downgraded its status, so any failure before the
-			// post-submit `updateCurrentTransactionHash` destroyed the only
-			// record of the UTxO this request depends on — leaving the request
-			// stuck on 'Transaction hash not found' with nothing to recover
-			// from, since error-state-recovery then re-pinned that same
-			// hash-less row. V2 already does it this way; see
-			// packages/payment-source-v2/src/services/payments/collection/service.ts
-			...createPendingTransaction(request.SmartContractWallet.id),
-			TransactionHistory: {
-				connect: {
-					id: request.CurrentTransaction!.id,
-				},
+	// See purchases/collect-refund for the full rationale: never mutate the
+	// escrow row, and resolve the write shape from a FRESH read because
+	// advancedRetryAll replays this function with a stale `request`.
+	const escrowTransactionId = request.CurrentTransaction!.id;
+	const started = await prisma.$transaction(async (tx) => {
+		const fresh = await tx.paymentRequest.findUniqueOrThrow({
+			where: { id: request.id },
+			select: { CurrentTransaction: { select: { id: true, txHash: true, status: true } } },
+		});
+		return await tx.paymentRequest.update({
+			where: { id: request.id },
+			data: {
+				...connectPreviousAction(request.nextActionId),
+				...createNextPaymentAction(PaymentAction.WithdrawInitiated),
+				...resolveEscrowSpendTransactionWrite(
+					fresh.CurrentTransaction,
+					request.SmartContractWallet!.id,
+					escrowTransactionId,
+				),
 			},
-		},
+			select: { currentTransactionId: true },
+		});
 	});
 	//submit the transaction to the blockchain
 	const newTxHash = await wallet.submitTx(signedTx);
@@ -283,7 +284,14 @@ async function processSinglePaymentCollection(
 
 	await prisma.paymentRequest.update({
 		where: { id: request.id },
-		data: updateCurrentTransactionHash(newTxHash),
+		data: {
+			...updateCurrentTransactionHash(newTxHash),
+			// Withdraw is terminal — nothing later archives this row, so connect it
+			// explicitly or the withdrawal tx never reaches TransactionHistory.
+			...(started.currentTransactionId != null
+				? { TransactionHistory: { connect: { id: started.currentTransactionId } } }
+				: {}),
+		},
 	});
 	logger.debug(`Created withdrawal transaction:
         Tx ID: ${newTxHash}

--- a/packages/payment-source-v1/src/services/payments/collection/service.ts
+++ b/packages/payment-source-v1/src/services/payments/collection/service.ts
@@ -1,4 +1,4 @@
-import { OnChainState, PaymentAction, PaymentSourceType, TransactionStatus, Prisma } from '@/generated/prisma/client';
+import { OnChainState, PaymentAction, PaymentSourceType, Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { Asset, BlockfrostProvider, deserializeDatum } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -14,9 +14,11 @@ import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractWithdrawTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import { CONSTANTS } from '@masumi/payment-core/config';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPaymentAction,
+	createPendingTransaction,
 	createTxWindow,
 	loadHotWalletSession,
 	updateCurrentTransactionHash,
@@ -119,6 +121,8 @@ async function processSinglePaymentCollection(
 	if (!utxo) {
 		throw new Error('UTXO not found');
 	}
+
+	await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
 
 	const utxoDatum = utxo.output.plutusData;
 	if (!utxoDatum) {
@@ -256,17 +260,16 @@ async function processSinglePaymentCollection(
 		data: {
 			...connectPreviousAction(request.nextActionId),
 			...createNextPaymentAction(PaymentAction.WithdrawInitiated),
-			CurrentTransaction: {
-				update: {
-					txHash: null,
-					status: TransactionStatus.Pending,
-					BlocksWallet: {
-						connect: {
-							id: request.SmartContractWallet.id,
-						},
-					},
-				},
-			},
+			// Create a NEW pending row rather than blanking the current one in
+			// place. The in-place update overwrote the confirmed escrow tx hash
+			// with null and downgraded its status, so any failure before the
+			// post-submit `updateCurrentTransactionHash` destroyed the only
+			// record of the UTxO this request depends on — leaving the request
+			// stuck on 'Transaction hash not found' with nothing to recover
+			// from, since error-state-recovery then re-pinned that same
+			// hash-less row. V2 already does it this way; see
+			// packages/payment-source-v2/src/services/payments/collection/service.ts
+			...createPendingTransaction(request.SmartContractWallet.id),
 			TransactionHistory: {
 				connect: {
 					id: request.CurrentTransaction!.id,

--- a/packages/payment-source-v1/src/services/payments/submit-result/service.ts
+++ b/packages/payment-source-v1/src/services/payments/submit-result/service.ts
@@ -16,6 +16,7 @@ import { advancedRetryAll } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPaymentAction,
@@ -208,6 +209,8 @@ async function processSinglePaymentRequest(
 	}
 
 	const { utxo, decodedContract } = matchResult;
+
+	await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
 
 	const datum = createDatumFromDecodedContractV1({
 		decodedContract,

--- a/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/cancel-refund/service.ts
@@ -14,6 +14,7 @@ import { writePurchaseErrorTransition } from '@/services/shared/error-transition
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPurchaseAction,
@@ -168,6 +169,8 @@ export async function cancelRefundsV1() {
 						if (!utxo) {
 							throw new Error('UTXO not found');
 						}
+
+						await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
 
 						const decodedContract = decodeAndValidateUtxoDatum({ utxo, network });
 						// V1 Aiken cancel-refund requires new_datum.buyer/seller to equal the

--- a/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
@@ -17,9 +17,9 @@ import {
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPurchaseAction,
-	createPendingTransaction,
 	createTxWindow,
 	loadHotWalletSession,
+	resolveEscrowSpendTransactionWrite,
 	updateCurrentTransactionHash,
 } from '@/services/shared';
 import { getPaymentScriptFromPaymentSourceV1 } from '@masumi/payment-source-v1';
@@ -161,29 +161,33 @@ async function processSingleRefundCollection(
 	);
 
 	const signedTx = await wallet.signTx(unsignedTx);
-	await prisma.purchaseRequest.update({
-		where: { id: request.id },
-		data: {
-			...connectPreviousAction(request.nextActionId),
-			...createNextPurchaseAction(PurchasingAction.WithdrawRefundInitiated, {
-				submittedTxHash: null,
-			}),
-			// Create a NEW pending row rather than blanking the current one in
-			// place. The in-place update overwrote the confirmed escrow tx hash
-			// with null and downgraded its status, so any failure before the
-			// post-submit `updateCurrentTransactionHash` destroyed the only
-			// record of the UTxO this request depends on — leaving the request
-			// stuck on 'Transaction hash not found' with nothing to recover
-			// from, since error-state-recovery then re-pinned that same
-			// hash-less row. V2 already does it this way; see
-			// packages/payment-source-v2/src/services/payments/collection/service.ts
-			...createPendingTransaction(request.SmartContractWallet.id),
-			TransactionHistory: {
-				connect: {
-					id: request.CurrentTransaction!.id,
-				},
+	// Record the outgoing tx WITHOUT touching the escrow row: blanking its
+	// txHash in place destroyed the only record of the UTxO this request
+	// depends on, wedging it on 'Transaction hash not found'. The write shape
+	// is resolved from a FRESH read because this whole function is replayed by
+	// advancedRetryAll and the closed-over `request` never refreshes — see
+	// resolveEscrowSpendTransactionWrite.
+	const escrowTransactionId = request.CurrentTransaction!.id;
+	const started = await prisma.$transaction(async (tx) => {
+		const fresh = await tx.purchaseRequest.findUniqueOrThrow({
+			where: { id: request.id },
+			select: { CurrentTransaction: { select: { id: true, txHash: true, status: true } } },
+		});
+		return await tx.purchaseRequest.update({
+			where: { id: request.id },
+			data: {
+				...connectPreviousAction(request.nextActionId),
+				...createNextPurchaseAction(PurchasingAction.WithdrawRefundInitiated, {
+					submittedTxHash: null,
+				}),
+				...resolveEscrowSpendTransactionWrite(
+					fresh.CurrentTransaction,
+					request.SmartContractWallet!.id,
+					escrowTransactionId,
+				),
 			},
-		},
+			select: { currentTransactionId: true },
+		});
 	});
 
 	//submit the transaction to the blockchain
@@ -192,7 +196,15 @@ async function processSingleRefundCollection(
 
 	await prisma.purchaseRequest.update({
 		where: { id: request.id },
-		data: updateCurrentTransactionHash(newTxHash),
+		data: {
+			...updateCurrentTransactionHash(newTxHash),
+			// CollectRefund is terminal, so no later action will archive this row.
+			// Without an explicit connect the withdrawal tx never reaches
+			// TransactionHistory and drops out of the API response and audit trail.
+			...(started.currentTransactionId != null
+				? { TransactionHistory: { connect: { id: started.currentTransactionId } } }
+				: {}),
+		},
 	});
 
 	logger.debug(`Created withdrawal transaction:

--- a/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/collect-refund/service.ts
@@ -1,10 +1,4 @@
-import {
-	OnChainState,
-	PaymentSourceType,
-	PurchasingAction,
-	TransactionStatus,
-	Prisma,
-} from '@/generated/prisma/client';
+import { OnChainState, PaymentSourceType, PurchasingAction, Prisma } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
 import { BlockfrostProvider, deserializeDatum } from '@meshsdk/core';
 import { logger } from '@masumi/payment-core/logger';
@@ -19,9 +13,11 @@ import { writePurchaseErrorTransition } from '@/services/shared/error-transition
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractWithdrawTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPurchaseAction,
+	createPendingTransaction,
 	createTxWindow,
 	loadHotWalletSession,
 	updateCurrentTransactionHash,
@@ -125,6 +121,8 @@ async function processSingleRefundCollection(
 		throw new Error('UTXO not found');
 	}
 
+	await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
+
 	const utxoDatum = utxo.output.plutusData;
 	if (!utxoDatum) {
 		throw new Error('No datum found in UTXO');
@@ -170,17 +168,16 @@ async function processSingleRefundCollection(
 			...createNextPurchaseAction(PurchasingAction.WithdrawRefundInitiated, {
 				submittedTxHash: null,
 			}),
-			CurrentTransaction: {
-				update: {
-					txHash: null,
-					status: TransactionStatus.Pending,
-					BlocksWallet: {
-						connect: {
-							id: request.SmartContractWallet.id,
-						},
-					},
-				},
-			},
+			// Create a NEW pending row rather than blanking the current one in
+			// place. The in-place update overwrote the confirmed escrow tx hash
+			// with null and downgraded its status, so any failure before the
+			// post-submit `updateCurrentTransactionHash` destroyed the only
+			// record of the UTxO this request depends on — leaving the request
+			// stuck on 'Transaction hash not found' with nothing to recover
+			// from, since error-state-recovery then re-pinned that same
+			// hash-less row. V2 already does it this way; see
+			// packages/payment-source-v2/src/services/payments/collection/service.ts
+			...createPendingTransaction(request.SmartContractWallet.id),
 			TransactionHistory: {
 				connect: {
 					id: request.CurrentTransaction!.id,

--- a/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/request-refund/service.ts
@@ -14,6 +14,7 @@ import { writePurchaseErrorTransition } from '@/services/shared/error-transition
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { generateMasumiSmartContractInteractionTransactionAutomaticFees } from '@/utils/generator/transaction-generator';
 import {
+	assertEscrowUtxoUnspent,
 	connectPreviousAction,
 	createMeshProvider,
 	createNextPurchaseAction,
@@ -120,6 +121,8 @@ async function processSinglePurchaseRequest(
 	if (!utxo) {
 		throw new Error('UTXO not found');
 	}
+
+	await assertEscrowUtxoUnspent(blockchainProvider, smartContractAddress, utxo);
 
 	const utxoDatum = utxo.output.plutusData;
 	if (!utxoDatum) {

--- a/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
+++ b/packages/payment-source-v2/src/builders/__tests__/single-interaction.test.ts
@@ -91,7 +91,7 @@ describe('V2 single-item smart-contract input selection', () => {
 		builders.length = 0;
 	});
 
-	it('offers every wallet UTxO to Mesh in both fee passes, including collateral', async () => {
+	it('offers the spendable wallet UTxOs to Mesh in both fee passes, holding back collateral', async () => {
 		const collateralUtxo = createUtxo('collateral', '8281874');
 		const smallUtxo = createUtxo('small', '3336392');
 		const largeUtxo = createUtxo('large', '485435616');
@@ -127,7 +127,10 @@ describe('V2 single-item smart-contract input selection', () => {
 		expect(builders).toHaveLength(2);
 		for (const builder of builders) {
 			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
-			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([collateralUtxo, smallUtxo, largeUtxo]);
+			// Mesh does not exclude `txInCollateral` UTxOs from `selectUtxosFrom`
+			// candidates, so coin selection would otherwise spend the collateral
+			// reserve and leave the wallet unable to fund the next escrow action.
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
 			expect(builder.txIn).toHaveBeenCalledTimes(1);
 		}
 	});

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -149,8 +149,9 @@ function refKey(input: { txHash: string; outputIndex: number }): string {
  * Keeps every payment-key wallet candidate available to Mesh while excluding
  * only inputs that the transaction already spends as scripts.
  *
- * In particular, callers must not exclude the declared collateral: CIP-40
- * allows a VKey UTxO to appear in both regular and collateral input sets.
+ * This does NOT exclude the declared collateral — see
+ * `getSpendableWalletUtxos`, which the builders apply immediately before
+ * handing the candidates to `selectUtxosFrom`.
  */
 export function getWalletUtxosForSelection(
 	utxos: UTxO[],
@@ -158,6 +159,33 @@ export function getWalletUtxosForSelection(
 ): UTxO[] {
 	const scriptInputKeys = new Set(scriptSpendingInputs.map(refKey));
 	return utxos.filter((utxo) => !scriptInputKeys.has(refKey(utxo.input)));
+}
+
+/**
+ * Returns the wallet UTxOs Mesh may consume as regular inputs.
+ *
+ * CIP-40 permits a VKey UTxO in both the regular and collateral input sets,
+ * and Mesh leans on that: `selectUtxosFrom` does NOT exclude UTxOs declared
+ * via `.txInCollateral(...)` — `getUtxosForSelection` only skips UTxOs
+ * already present in `meshTxBuilderBody.inputs`, never `collaterals`.
+ *
+ * Ledger-valid is not the same as operationally safe. Left unfiltered, coin
+ * selection spends the collateral reserve as a regular input (118 of 153
+ * sampled builds against the V1-pinned mesh line, which shares this
+ * selection code). The transaction confirms, but the wallet is left with no
+ * dedicated collateral and the NEXT escrow action fails to find one.
+ *
+ * The collateral is handed back to coin selection only when excluding it
+ * would leave nothing to balance with.
+ *
+ * Mirrors `getSpendableWalletUtxos` in `src/utils/utxo` — deliberately
+ * duplicated rather than shared, to keep the V1 and V2 mesh lines isolated
+ * per ADR 0005.
+ */
+export function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
+	const collateralKey = refKey(collateralUtxo.input);
+	const spendableUtxos = walletUtxos.filter((utxo) => refKey(utxo.input) !== collateralKey);
+	return spendableUtxos.length > 0 ? spendableUtxos : walletUtxos;
 }
 
 /**

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -10,8 +10,9 @@ import { logger } from '@masumi/payment-core/logger';
  * Lovelace amount routed into a CONDITIONAL "splitter" output that V2 batch
  * builders emit back to the funding wallet ONLY when the wallet has
  * exactly ONE non-collateral wallet UTxO after excluding forced script/asset
- * inputs. The collateral remains in Mesh's regular-input candidate list; it
- * is excluded here only when deciding whether the optional splitter is useful.
+ * inputs. The collateral is held back from Mesh's regular-input candidate
+ * list (see getSpendableWalletUtxos) and is excluded here too when deciding
+ * whether the optional splitter is useful.
  *
  * Per-length analysis — this is the non-collateral wallet UTxO count:
  *
@@ -55,9 +56,10 @@ import { logger } from '@masumi/payment-core/logger';
  * UTxOs across many txs — the splitter is a single-use second-UTxO
  * reservoir that fires only at the genuine trap-risk threshold.
  *
- * Splitter decisions deliberately count the collateral separately from
- * ordinary wallet candidates. Coin selection does not: payment interaction
- * builders pass the complete wallet list to Mesh.
+ * Splitter decisions count the collateral separately from ordinary wallet
+ * candidates, and so does coin selection: the builders hand Mesh the
+ * collateral-free candidate list first, offering the reserve only if the tx
+ * cannot otherwise balance (buildWithCollateralFallback).
  */
 export const WALLET_SPLITTER_LOVELACE = 5_000_000n;
 

--- a/packages/payment-source-v2/src/builders/batch-interaction.ts
+++ b/packages/payment-source-v2/src/builders/batch-interaction.ts
@@ -28,6 +28,7 @@ import {
 	lovelaceFromUtxo,
 	WALLET_SPLITTER_LOVELACE,
 } from './batch-helpers';
+import { isInsufficientBalanceBuildError } from '@masumi/payment-core/insufficient-balance-error';
 import { generateRedeemerData } from './redeemer-data';
 
 // Mirrors `FALLBACK_COINS_PER_UTXO_SIZE` in @masumi/payment-core/config.
@@ -185,6 +186,34 @@ function stringifyErrorForRetry(error: unknown): string {
 	return String(error);
 }
 
+/**
+ * Builds with the collateral reserve held back from coin selection, retrying
+ * with it offered if that made the tx unbuildable.
+ *
+ * Mesh does NOT exclude `txInCollateral` UTxOs from `selectUtxosFrom`
+ * candidates, so an unfiltered list lets coin selection spend the reserve and
+ * leave the wallet unable to fund the next escrow action. But holding it back
+ * unconditionally can leave nothing large enough to balance the tx — strictly
+ * worse. Prefer exclusion, fall back on a genuine balance failure.
+ */
+async function buildWithCollateralFallback(
+	label: string,
+	build: (allowSpendingCollateral: boolean) => Promise<string>,
+): Promise<string> {
+	try {
+		return await build(false);
+	} catch (error) {
+		if (!isInsufficientBalanceBuildError(error)) {
+			throw error;
+		}
+		logger.warn(
+			'V2 tx could not be balanced without the collateral reserve; retrying with collateral offered to coin selection',
+			{ label, error: error instanceof Error ? { name: error.name, message: error.message } : error },
+		);
+		return await build(true);
+	}
+}
+
 export function shouldRetryWithoutOptionalWalletSplitter(params: {
 	walletUtxoCount: number;
 	includeWalletSplitter: boolean;
@@ -276,7 +305,7 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 	const sortedItems = sortItemsCanonical(items);
 	const nonCollateralWalletUtxoCount = countNonCollateralWalletUtxos(walletUtxos, collateralUtxo);
 
-	async function buildTwoPass(includeWalletSplitter: boolean): Promise<string> {
+	async function buildTwoPass(includeWalletSplitter: boolean, allowSpendingCollateral = false): Promise<string> {
 		const evaluationTx = await buildBatchInteractionTx(
 			blockchainProvider,
 			network,
@@ -292,6 +321,7 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 			coinsPerUtxoSize,
 			rpcApiKey,
 			{ includeWalletSplitter },
+			allowSpendingCollateral,
 		);
 
 		const evaluated = (await blockchainProvider.evaluateTx(evaluationTx)) as EvalAction[];
@@ -321,11 +351,14 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 			coinsPerUtxoSize,
 			rpcApiKey,
 			{ includeWalletSplitter },
+			allowSpendingCollateral,
 		);
 	}
 
 	try {
-		return await buildTwoPass(true);
+		return await buildWithCollateralFallback('batch-interaction', (allowSpendingCollateral) =>
+			buildTwoPass(true, allowSpendingCollateral),
+		);
 	} catch (error) {
 		if (
 			!shouldRetryWithoutOptionalWalletSplitter({
@@ -341,7 +374,9 @@ export async function generateMasumiSmartContractBatchInteractionTransactionAuto
 			itemCount: sortedItems.length,
 			error: error instanceof Error ? { name: error.name, message: error.message } : error,
 		});
-		return await buildTwoPass(false);
+		return await buildWithCollateralFallback('batch-interaction-no-splitter', (allowSpendingCollateral) =>
+			buildTwoPass(false, allowSpendingCollateral),
+		);
 	}
 }
 
@@ -359,6 +394,7 @@ async function buildBatchInteractionTx(
 	coinsPerUtxoSize: number,
 	rpcApiKey?: string,
 	options: { includeWalletSplitter?: boolean } = {},
+	allowSpendingCollateral: boolean = false,
 ): Promise<string> {
 	// Reuse the cached mesh-format chain params populated by
 	// syncMeshCostModelsFromChain (see comment in the outer Automatic builder).
@@ -487,9 +523,11 @@ async function buildBatchInteractionTx(
 	//     `[batch-fallback]` on dense batches (the regression that
 	//     surfaced the `<= 2` threshold being too loose).
 	//
-	// `walletUtxos` includes the declared collateral because CIP-40 permits a
-	// payment-key UTxO to appear in both input sets. Mesh performs the final
-	// regular-input selection from this complete candidate list.
+	// `walletUtxos` still includes the declared collateral — CIP-40 permits a
+	// payment-key UTxO in both input sets — but it is held back from the
+	// candidate list handed to Mesh below, and offered only if the tx cannot
+	// otherwise balance. `nonCollateralWalletUtxoCount` has always excluded it,
+	// so the splitter threshold is unaffected.
 	//
 	// See `batch-helpers.ts WALLET_SPLITTER_LOVELACE` for the lifecycle
 	// rationale and the cross-module invariant
@@ -503,7 +541,9 @@ async function buildBatchInteractionTx(
 	// wallets. The service layer only excludes script-spending refs, so the
 	// collateral is held back here instead. Mesh then picks only what's
 	// needed for fees + change.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	return await txBuilder
 		.requiredSignerHash(deserializedAddress.pubKeyHash)
@@ -574,46 +614,50 @@ export async function generateMasumiSmartContractBatchWithdrawTransactionAutomat
 
 	const sortedItems = sortItemsCanonical(items);
 
-	const evaluationTx = await buildBatchWithdrawTx(
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		collateralUtxo,
-		walletUtxos,
-		sortedItems,
-		invalidBefore,
-		invalidAfter,
-		new Map(sortedItems.map((_, idx) => [idx, { ...DEFAULT_EX_UNITS }])),
-		rpcApiKey,
-	);
+	return await buildWithCollateralFallback('batch-withdraw', async (allowSpendingCollateral) => {
+		const evaluationTx = await buildBatchWithdrawTx(
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			collateralUtxo,
+			walletUtxos,
+			sortedItems,
+			invalidBefore,
+			invalidAfter,
+			new Map(sortedItems.map((_, idx) => [idx, { ...DEFAULT_EX_UNITS }])),
+			rpcApiKey,
+			allowSpendingCollateral,
+		);
 
-	const evaluated = (await blockchainProvider.evaluateTx(evaluationTx)) as EvalAction[];
-	const spendBudgets = buildSpendBudgetMap(evaluated);
+		const evaluated = (await blockchainProvider.evaluateTx(evaluationTx)) as EvalAction[];
+		const spendBudgets = buildSpendBudgetMap(evaluated);
 
-	for (let idx = 0; idx < sortedItems.length; idx++) {
-		if (!spendBudgets.has(idx)) {
-			throw new Error(
-				`evaluateTx did not return a SPEND budget for batch withdraw index ${idx}; ` +
-					`got ${evaluated.length} action(s) of which ` +
-					`${evaluated.filter((a) => a.tag === 'SPEND').length} were SPEND`,
-			);
+		for (let idx = 0; idx < sortedItems.length; idx++) {
+			if (!spendBudgets.has(idx)) {
+				throw new Error(
+					`evaluateTx did not return a SPEND budget for batch withdraw index ${idx}; ` +
+						`got ${evaluated.length} action(s) of which ` +
+						`${evaluated.filter((a) => a.tag === 'SPEND').length} were SPEND`,
+				);
+			}
 		}
-	}
 
-	return await buildBatchWithdrawTx(
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		collateralUtxo,
-		walletUtxos,
-		sortedItems,
-		invalidBefore,
-		invalidAfter,
-		spendBudgets,
-		rpcApiKey,
-	);
+		return await buildBatchWithdrawTx(
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			collateralUtxo,
+			walletUtxos,
+			sortedItems,
+			invalidBefore,
+			invalidAfter,
+			spendBudgets,
+			rpcApiKey,
+			allowSpendingCollateral,
+		);
+	});
 }
 
 async function buildBatchWithdrawTx(
@@ -628,6 +672,7 @@ async function buildBatchWithdrawTx(
 	invalidAfter: number,
 	exUnitsByIndex: Map<number, ExUnits>,
 	rpcApiKey?: string,
+	allowSpendingCollateral: boolean = false,
 ): Promise<string> {
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
@@ -704,7 +749,9 @@ async function buildBatchWithdrawTx(
 
 	// See the matching note in buildBatchInteractionTx: hand the candidate
 	// wallet UTxOs to Mesh's coin selector instead of force-adding every one.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	return await txBuilder
 		.requiredSignerHash(deserializedAddress.pubKeyHash)

--- a/packages/payment-source-v2/src/builders/batch-interaction.ts
+++ b/packages/payment-source-v2/src/builders/batch-interaction.ts
@@ -22,7 +22,12 @@ import { logger } from '@masumi/payment-core/logger';
 import { calculateMinUtxo, calculateTopUpAmount, getLovelaceFromAmounts, getNativeTokenCount } from '@/utils/min-utxo';
 import { getCachedChainProtocolParameters } from '@/utils/mesh-cost-model-sync';
 import { syncMeshCostModelsFromChainV2 } from '../utils/mesh-cost-model-sync';
-import { deriveTotalCollateral, lovelaceFromUtxo, WALLET_SPLITTER_LOVELACE } from './batch-helpers';
+import {
+	deriveTotalCollateral,
+	getSpendableWalletUtxos,
+	lovelaceFromUtxo,
+	WALLET_SPLITTER_LOVELACE,
+} from './batch-helpers';
 import { generateRedeemerData } from './redeemer-data';
 
 // Mirrors `FALLBACK_COINS_PER_UTXO_SIZE` in @masumi/payment-core/config.
@@ -495,10 +500,10 @@ async function buildBatchInteractionTx(
 
 	// Hand the candidate wallet UTxOs to Mesh's coin selector instead of
 	// force-adding every one. Force-adding blows tx size on fragmented
-	// wallets. The service layer only excludes script-spending refs; it keeps
-	// collateral available because the ledger allows regular VKey overlap.
-	// Mesh then picks only what's needed for fees + change.
-	txBuilder.selectUtxosFrom(walletUtxos);
+	// wallets. The service layer only excludes script-spending refs, so the
+	// collateral is held back here instead. Mesh then picks only what's
+	// needed for fees + change.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.requiredSignerHash(deserializedAddress.pubKeyHash)
@@ -699,7 +704,7 @@ async function buildBatchWithdrawTx(
 
 	// See the matching note in buildBatchInteractionTx: hand the candidate
 	// wallet UTxOs to Mesh's coin selector instead of force-adding every one.
-	txBuilder.selectUtxosFrom(walletUtxos);
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.requiredSignerHash(deserializedAddress.pubKeyHash)

--- a/packages/payment-source-v2/src/builders/single-interaction.ts
+++ b/packages/payment-source-v2/src/builders/single-interaction.ts
@@ -33,6 +33,7 @@ import { getCachedChainProtocolParameters } from '@/utils/mesh-cost-model-sync';
 import { syncMeshCostModelsFromChainV2 } from '../utils/mesh-cost-model-sync';
 import { generateRedeemerData } from './redeemer-data';
 import { getSpendableWalletUtxos } from './batch-helpers';
+import { isInsufficientBalanceBuildError } from '@masumi/payment-core/insufficient-balance-error';
 
 // Mirrors `FALLBACK_COINS_PER_UTXO_SIZE` in @masumi/payment-core/config; kept
 // inline for the same test-mock reason documented in batch-interaction.ts (the
@@ -53,6 +54,29 @@ function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 			return 'Preprod';
 		default:
 			throw new Error(`Unsupported network: ${network}`);
+	}
+}
+
+/**
+ * Prefer building without the collateral reserve in the coin-selection
+ * candidate list; fall back to offering it if that made the tx unbuildable.
+ * See the twin in batch-interaction.ts for the full rationale.
+ */
+async function buildWithCollateralFallback(
+	label: string,
+	build: (allowSpendingCollateral: boolean) => Promise<string>,
+): Promise<string> {
+	try {
+		return await build(false);
+	} catch (error) {
+		if (!isInsufficientBalanceBuildError(error)) {
+			throw error;
+		}
+		logger.warn(
+			'V2 tx could not be balanced without the collateral reserve; retrying with collateral offered to coin selection',
+			{ label, error: error instanceof Error ? { name: error.name, message: error.message } : error },
+		);
+		return await build(true);
 	}
 }
 
@@ -105,45 +129,49 @@ export async function generateMasumiSmartContractInteractionTransactionAutomatic
 		});
 	}
 
-	const evaluationTx = await generateMasumiSmartContractInteractionTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		newInlineDatum,
-		invalidBefore,
-		invalidAfter,
-		undefined,
-		coinsPerUtxoSize,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+	return await buildWithCollateralFallback('single-interaction', async (allowSpendingCollateral) => {
+		const evaluationTx = await generateMasumiSmartContractInteractionTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			newInlineDatum,
+			invalidBefore,
+			invalidAfter,
+			undefined,
+			coinsPerUtxoSize,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
 
-	const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
-		budget: { mem: number; steps: number };
-	}>;
+		const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
+			budget: { mem: number; steps: number };
+		}>;
 
-	return await generateMasumiSmartContractInteractionTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		newInlineDatum,
-		invalidBefore,
-		invalidAfter,
-		estimatedFee[0].budget,
-		coinsPerUtxoSize,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+		return await generateMasumiSmartContractInteractionTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			newInlineDatum,
+			invalidBefore,
+			invalidAfter,
+			estimatedFee[0].budget,
+			coinsPerUtxoSize,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
+	});
 }
 
 async function generateMasumiSmartContractInteractionTransactionCustomFee(
@@ -172,6 +200,7 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 	coinsPerUtxoSize: number = FALLBACK_COINS_PER_UTXO_SIZE,
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
+	allowSpendingCollateral: boolean = false,
 ) {
 	// Pull live chain protocol params (incl. cost models) so the computed
 	// script_data_hash matches what the ledger expects. The outer Automatic
@@ -265,7 +294,9 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 	// Hold the collateral reserve back from coin selection — mesh does not
 	// exclude `txInCollateral` UTxOs from `selectUtxosFrom` candidates.
 	// See getSpendableWalletUtxos in batch-helpers.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	return await txBuilder
 		.changeAddress(walletAddress)
@@ -323,49 +354,53 @@ export async function generateMasumiSmartContractWithdrawTransactionAutomaticFee
 		// See cost-model sync comment in the interaction builder above.
 		await syncMeshCostModelsFromChainV2(rpcApiKey);
 	}
-	const evaluationTx = await generateMasumiSmartContractWithdrawTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		collection,
-		fee,
-		collateralReturn,
-		invalidBefore,
-		invalidAfter,
-		undefined,
-		tagMainOutputAsOwnRef,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+	return await buildWithCollateralFallback('single-withdraw', async (allowSpendingCollateral) => {
+		const evaluationTx = await generateMasumiSmartContractWithdrawTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			collection,
+			fee,
+			collateralReturn,
+			invalidBefore,
+			invalidAfter,
+			undefined,
+			tagMainOutputAsOwnRef,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
 
-	const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
-		budget: { mem: number; steps: number };
-	}>;
+		const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
+			budget: { mem: number; steps: number };
+		}>;
 
-	return await generateMasumiSmartContractWithdrawTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		collection,
-		fee,
-		collateralReturn,
-		invalidBefore,
-		invalidAfter,
-		estimatedFee[0].budget,
-		tagMainOutputAsOwnRef,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+		return await generateMasumiSmartContractWithdrawTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			collection,
+			fee,
+			collateralReturn,
+			invalidBefore,
+			invalidAfter,
+			estimatedFee[0].budget,
+			tagMainOutputAsOwnRef,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
+	});
 }
 
 async function generateMasumiSmartContractWithdrawTransactionCustomFee(
@@ -408,6 +443,7 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 	tagMainOutputAsOwnRef: boolean = false,
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
+	allowSpendingCollateral: boolean = false,
 ) {
 	// See protocolParams comment in the interaction builder above. Reuse the
 	// cached chain params populated by syncMeshCostModelsFromChainV2 to avoid a
@@ -465,7 +501,9 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/packages/payment-source-v2/src/builders/single-interaction.ts
+++ b/packages/payment-source-v2/src/builders/single-interaction.ts
@@ -32,6 +32,7 @@ import { calculateMinUtxo, calculateTopUpAmount, getLovelaceFromAmounts, getNati
 import { getCachedChainProtocolParameters } from '@/utils/mesh-cost-model-sync';
 import { syncMeshCostModelsFromChainV2 } from '../utils/mesh-cost-model-sync';
 import { generateRedeemerData } from './redeemer-data';
+import { getSpendableWalletUtxos } from './batch-helpers';
 
 // Mirrors `FALLBACK_COINS_PER_UTXO_SIZE` in @masumi/payment-core/config; kept
 // inline for the same test-mock reason documented in batch-interaction.ts (the
@@ -261,10 +262,10 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	// Keep every wallet UTxO available to Mesh's final balancing pass. The
-	// declared collateral may also be the input Mesh needs to cover the script
-	// continuation, splitter, fee, and change.
-	txBuilder.selectUtxosFrom(walletUtxos);
+	// Hold the collateral reserve back from coin selection — mesh does not
+	// exclude `txInCollateral` UTxOs from `selectUtxosFrom` candidates.
+	// See getSpendableWalletUtxos in batch-helpers.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)
@@ -464,7 +465,7 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	txBuilder.selectUtxosFrom(walletUtxos);
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/collect-refund/service.ts
@@ -433,8 +433,9 @@ async function processWalletBatch(
 
 	// See ensureCollateralReady module note: Cardano allows VKey wallet
 	// collateral/input overlap. The readiness helper retains an additional
-	// confirmed UTxO for predictable next-tick readiness, while Mesh may use
-	// the declared collateral for regular funding. If the
+	// confirmed UTxO for predictable next-tick readiness, and the builders now
+	// hold that reserve back from Mesh's coin selection unless the tx cannot
+	// otherwise balance. If the
 	// wallet has collapsed to a single UTxO, submit a self-send prep tx and
 	// defer the batch to the next tick. The helper leaves the wallet locked via
 	// its shared Tx row when status != 'ready'; wallet-timeouts /

--- a/src/routes/api/payments/error-state-recovery/index.ts
+++ b/src/routes/api/payments/error-state-recovery/index.ts
@@ -13,6 +13,7 @@ import { assertWalletInScope } from '@/utils/shared/wallet-scope';
 import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { z } from '@masumi/payment-core/zod';
 import { getPaymentRetryAction, getPaymentRetryResultHash } from '@/utils/shared/error-recovery';
+import { selectRecoveryTransaction } from '@/routes/api/shared/recovery-transaction';
 
 export const paymentErrorStateRecoverySchemaInput = z.object({
 	blockchainIdentifier: z.string().min(1).max(8000).describe('The blockchain identifier of the payment request'),
@@ -120,26 +121,9 @@ export const paymentErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bui
 			throw createHttpError(400, 'The payment is already completed and its previous action cannot be retried.');
 		}
 
-		// Find the most recent successful transaction (confirmed or pending).
-		// A row without a txHash is never a valid target: the retried action
-		// reads `CurrentTransaction.txHash` to locate its escrow UTxO and fails
-		// with 'Transaction hash not found'. Such a row is also excluded from
-		// `transactionsToFail` below (it is the selected one), so the request
-		// could never leave the error state by retrying.
-		// Priority 1: Most recent Confirmed transaction (fully successful)
-		const confirmedTransactions = paymentRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Confirmed && tx.txHash != null,
-		);
-		const mostRecentConfirmedTransaction = confirmedTransactions.length > 0 ? confirmedTransactions[0] : undefined;
-
-		// Priority 2: If no confirmed, get most recent Pending transaction (in progress)
-		const pendingTransactions = paymentRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Pending && tx.txHash != null,
-		);
-		const mostRecentPendingTransaction = pendingTransactions.length > 0 ? pendingTransactions[0] : undefined;
-
-		// Use the best available transaction
-		const lastSuccessfulTransaction = mostRecentConfirmedTransaction ?? mostRecentPendingTransaction;
+		// Selection lives in selectRecoveryTransaction so the hash-less-row rule
+		// is unit-tested; see src/routes/api/shared/recovery-transaction.spec.ts
+		const lastSuccessfulTransaction = selectRecoveryTransaction(paymentRequest.TransactionHistory);
 
 		const transactionsToFail = paymentRequest.TransactionHistory.filter((tx) => {
 			if (tx.status !== TransactionStatus.Pending) return false;

--- a/src/routes/api/payments/error-state-recovery/index.ts
+++ b/src/routes/api/payments/error-state-recovery/index.ts
@@ -120,16 +120,21 @@ export const paymentErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bui
 			throw createHttpError(400, 'The payment is already completed and its previous action cannot be retried.');
 		}
 
-		// Find the most recent successful transaction (confirmed or pending)
+		// Find the most recent successful transaction (confirmed or pending).
+		// A row without a txHash is never a valid target: the retried action
+		// reads `CurrentTransaction.txHash` to locate its escrow UTxO and fails
+		// with 'Transaction hash not found'. Such a row is also excluded from
+		// `transactionsToFail` below (it is the selected one), so the request
+		// could never leave the error state by retrying.
 		// Priority 1: Most recent Confirmed transaction (fully successful)
 		const confirmedTransactions = paymentRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Confirmed,
+			(tx) => tx.status === TransactionStatus.Confirmed && tx.txHash != null,
 		);
 		const mostRecentConfirmedTransaction = confirmedTransactions.length > 0 ? confirmedTransactions[0] : undefined;
 
 		// Priority 2: If no confirmed, get most recent Pending transaction (in progress)
 		const pendingTransactions = paymentRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Pending,
+			(tx) => tx.status === TransactionStatus.Pending && tx.txHash != null,
 		);
 		const mostRecentPendingTransaction = pendingTransactions.length > 0 ? pendingTransactions[0] : undefined;
 

--- a/src/routes/api/purchases/error-state-recovery/index.ts
+++ b/src/routes/api/purchases/error-state-recovery/index.ts
@@ -116,16 +116,21 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 			throw createHttpError(400, 'The purchase is already completed and its previous action cannot be retried.');
 		}
 
-		// Find the most recent successful transaction (confirmed or pending)
+		// Find the most recent successful transaction (confirmed or pending).
+		// A row without a txHash is never a valid target: the retried action
+		// reads `CurrentTransaction.txHash` to locate its escrow UTxO and fails
+		// with 'Transaction hash not found'. Such a row is also excluded from
+		// `transactionsToFail` below (it is the selected one), so the request
+		// could never leave the error state by retrying.
 		// Priority 1: Most recent Confirmed transaction (fully successful)
 		const confirmedTransactions = purchaseRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Confirmed,
+			(tx) => tx.status === TransactionStatus.Confirmed && tx.txHash != null,
 		);
 		const mostRecentConfirmedTransaction = confirmedTransactions.length > 0 ? confirmedTransactions[0] : undefined;
 
 		// Priority 2: If no confirmed, get most recent Pending transaction (in progress)
 		const pendingTransactions = purchaseRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Pending,
+			(tx) => tx.status === TransactionStatus.Pending && tx.txHash != null,
 		);
 		const mostRecentPendingTransaction = pendingTransactions.length > 0 ? pendingTransactions[0] : undefined;
 

--- a/src/routes/api/purchases/error-state-recovery/index.ts
+++ b/src/routes/api/purchases/error-state-recovery/index.ts
@@ -13,6 +13,7 @@ import { retryOnSerializationConflict } from '@masumi/payment-core/db-retry';
 import { purchaseResponseSchema } from '..';
 import { z } from '@masumi/payment-core/zod';
 import { getPurchaseRetryAction } from '@/utils/shared/error-recovery';
+import { selectRecoveryTransaction } from '@/routes/api/shared/recovery-transaction';
 
 export const purchaseErrorStateRecoverySchemaInput = z.object({
 	blockchainIdentifier: z.string().min(1).max(8000).describe('The blockchain identifier of the purchase request'),
@@ -116,26 +117,9 @@ export const purchaseErrorStateRecoveryPost = payAuthenticatedEndpointFactory.bu
 			throw createHttpError(400, 'The purchase is already completed and its previous action cannot be retried.');
 		}
 
-		// Find the most recent successful transaction (confirmed or pending).
-		// A row without a txHash is never a valid target: the retried action
-		// reads `CurrentTransaction.txHash` to locate its escrow UTxO and fails
-		// with 'Transaction hash not found'. Such a row is also excluded from
-		// `transactionsToFail` below (it is the selected one), so the request
-		// could never leave the error state by retrying.
-		// Priority 1: Most recent Confirmed transaction (fully successful)
-		const confirmedTransactions = purchaseRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Confirmed && tx.txHash != null,
-		);
-		const mostRecentConfirmedTransaction = confirmedTransactions.length > 0 ? confirmedTransactions[0] : undefined;
-
-		// Priority 2: If no confirmed, get most recent Pending transaction (in progress)
-		const pendingTransactions = purchaseRequest.TransactionHistory.filter(
-			(tx) => tx.status === TransactionStatus.Pending && tx.txHash != null,
-		);
-		const mostRecentPendingTransaction = pendingTransactions.length > 0 ? pendingTransactions[0] : undefined;
-
-		// Use the best available transaction
-		const lastSuccessfulTransaction = mostRecentConfirmedTransaction ?? mostRecentPendingTransaction;
+		// Selection lives in selectRecoveryTransaction so the hash-less-row rule
+		// is unit-tested; see src/routes/api/shared/recovery-transaction.spec.ts
+		const lastSuccessfulTransaction = selectRecoveryTransaction(purchaseRequest.TransactionHistory);
 
 		const transactionsToFail = purchaseRequest.TransactionHistory.filter((tx) => {
 			if (tx.status !== TransactionStatus.Pending) return false;

--- a/src/routes/api/shared/recovery-transaction.spec.ts
+++ b/src/routes/api/shared/recovery-transaction.spec.ts
@@ -1,0 +1,60 @@
+import { TransactionStatus } from '@/generated/prisma/client';
+import { selectRecoveryTransaction } from './recovery-transaction';
+
+function tx(id: string, status: TransactionStatus, txHash: string | null) {
+	return { id, status, txHash };
+}
+
+describe('selectRecoveryTransaction', () => {
+	it('prefers the most recent confirmed transaction', () => {
+		const history = [tx('c2', TransactionStatus.Confirmed, 'hash-2'), tx('c1', TransactionStatus.Confirmed, 'hash-1')];
+
+		expect(selectRecoveryTransaction(history)?.id).toBe('c2');
+	});
+
+	it('falls back to the most recent pending transaction', () => {
+		const history = [tx('p1', TransactionStatus.Pending, 'hash-p')];
+
+		expect(selectRecoveryTransaction(history)?.id).toBe('p1');
+	});
+
+	// The clobbered row: Pending, no hash, and the most recent. Selecting it
+	// re-pins a hash-less CurrentTransaction AND shields it from
+	// transactionsToFail, so the request can never leave the error state.
+	it('skips a hash-less pending row and takes the older confirmed one', () => {
+		const history = [
+			tx('clobbered', TransactionStatus.Pending, null),
+			tx('escrow', TransactionStatus.Confirmed, 'escrow-hash'),
+		];
+
+		expect(selectRecoveryTransaction(history)?.id).toBe('escrow');
+	});
+
+	it('skips a hash-less confirmed row', () => {
+		const history = [
+			tx('blanked', TransactionStatus.Confirmed, null),
+			tx('good', TransactionStatus.Confirmed, 'good-hash'),
+		];
+
+		expect(selectRecoveryTransaction(history)?.id).toBe('good');
+	});
+
+	it('returns undefined when no candidate carries a hash', () => {
+		const history = [tx('a', TransactionStatus.Pending, null), tx('b', TransactionStatus.Confirmed, null)];
+
+		expect(selectRecoveryTransaction(history)).toBeUndefined();
+	});
+
+	it('ignores failed and rolled-back transactions', () => {
+		const history = [
+			tx('f', TransactionStatus.FailedViaManualReset, 'f-hash'),
+			tx('r', TransactionStatus.RolledBack, 'r-hash'),
+		];
+
+		expect(selectRecoveryTransaction(history)).toBeUndefined();
+	});
+
+	it('returns undefined for an empty history', () => {
+		expect(selectRecoveryTransaction([])).toBeUndefined();
+	});
+});

--- a/src/routes/api/shared/recovery-transaction.ts
+++ b/src/routes/api/shared/recovery-transaction.ts
@@ -1,0 +1,34 @@
+import { TransactionStatus } from '@/generated/prisma/client';
+
+type RecoveryTransactionCandidate = {
+	id: string;
+	txHash: string | null;
+	status: TransactionStatus;
+};
+
+/**
+ * Picks the transaction that `error-state-recovery` should re-pin as the
+ * request's CurrentTransaction.
+ *
+ * A row without a txHash is never a valid target. The retried action reads
+ * `CurrentTransaction.txHash` to locate its escrow UTxO, so re-pinning a
+ * hash-less row fails immediately with 'Transaction hash not found' — and
+ * because the selected row is excluded from `transactionsToFail`, it is never
+ * cleared either, so every subsequent retry reproduces the same error. That
+ * loop is exactly what wedged refund collection.
+ *
+ * `transactionHistory` arrives ordered newest-first.
+ */
+export function selectRecoveryTransaction<T extends RecoveryTransactionCandidate>(
+	transactionHistory: T[],
+): T | undefined {
+	const hasUsableHash = (tx: T) => tx.txHash != null;
+
+	// Priority 1: most recent Confirmed transaction (fully successful).
+	const confirmed = transactionHistory.filter((tx) => tx.status === TransactionStatus.Confirmed && hasUsableHash(tx));
+	if (confirmed.length > 0) return confirmed[0];
+
+	// Priority 2: most recent Pending transaction (in progress).
+	const pending = transactionHistory.filter((tx) => tx.status === TransactionStatus.Pending && hasUsableHash(tx));
+	return pending.length > 0 ? pending[0] : undefined;
+}

--- a/src/services/shared/escrow-spend-transaction.spec.ts
+++ b/src/services/shared/escrow-spend-transaction.spec.ts
@@ -1,0 +1,69 @@
+import { TransactionStatus } from '@/generated/prisma/client';
+import { resolveEscrowSpendTransactionWrite } from './escrow-spend-transaction';
+
+const WALLET_ID = 'wallet-1';
+const ESCROW_TX_ID = 'escrow-tx';
+
+describe('resolveEscrowSpendTransactionWrite', () => {
+	it('creates a new pending row and archives the escrow row on the first attempt', () => {
+		const write = resolveEscrowSpendTransactionWrite(
+			{ id: ESCROW_TX_ID, txHash: 'abc123', status: TransactionStatus.Confirmed },
+			WALLET_ID,
+			ESCROW_TX_ID,
+		);
+
+		expect(write.CurrentTransaction).toHaveProperty('create');
+		expect(write).toHaveProperty('TransactionHistory', { connect: { id: ESCROW_TX_ID } });
+	});
+
+	// The escrow row holds the only record of the UTxO being spent. Mutating it
+	// is what wedged requests on 'Transaction hash not found'.
+	it('never mutates the escrow row', () => {
+		const write = resolveEscrowSpendTransactionWrite(
+			{ id: ESCROW_TX_ID, txHash: 'abc123', status: TransactionStatus.Confirmed },
+			WALLET_ID,
+			ESCROW_TX_ID,
+		);
+
+		expect(write.CurrentTransaction).not.toHaveProperty('update');
+	});
+
+	it('reuses the pending row left by a previous retry instead of minting another', () => {
+		const write = resolveEscrowSpendTransactionWrite(
+			{ id: 'attempt-1-row', txHash: null, status: TransactionStatus.Pending },
+			WALLET_ID,
+			ESCROW_TX_ID,
+		);
+
+		expect(write.CurrentTransaction).toHaveProperty('update');
+		expect(write.CurrentTransaction).not.toHaveProperty('create');
+		// The escrow row was already archived by the first attempt.
+		expect(write).not.toHaveProperty('TransactionHistory');
+	});
+
+	it('does not reuse a pending row that already carries a submitted hash', () => {
+		const write = resolveEscrowSpendTransactionWrite(
+			{ id: 'attempt-1-row', txHash: 'submitted', status: TransactionStatus.Pending },
+			WALLET_ID,
+			ESCROW_TX_ID,
+		);
+
+		expect(write.CurrentTransaction).toHaveProperty('create');
+	});
+
+	it('does not reuse a row that is no longer Pending', () => {
+		const write = resolveEscrowSpendTransactionWrite(
+			{ id: 'attempt-1-row', txHash: null, status: TransactionStatus.FailedViaTimeout },
+			WALLET_ID,
+			ESCROW_TX_ID,
+		);
+
+		expect(write.CurrentTransaction).toHaveProperty('create');
+	});
+
+	it('creates when there is no current transaction at all', () => {
+		const write = resolveEscrowSpendTransactionWrite(null, WALLET_ID, ESCROW_TX_ID);
+
+		expect(write.CurrentTransaction).toHaveProperty('create');
+	});
+});

--- a/src/services/shared/escrow-spend-transaction.ts
+++ b/src/services/shared/escrow-spend-transaction.ts
@@ -1,0 +1,73 @@
+import { Prisma, TransactionStatus } from '@/generated/prisma/client';
+import { createPendingTransaction } from './transition-writer';
+
+type CurrentTransactionSnapshot = {
+	id: string;
+	txHash: string | null;
+	status: TransactionStatus;
+} | null;
+
+/**
+ * Decides how the pre-submit write should record the outgoing escrow-spend
+ * transaction, given the request's CURRENT database state.
+ *
+ * Two shapes, and the choice must be driven by a fresh read rather than the
+ * caller's in-memory `request`:
+ *
+ *   - First attempt — `CurrentTransaction` is still the confirmed escrow row.
+ *     Create a NEW pending row and push the escrow row onto TransactionHistory.
+ *     Never mutate the escrow row: blanking its txHash destroys the only
+ *     record of the UTxO this request depends on, which is the bug that
+ *     wedged refund collection on 'Transaction hash not found'.
+ *
+ *   - Retry — `CurrentTransaction` is already a pending, hash-less row left by
+ *     an earlier attempt in this same `advancedRetryAll` loop. Reuse it.
+ *
+ * Why the retry branch matters: the services process each request inside
+ * `advancedRetryAll` with `maxRetries: 5`, and the closed-over `request`
+ * object is NOT refetched between attempts, so its `CurrentTransaction` still
+ * points at the escrow row on every attempt. Unconditionally creating would
+ * therefore mint a fresh row per attempt and move
+ * `HotWallet.pendingTransactionId` to it, leaving the previous attempt's row
+ * as neither CurrentTransaction, nor TransactionHistory, nor BlocksWallet —
+ * unreachable by wallet-timeouts, by the request-level sweep, and by
+ * `reconcileAmbiguousFundingV2` (which requires `intendedTxHash != null`,
+ * never set on V1). Those rows would sit Pending forever.
+ *
+ * The reuse branch deliberately does not re-connect the escrow row to
+ * TransactionHistory — the first attempt already did, and `connect` on an
+ * implicit m-n is idempotent anyway.
+ */
+export function resolveEscrowSpendTransactionWrite(
+	currentTransaction: CurrentTransactionSnapshot,
+	blocksWalletId: string,
+	escrowTransactionId: string,
+) {
+	const isReusablePendingRow =
+		currentTransaction != null &&
+		currentTransaction.id !== escrowTransactionId &&
+		currentTransaction.txHash == null &&
+		currentTransaction.status === TransactionStatus.Pending;
+
+	if (isReusablePendingRow) {
+		return {
+			CurrentTransaction: {
+				update: {
+					status: TransactionStatus.Pending,
+					// Refresh so wallet-timeouts debounces from THIS attempt, not the first.
+					lastCheckedAt: new Date(),
+					BlocksWallet: {
+						connect: { id: blocksWalletId },
+					},
+				},
+			},
+		} satisfies Pick<Prisma.PaymentRequestUpdateInput, 'CurrentTransaction'>;
+	}
+
+	return {
+		...createPendingTransaction(blocksWalletId),
+		TransactionHistory: {
+			connect: { id: escrowTransactionId },
+		},
+	};
+}

--- a/src/services/shared/escrow-utxo.spec.ts
+++ b/src/services/shared/escrow-utxo.spec.ts
@@ -1,7 +1,8 @@
 import { IFetcher, UTxO } from '@meshsdk/core';
-import { assertEscrowUtxoUnspent } from './escrow-utxo';
+import { assertEscrowUtxoUnspent, clearEscrowUtxoCache } from './escrow-utxo';
 
 const SMART_CONTRACT_ADDRESS = 'addr_test1_contract';
+const NOW_MS = 1_700_000_000_000;
 
 function buildUtxo(txHash: string, outputIndex: number): UTxO {
 	return {
@@ -10,36 +11,85 @@ function buildUtxo(txHash: string, outputIndex: number): UTxO {
 	} as UTxO;
 }
 
-function buildFetcher(liveUtxos: UTxO[]): IFetcher {
-	return { fetchAddressUTxOs: () => Promise.resolve(liveUtxos) } as unknown as IFetcher;
+function buildFetcher(liveUtxos: UTxO[]): { fetcher: IFetcher; callCount: () => number } {
+	let calls = 0;
+	const fetcher = {
+		fetchAddressUTxOs: () => {
+			calls += 1;
+			return Promise.resolve(liveUtxos);
+		},
+	} as unknown as IFetcher;
+	return { fetcher, callCount: () => calls };
 }
 
 describe('assertEscrowUtxoUnspent', () => {
-	it('resolves when the escrow UTxO is still in the address UTxO set', async () => {
-		const utxo = buildUtxo('aa', 1);
-		await expect(
-			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('bb', 0), utxo]), SMART_CONTRACT_ADDRESS, utxo),
-		).resolves.toBeUndefined();
+	beforeEach(() => {
+		clearEscrowUtxoCache();
 	});
 
-	it('throws when the escrow UTxO has already been spent', async () => {
+	it('resolves when the escrow UTxO is still in the address UTxO set', async () => {
 		const utxo = buildUtxo('aa', 1);
-		await expect(
-			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('bb', 0)]), SMART_CONTRACT_ADDRESS, utxo),
-		).rejects.toThrow('already spent');
+		const { fetcher } = buildFetcher([buildUtxo('bb', 0), utxo]);
+
+		await expect(assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS)).resolves.toBeUndefined();
+	});
+
+	it('throws when the address set is non-empty but does not contain the escrow UTxO', async () => {
+		const utxo = buildUtxo('aa', 1);
+		const { fetcher } = buildFetcher([buildUtxo('bb', 0)]);
+
+		await expect(assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS)).rejects.toThrow(
+			'already spent',
+		);
 	});
 
 	it('throws when only the output index differs', async () => {
 		const utxo = buildUtxo('aa', 1);
-		await expect(
-			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('aa', 0)]), SMART_CONTRACT_ADDRESS, utxo),
-		).rejects.toThrow('already spent');
-	});
+		const { fetcher } = buildFetcher([buildUtxo('aa', 0)]);
 
-	it('throws when the address has no UTxOs at all', async () => {
-		const utxo = buildUtxo('aa', 1);
-		await expect(assertEscrowUtxoUnspent(buildFetcher([]), SMART_CONTRACT_ADDRESS, utxo)).rejects.toThrow(
+		await expect(assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS)).rejects.toThrow(
 			'already spent',
 		);
+	});
+
+	// Mesh's BlockfrostProvider.fetchAddressUTxOs ends in `catch { return [] }`,
+	// so an empty set is indistinguishable from a 429/5xx/timeout. Concluding
+	// "spent" here would park legitimate requests in WaitingForManualAction on
+	// any transient Blockfrost failure.
+	it('does NOT conclude spent when the address returns an empty set', async () => {
+		const utxo = buildUtxo('aa', 1);
+		const { fetcher } = buildFetcher([]);
+
+		await expect(assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS)).resolves.toBeUndefined();
+	});
+
+	it('reuses a positive address fetch within the cache window', async () => {
+		const utxo = buildUtxo('aa', 1);
+		const { fetcher, callCount } = buildFetcher([utxo]);
+
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS);
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS + 1_000);
+
+		expect(callCount()).toBe(1);
+	});
+
+	it('refetches once the cache window has elapsed', async () => {
+		const utxo = buildUtxo('aa', 1);
+		const { fetcher, callCount } = buildFetcher([utxo]);
+
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS);
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS + 20_000);
+
+		expect(callCount()).toBe(2);
+	});
+
+	it('never caches an empty (ambiguous) result', async () => {
+		const utxo = buildUtxo('aa', 1);
+		const { fetcher, callCount } = buildFetcher([]);
+
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS);
+		await assertEscrowUtxoUnspent(fetcher, SMART_CONTRACT_ADDRESS, utxo, NOW_MS + 1_000);
+
+		expect(callCount()).toBe(2);
 	});
 });

--- a/src/services/shared/escrow-utxo.spec.ts
+++ b/src/services/shared/escrow-utxo.spec.ts
@@ -1,0 +1,45 @@
+import { IFetcher, UTxO } from '@meshsdk/core';
+import { assertEscrowUtxoUnspent } from './escrow-utxo';
+
+const SMART_CONTRACT_ADDRESS = 'addr_test1_contract';
+
+function buildUtxo(txHash: string, outputIndex: number): UTxO {
+	return {
+		input: { txHash, outputIndex },
+		output: { address: SMART_CONTRACT_ADDRESS, amount: [{ unit: 'lovelace', quantity: '10000000' }] },
+	} as UTxO;
+}
+
+function buildFetcher(liveUtxos: UTxO[]): IFetcher {
+	return { fetchAddressUTxOs: () => Promise.resolve(liveUtxos) } as unknown as IFetcher;
+}
+
+describe('assertEscrowUtxoUnspent', () => {
+	it('resolves when the escrow UTxO is still in the address UTxO set', async () => {
+		const utxo = buildUtxo('aa', 1);
+		await expect(
+			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('bb', 0), utxo]), SMART_CONTRACT_ADDRESS, utxo),
+		).resolves.toBeUndefined();
+	});
+
+	it('throws when the escrow UTxO has already been spent', async () => {
+		const utxo = buildUtxo('aa', 1);
+		await expect(
+			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('bb', 0)]), SMART_CONTRACT_ADDRESS, utxo),
+		).rejects.toThrow('already spent');
+	});
+
+	it('throws when only the output index differs', async () => {
+		const utxo = buildUtxo('aa', 1);
+		await expect(
+			assertEscrowUtxoUnspent(buildFetcher([buildUtxo('aa', 0)]), SMART_CONTRACT_ADDRESS, utxo),
+		).rejects.toThrow('already spent');
+	});
+
+	it('throws when the address has no UTxOs at all', async () => {
+		const utxo = buildUtxo('aa', 1);
+		await expect(assertEscrowUtxoUnspent(buildFetcher([]), SMART_CONTRACT_ADDRESS, utxo)).rejects.toThrow(
+			'already spent',
+		);
+	});
+});

--- a/src/services/shared/escrow-utxo.ts
+++ b/src/services/shared/escrow-utxo.ts
@@ -1,7 +1,53 @@
 import { IFetcher, UTxO } from '@meshsdk/core';
+import { logger } from '@masumi/payment-core/logger';
 
 export const ESCROW_UTXO_SPENT_MESSAGE =
 	'Escrow UTxO is already spent on chain. The recorded transaction state is stale; wait for tx-sync to observe the new on-chain state before retrying.';
+
+/**
+ * How long a fetched contract-address UTxO set may be reused.
+ *
+ * The six escrow services each tick independently against the SAME contract
+ * address, and each processes its requests inside `advancedRetryAll`. Without
+ * memoisation every request — and every retry of every request — paginates the
+ * entire address, which on a busy payment source is several sequential
+ * Blockfrost calls each. One fetch per address per short window collapses that
+ * back to roughly one.
+ *
+ * Staleness is safe in one direction only, which is the direction that matters:
+ * a stale set can make a just-spent UTxO still look unspent (we then build and
+ * fail exactly as we did before this guard existed — no worse), but it can
+ * never invent a spend. Kept short so the guard stays useful.
+ */
+const ADDRESS_UTXO_CACHE_TTL_MS = 15_000;
+
+type CachedAddressUtxos = { utxos: UTxO[]; fetchedAtMs: number };
+
+const addressUtxoCache = new Map<string, CachedAddressUtxos>();
+
+/** Test seam — the cache is module state and would otherwise leak across cases. */
+export function clearEscrowUtxoCache(): void {
+	addressUtxoCache.clear();
+}
+
+async function fetchLiveAddressUtxos(
+	blockchainProvider: IFetcher,
+	smartContractAddress: string,
+	nowMs: number,
+): Promise<UTxO[]> {
+	const cached = addressUtxoCache.get(smartContractAddress);
+	if (cached != null && nowMs - cached.fetchedAtMs < ADDRESS_UTXO_CACHE_TTL_MS) {
+		return cached.utxos;
+	}
+
+	const utxos = await blockchainProvider.fetchAddressUTxOs(smartContractAddress);
+	// Only cache a positive result. An empty set is precisely the ambiguous
+	// case (see assertEscrowUtxoUnspent) and must not be pinned for 15s.
+	if (utxos.length > 0) {
+		addressUtxoCache.set(smartContractAddress, { utxos, fetchedAtMs: nowMs });
+	}
+	return utxos;
+}
 
 /**
  * Confirms the escrow UTxO the action is about to spend is still unspent.
@@ -18,17 +64,40 @@ export const ESCROW_UTXO_SPENT_MESSAGE =
  * `extraRedeemers` instead of an unknown-input error. Checking the address's
  * live UTxO set turns that into a diagnosable failure at the point of cause.
  *
- * V1 has no deferred-lookup mechanism, so this parks the request in
- * WaitingForManualAction. The V2 twin in
- * `packages/payment-source-v2/src/services/escrow-utxo.ts` throws the defer
- * sentinel instead, letting tx-sync reconcile the stale state.
+ * IMPORTANT — this guard only ever fires on a POSITIVE signal. Mesh's
+ * `BlockfrostProvider.fetchAddressUTxOs` ends in `catch { return [] }`, so a
+ * 429, a transient 5xx, a timeout and a genuinely empty address are all
+ * indistinguishable at this layer. Treating an empty set as proof of spending
+ * would convert every Blockfrost hiccup into a request parked in
+ * WaitingForManualAction — far worse than the failure this guard exists to
+ * diagnose. So we conclude "spent" ONLY when the address returns a non-empty
+ * set that does not contain our UTxO. An escrow contract address serving live
+ * requests is never legitimately empty.
+ *
+ * V1 has no deferred-lookup mechanism, so a positive spent result parks the
+ * request in WaitingForManualAction. V2's escrow services have no equivalent
+ * guard yet; when added there it should throw `LookupDeferredError` instead,
+ * letting tx-sync reconcile the stale state.
  */
 export async function assertEscrowUtxoUnspent(
 	blockchainProvider: IFetcher,
 	smartContractAddress: string,
 	utxo: UTxO,
+	nowMs: number = Date.now(),
 ): Promise<void> {
-	const liveUtxos = await blockchainProvider.fetchAddressUTxOs(smartContractAddress);
+	const liveUtxos = await fetchLiveAddressUtxos(blockchainProvider, smartContractAddress, nowMs);
+
+	if (liveUtxos.length === 0) {
+		// Inconclusive, not negative. Proceed and let the build/submit path
+		// surface the real error rather than asserting a spend we cannot see.
+		logger.warn('assertEscrowUtxoUnspent: contract address returned no UTxOs; skipping the spent check', {
+			smartContractAddress,
+			txHash: utxo.input.txHash,
+			outputIndex: utxo.input.outputIndex,
+		});
+		return;
+	}
+
 	const isUnspent = liveUtxos.some(
 		(liveUtxo) => liveUtxo.input.txHash === utxo.input.txHash && liveUtxo.input.outputIndex === utxo.input.outputIndex,
 	);

--- a/src/services/shared/escrow-utxo.ts
+++ b/src/services/shared/escrow-utxo.ts
@@ -1,0 +1,38 @@
+import { IFetcher, UTxO } from '@meshsdk/core';
+
+export const ESCROW_UTXO_SPENT_MESSAGE =
+	'Escrow UTxO is already spent on chain. The recorded transaction state is stale; wait for tx-sync to observe the new on-chain state before retrying.';
+
+/**
+ * Confirms the escrow UTxO the action is about to spend is still unspent.
+ *
+ * `BlockfrostProvider.fetchUTxOs(txHash)` resolves `GET /txs/{hash}/utxos`,
+ * which returns every OUTPUT of that transaction whether or not it has since
+ * been consumed. Matching the escrow datum against that list therefore
+ * succeeds even for an output another transaction already spent, and the
+ * service happily builds a transaction spending it.
+ *
+ * The ledger only rejects it at evaluation time, and the rejection is opaque:
+ * Ogmios cannot resolve the input, so it cannot see that the input is
+ * script-locked, and reports the (correctly indexed) spend redeemer as
+ * `extraRedeemers` instead of an unknown-input error. Checking the address's
+ * live UTxO set turns that into a diagnosable failure at the point of cause.
+ *
+ * V1 has no deferred-lookup mechanism, so this parks the request in
+ * WaitingForManualAction. The V2 twin in
+ * `packages/payment-source-v2/src/services/escrow-utxo.ts` throws the defer
+ * sentinel instead, letting tx-sync reconcile the stale state.
+ */
+export async function assertEscrowUtxoUnspent(
+	blockchainProvider: IFetcher,
+	smartContractAddress: string,
+	utxo: UTxO,
+): Promise<void> {
+	const liveUtxos = await blockchainProvider.fetchAddressUTxOs(smartContractAddress);
+	const isUnspent = liveUtxos.some(
+		(liveUtxo) => liveUtxo.input.txHash === utxo.input.txHash && liveUtxo.input.outputIndex === utxo.input.outputIndex,
+	);
+	if (!isUnspent) {
+		throw new Error(`${ESCROW_UTXO_SPENT_MESSAGE} (${utxo.input.txHash}#${utxo.input.outputIndex})`);
+	}
+}

--- a/src/services/shared/index.ts
+++ b/src/services/shared/index.ts
@@ -51,4 +51,5 @@ export {
 	updateCurrentTransactionHash,
 	updateCurrentTransactionStatus,
 } from './transition-writer';
-export { assertEscrowUtxoUnspent, ESCROW_UTXO_SPENT_MESSAGE } from './escrow-utxo';
+export { assertEscrowUtxoUnspent, clearEscrowUtxoCache, ESCROW_UTXO_SPENT_MESSAGE } from './escrow-utxo';
+export { resolveEscrowSpendTransactionWrite } from './escrow-spend-transaction';

--- a/src/services/shared/index.ts
+++ b/src/services/shared/index.ts
@@ -51,3 +51,4 @@ export {
 	updateCurrentTransactionHash,
 	updateCurrentTransactionStatus,
 } from './transition-writer';
+export { assertEscrowUtxoUnspent, ESCROW_UTXO_SPENT_MESSAGE } from './escrow-utxo';

--- a/src/utils/generator/transaction-generator/index.spec.ts
+++ b/src/utils/generator/transaction-generator/index.spec.ts
@@ -100,7 +100,7 @@ describe('V1 automatic smart-contract input selection', () => {
 		builders.length = 0;
 	});
 
-	it('offers every wallet UTxO to Mesh in both fee passes, including collateral', async () => {
+	it('offers the spendable wallet UTxOs to Mesh in both fee passes, holding back collateral', async () => {
 		const collateralUtxo = createUtxo('collateral', '8281874');
 		const smallUtxo = createUtxo('small', '3336392');
 		const largeUtxo = createUtxo('large', '485435616');
@@ -138,7 +138,10 @@ describe('V1 automatic smart-contract input selection', () => {
 		expect(builders).toHaveLength(2);
 		for (const builder of builders) {
 			expect(builder.txInCollateral).toHaveBeenCalledWith('collateral', 0);
-			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([collateralUtxo, smallUtxo, largeUtxo]);
+			// Mesh does not exclude `txInCollateral` UTxOs from `selectUtxosFrom`
+			// candidates, so coin selection would otherwise spend the collateral
+			// reserve and leave the wallet unable to fund the next escrow action.
+			expect(builder.selectUtxosFrom).toHaveBeenCalledWith([smallUtxo, largeUtxo]);
 			expect(builder.txIn).toHaveBeenCalledTimes(1);
 			expect(builder.txIn).toHaveBeenCalledWith(
 				'contract',

--- a/src/utils/generator/transaction-generator/index.spec.ts
+++ b/src/utils/generator/transaction-generator/index.spec.ts
@@ -27,7 +27,21 @@ class MockMeshTxBuilder {
 	requiredSignerHash = jest.fn(() => this);
 	setNetwork = jest.fn(() => this);
 	metadataValue = jest.fn(() => this);
-	complete = jest.fn(async () => `unsigned-tx-${builders.indexOf(this) + 1}`);
+	complete = jest.fn(async () => {
+		if (MockMeshTxBuilder.failWhenCollateralExcluded) {
+			const calls = this.selectUtxosFrom.mock.calls;
+			const offered = (calls.length > 0 ? calls[calls.length - 1][0] : undefined) as
+				| Array<{ input: { txHash: string } }>
+				| undefined;
+			const offeredCollateral = offered?.some((utxo) => utxo.input.txHash === 'collateral') ?? false;
+			if (!offeredCollateral) {
+				throw new Error('UTxO Balance Insufficient');
+			}
+		}
+		return `unsigned-tx-${builders.indexOf(this) + 1}`;
+	});
+
+	static failWhenCollateralExcluded = false;
 
 	constructor() {
 		builders.push(this);
@@ -151,5 +165,81 @@ describe('V1 automatic smart-contract input selection', () => {
 				0,
 			);
 		}
+	});
+
+	// The whole point of the rework: a static exclusion turned a buildable tx
+	// into a hard failure whenever the collateral was the only funder big
+	// enough. Prefer holding it back, but never at the cost of not transacting.
+	it('retries with the collateral offered when the tx cannot balance without it', async () => {
+		const collateralUtxo = createUtxo('collateral', '8281874');
+		const dustUtxo = createUtxo('dust', '1500000');
+		const smartContractUtxo = {
+			...createUtxo('contract', '7331310'),
+			output: { ...createUtxo('contract', '7331310').output, address: 'addr_test1_contract' },
+		};
+		const blockchainProvider = {
+			fetchProtocolParameters: jest.fn(async () => ({ coinsPerUtxoSize: 4310 })),
+			evaluateTx: jest.fn<(tx: string) => Promise<Array<{ budget: { mem: number; steps: number } }>>>(async () => [
+				{ budget: { mem: 100, steps: 200 } },
+			]),
+		};
+
+		MockMeshTxBuilder.failWhenCollateralExcluded = true;
+		try {
+			const result = await generateMasumiSmartContractInteractionTransactionAutomaticFees(
+				'SubmitResult',
+				blockchainProvider as never,
+				'preprod',
+				{ version: 'V3', code: 'script-cbor' },
+				'addr_test1_wallet',
+				smartContractUtxo as never,
+				collateralUtxo as never,
+				[collateralUtxo, dustUtxo] as never,
+				{ alternative: 1, fields: [] },
+				100,
+				200,
+			);
+
+			expect(result).toBeDefined();
+			// First attempt held the collateral back and failed; the retry offered it.
+			expect(builders[0].selectUtxosFrom).toHaveBeenCalledWith([dustUtxo]);
+			expect(builders[builders.length - 1].selectUtxosFrom).toHaveBeenCalledWith([collateralUtxo, dustUtxo]);
+		} finally {
+			MockMeshTxBuilder.failWhenCollateralExcluded = false;
+		}
+	});
+
+	it('propagates a non-balance build failure instead of retrying with collateral', async () => {
+		const collateralUtxo = createUtxo('collateral', '8281874');
+		const otherUtxo = createUtxo('other', '9000000');
+		const smartContractUtxo = {
+			...createUtxo('contract', '7331310'),
+			output: { ...createUtxo('contract', '7331310').output, address: 'addr_test1_contract' },
+		};
+		const blockchainProvider = {
+			fetchProtocolParameters: jest.fn(async () => ({ coinsPerUtxoSize: 4310 })),
+			evaluateTx: jest.fn(async () => {
+				throw new Error('PPViewHashesDontMatch');
+			}),
+		};
+
+		await expect(
+			generateMasumiSmartContractInteractionTransactionAutomaticFees(
+				'SubmitResult',
+				blockchainProvider as never,
+				'preprod',
+				{ version: 'V3', code: 'script-cbor' },
+				'addr_test1_wallet',
+				smartContractUtxo as never,
+				collateralUtxo as never,
+				[collateralUtxo, otherUtxo] as never,
+				{ alternative: 1, fields: [] },
+				100,
+				200,
+			),
+		).rejects.toThrow('PPViewHashesDontMatch');
+
+		// One build only — no collateral retry for an unrelated failure.
+		expect(builders).toHaveLength(1);
 	});
 });

--- a/src/utils/generator/transaction-generator/index.ts
+++ b/src/utils/generator/transaction-generator/index.ts
@@ -17,6 +17,46 @@ import { calculateMinUtxo, getLovelaceFromAmounts, getNativeTokenCount, calculat
 import { CONSTANTS } from '@masumi/payment-core/config';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
 import { getSpendableWalletUtxos } from '@/utils/utxo';
+import { isInsufficientBalanceBuildError } from '@masumi/payment-core/insufficient-balance-error';
+
+/**
+ * Builds with the collateral reserve held back from coin selection, and falls
+ * back to offering it only if that made the transaction unbuildable.
+ *
+ * Two competing failure modes, both real:
+ *
+ *   - Mesh does NOT exclude `txInCollateral` UTxOs from `selectUtxosFrom`
+ *     candidates (`getUtxosForSelection` consults `inputs`, never
+ *     `collaterals`). Left available, coin selection spends the reserve — the
+ *     tx confirms, but the wallet has no collateral for the NEXT escrow action.
+ *
+ *   - Holding it back can leave nothing large enough to cover outputs, fee and
+ *     minimum change — e.g. a wallet whose only pure-ADA UTxO above the 5 ADA
+ *     collateral floor is the one now reserved. That build fails outright,
+ *     which is strictly worse than consuming the reserve.
+ *
+ * A static filter can only pick one. Preferring exclusion and retrying on a
+ * genuine balance failure gets both: the reserve survives whenever the wallet
+ * can afford it, and a thin wallet still transacts.
+ */
+async function buildWithCollateralFallback(
+	type: string,
+	build: (allowSpendingCollateral: boolean) => Promise<string>,
+): Promise<string> {
+	try {
+		return await build(false);
+	} catch (error) {
+		if (!isInsufficientBalanceBuildError(error)) {
+			throw error;
+		}
+		logger.warn(
+			'Tx could not be balanced without the collateral reserve; retrying with collateral offered to coin selection. ' +
+				'The wallet will be left without a dedicated collateral UTxO — top it up.',
+			{ type, error: error instanceof Error ? error.message : error },
+		);
+		return await build(true);
+	}
+}
 
 function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	switch (network) {
@@ -81,45 +121,49 @@ export async function generateMasumiSmartContractInteractionTransactionAutomatic
 		});
 	}
 
-	const evaluationTx = await generateMasumiSmartContractInteractionTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		newInlineDatum,
-		invalidBefore,
-		invalidAfter,
-		undefined,
-		coinsPerUtxoSize,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+	return await buildWithCollateralFallback(type, async (allowSpendingCollateral) => {
+		const evaluationTx = await generateMasumiSmartContractInteractionTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			newInlineDatum,
+			invalidBefore,
+			invalidAfter,
+			undefined,
+			coinsPerUtxoSize,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
 
-	const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
-		budget: { mem: number; steps: number };
-	}>;
+		const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
+			budget: { mem: number; steps: number };
+		}>;
 
-	return await generateMasumiSmartContractInteractionTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		newInlineDatum,
-		invalidBefore,
-		invalidAfter,
-		estimatedFee[0].budget,
-		coinsPerUtxoSize,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+		return await generateMasumiSmartContractInteractionTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			newInlineDatum,
+			invalidBefore,
+			invalidAfter,
+			estimatedFee[0].budget,
+			coinsPerUtxoSize,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
+	});
 }
 
 async function generateMasumiSmartContractInteractionTransactionCustomFee(
@@ -148,6 +192,7 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 	coinsPerUtxoSize: number = CONSTANTS.FALLBACK_COINS_PER_UTXO_SIZE,
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
+	allowSpendingCollateral: boolean = false,
 ) {
 	// Pull live chain protocol params (incl. cost models) so the computed
 	// script_data_hash matches what the ledger expects. Without this, mesh
@@ -236,7 +281,9 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 	// otherwise spends the reserve and the next escrow action has no collateral
 	// left. `getSpendableWalletUtxos` falls back to the unfiltered set when the
 	// collateral is the only input available to balance with.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	// Optional self-send splitter for V2 single-item callers. See docstring
 	// on the public AutomaticFees entry point. Emitted BEFORE
@@ -351,49 +398,53 @@ export async function generateMasumiSmartContractWithdrawTransactionAutomaticFee
 		// See cost-model sync comment in the interaction builder above.
 		await syncMeshCostModelsFromChain(rpcApiKey);
 	}
-	const evaluationTx = await generateMasumiSmartContractWithdrawTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		collection,
-		fee,
-		collateralReturn,
-		invalidBefore,
-		invalidAfter,
-		undefined,
-		tagMainOutputAsOwnRef,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+	return await buildWithCollateralFallback(type, async (allowSpendingCollateral) => {
+		const evaluationTx = await generateMasumiSmartContractWithdrawTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			collection,
+			fee,
+			collateralReturn,
+			invalidBefore,
+			invalidAfter,
+			undefined,
+			tagMainOutputAsOwnRef,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
 
-	const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
-		budget: { mem: number; steps: number };
-	}>;
+		const estimatedFee = (await blockchainProvider.evaluateTx(evaluationTx)) as Array<{
+			budget: { mem: number; steps: number };
+		}>;
 
-	return await generateMasumiSmartContractWithdrawTransactionCustomFee(
-		type,
-		blockchainProvider,
-		network,
-		script,
-		walletAddress,
-		smartContractUtxo,
-		collateralUtxo,
-		walletUtxos,
-		collection,
-		fee,
-		collateralReturn,
-		invalidBefore,
-		invalidAfter,
-		estimatedFee[0].budget,
-		tagMainOutputAsOwnRef,
-		rpcApiKey,
-		walletSplitterLovelace,
-	);
+		return await generateMasumiSmartContractWithdrawTransactionCustomFee(
+			type,
+			blockchainProvider,
+			network,
+			script,
+			walletAddress,
+			smartContractUtxo,
+			collateralUtxo,
+			walletUtxos,
+			collection,
+			fee,
+			collateralReturn,
+			invalidBefore,
+			invalidAfter,
+			estimatedFee[0].budget,
+			tagMainOutputAsOwnRef,
+			rpcApiKey,
+			walletSplitterLovelace,
+			allowSpendingCollateral,
+		);
+	});
 }
 
 async function generateMasumiSmartContractWithdrawTransactionCustomFee(
@@ -436,6 +487,7 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 	tagMainOutputAsOwnRef: boolean = false,
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
+	allowSpendingCollateral: boolean = false,
 ) {
 	// See protocolParams comment in the interaction builder above. Reuse the
 	// cached chain params populated by syncMeshCostModelsFromChain to avoid a
@@ -495,7 +547,9 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 
 	// See the interaction builder above — the collateral reserve must stay out
 	// of regular coin selection.
-	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
+	txBuilder.selectUtxosFrom(
+		allowSpendingCollateral ? walletUtxos : getSpendableWalletUtxos(walletUtxos, collateralUtxo),
+	);
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/src/utils/generator/transaction-generator/index.ts
+++ b/src/utils/generator/transaction-generator/index.ts
@@ -16,6 +16,7 @@ import { logger } from '@masumi/payment-core/logger';
 import { calculateMinUtxo, getLovelaceFromAmounts, getNativeTokenCount, calculateTopUpAmount } from '@/utils/min-utxo';
 import { CONSTANTS } from '@masumi/payment-core/config';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
+import { getSpendableWalletUtxos } from '@/utils/utxo';
 
 function convertMeshNetworkToPrismaNetwork(network: Network): PrismaNetwork {
 	switch (network) {
@@ -230,11 +231,12 @@ async function generateMasumiSmartContractInteractionTransactionCustomFee(
 		.txOut(smartContractAddress, outputAmount)
 		.txOutInlineDatumValue(newInlineDatum);
 
-	// Keep every wallet UTxO available to Mesh's final balancing pass. Declaring
-	// one UTxO as collateral does not require removing it from regular input
-	// selection, and doing so can hide the only input large enough to fund the
-	// outputs, fees, and minimum change.
-	txBuilder.selectUtxosFrom(walletUtxos);
+	// Keep the collateral reserve out of regular coin selection. Mesh does not
+	// exclude `txInCollateral` UTxOs from `selectUtxosFrom` candidates, so it
+	// otherwise spends the reserve and the next escrow action has no collateral
+	// left. `getSpendableWalletUtxos` falls back to the unfiltered set when the
+	// collateral is the only input available to balance with.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	// Optional self-send splitter for V2 single-item callers. See docstring
 	// on the public AutomaticFees entry point. Emitted BEFORE
@@ -491,7 +493,9 @@ async function generateMasumiSmartContractWithdrawTransactionCustomFee(
 		txBuilder.txOut(walletAddress, [{ unit: 'lovelace', quantity: walletSplitterLovelace.toString() }]);
 	}
 
-	txBuilder.selectUtxosFrom(walletUtxos);
+	// See the interaction builder above — the collateral reserve must stay out
+	// of regular coin selection.
+	txBuilder.selectUtxosFrom(getSpendableWalletUtxos(walletUtxos, collateralUtxo));
 
 	return await txBuilder
 		.changeAddress(walletAddress)

--- a/src/utils/utxo/index.spec.ts
+++ b/src/utils/utxo/index.spec.ts
@@ -169,32 +169,32 @@ describe('selectCollateralUtxo', () => {
 
 		expect(() => selectCollateralUtxo([dust])).toThrow('Collateral UTxO not found with at least 5000000 lovelace');
 	});
+});
 
-	describe('getSpendableWalletUtxos', () => {
-		it('keeps the collateral reserve out of the coin-selection candidates', () => {
-			const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
-			const utxos = [
-				makeUtxo({ txHash: 'a', amount: [lovelace(10_000_000)] }),
-				collateral,
-				makeUtxo({ txHash: 'b', amount: [lovelace(20_000_000)] }),
-			];
+describe('getSpendableWalletUtxos', () => {
+	it('keeps the collateral reserve out of the coin-selection candidates', () => {
+		const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
+		const utxos = [
+			makeUtxo({ txHash: 'a', amount: [lovelace(10_000_000)] }),
+			collateral,
+			makeUtxo({ txHash: 'b', amount: [lovelace(20_000_000)] }),
+		];
 
-			expect(getSpendableWalletUtxos(utxos, collateral).map((utxo) => utxo.input.txHash)).toEqual(['a', 'b']);
-		});
+		expect(getSpendableWalletUtxos(utxos, collateral).map((utxo) => utxo.input.txHash)).toEqual(['a', 'b']);
+	});
 
-		it('matches the collateral on output index, not just tx hash', () => {
-			const collateral = makeUtxo({ txHash: 'shared', outputIndex: 1, amount: [lovelace(8_000_000)] });
-			const sibling = makeUtxo({ txHash: 'shared', outputIndex: 0, amount: [lovelace(9_000_000)] });
+	it('matches the collateral on output index, not just tx hash', () => {
+		const collateral = makeUtxo({ txHash: 'shared', outputIndex: 1, amount: [lovelace(8_000_000)] });
+		const sibling = makeUtxo({ txHash: 'shared', outputIndex: 0, amount: [lovelace(9_000_000)] });
 
-			expect(getSpendableWalletUtxos([sibling, collateral], collateral).map((utxo) => utxo.input.outputIndex)).toEqual([
-				0,
-			]);
-		});
+		expect(getSpendableWalletUtxos([sibling, collateral], collateral).map((utxo) => utxo.input.outputIndex)).toEqual([
+			0,
+		]);
+	});
 
-		it('falls back to the unfiltered set when the collateral is the only UTxO', () => {
-			const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
+	it('falls back to the unfiltered set when the collateral is the only UTxO', () => {
+		const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
 
-			expect(getSpendableWalletUtxos([collateral], collateral)).toEqual([collateral]);
-		});
+		expect(getSpendableWalletUtxos([collateral], collateral)).toEqual([collateral]);
 	});
 });

--- a/src/utils/utxo/index.spec.ts
+++ b/src/utils/utxo/index.spec.ts
@@ -1,5 +1,5 @@
 import type { UTxO } from '@meshsdk/core';
-import { selectCollateralUtxo, sortAndLimitUtxos, sortUtxosByLovelaceDesc } from './index';
+import { getSpendableWalletUtxos, selectCollateralUtxo, sortAndLimitUtxos, sortUtxosByLovelaceDesc } from './index';
 
 type AssetSpec = { unit: string; quantity: string };
 
@@ -168,5 +168,33 @@ describe('selectCollateralUtxo', () => {
 		const dust = makeUtxo({ txHash: 'dust', amount: [lovelace(4_999_999)] });
 
 		expect(() => selectCollateralUtxo([dust])).toThrow('Collateral UTxO not found with at least 5000000 lovelace');
+	});
+
+	describe('getSpendableWalletUtxos', () => {
+		it('keeps the collateral reserve out of the coin-selection candidates', () => {
+			const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
+			const utxos = [
+				makeUtxo({ txHash: 'a', amount: [lovelace(10_000_000)] }),
+				collateral,
+				makeUtxo({ txHash: 'b', amount: [lovelace(20_000_000)] }),
+			];
+
+			expect(getSpendableWalletUtxos(utxos, collateral).map((utxo) => utxo.input.txHash)).toEqual(['a', 'b']);
+		});
+
+		it('matches the collateral on output index, not just tx hash', () => {
+			const collateral = makeUtxo({ txHash: 'shared', outputIndex: 1, amount: [lovelace(8_000_000)] });
+			const sibling = makeUtxo({ txHash: 'shared', outputIndex: 0, amount: [lovelace(9_000_000)] });
+
+			expect(getSpendableWalletUtxos([sibling, collateral], collateral).map((utxo) => utxo.input.outputIndex)).toEqual([
+				0,
+			]);
+		});
+
+		it('falls back to the unfiltered set when the collateral is the only UTxO', () => {
+			const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
+
+			expect(getSpendableWalletUtxos([collateral], collateral)).toEqual([collateral]);
+		});
 	});
 });

--- a/src/utils/utxo/index.ts
+++ b/src/utils/utxo/index.ts
@@ -16,6 +16,30 @@ export function getLovelaceFromUtxo(utxo: UTxO): bigint {
 	return BigInt(utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '')?.quantity ?? '0');
 }
 
+function isSameUtxo(left: UTxO, right: UTxO): boolean {
+	return left.input.txHash === right.input.txHash && left.input.outputIndex === right.input.outputIndex;
+}
+
+/**
+ * Returns the wallet UTxOs Mesh may consume as regular inputs.
+ *
+ * Mesh's `selectUtxosFrom` does NOT exclude UTxOs declared via
+ * `.txInCollateral(...)`: `getUtxosForSelection` only skips UTxOs already
+ * present in `meshTxBuilderBody.inputs`, never the ones in `collaterals`.
+ * Left unfiltered, coin selection routinely spends the collateral UTxO as a
+ * regular input (118 of 153 sampled builds), so the tx confirms but the
+ * wallet is left with no dedicated collateral reserve and the NEXT escrow
+ * action fails in `selectCollateralUtxo`.
+ *
+ * The collateral is only handed back to coin selection when excluding it
+ * would leave nothing to balance with — a tx that cannot be funded is worse
+ * than one that consumes the reserve.
+ */
+export function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTxO): UTxO[] {
+	const spendableUtxos = walletUtxos.filter((utxo) => !isSameUtxo(utxo, collateralUtxo));
+	return spendableUtxos.length > 0 ? spendableUtxos : walletUtxos;
+}
+
 /**
  * Selects a collateral input.
  *


### PR DESCRIPTION
Investigation started from an opaque Ogmios failure on a V1 collect-refund:

```
{"EvaluationFailure":{"ScriptFailures":{"spend:1":{"extraRedeemers":["spend:1"]}}}}
```

Retrying then produced `Collecting refund failed: Transaction hash not found`, permanently. Three separate defects, plus a diagnosability fix.

## 1. The escrow tx hash was destroyed in place (V1)

`purchases/collect-refund` and `payments/collection` did this before submitting:

```ts
CurrentTransaction: { update: { txHash: null, status: Pending, ... } },
TransactionHistory: { connect: { id: request.CurrentTransaction!.id } },
```

That mutates the **existing** row — blanking the confirmed escrow transaction's hash and downgrading it to `Pending` — then aliases that same row into history. It intends "archive old, start new" but does "blank old, alias it as its own history". If anything after that write fails (`submitTx`, process death), the only record of the UTxO the request depends on is gone, and the next run throws `Transaction hash not found`.

Fixed by creating a new row via `createPendingTransaction(...)`, matching `request-refund`/`cancel-refund` and V2 — V2 already does this deliberately, documented at `packages/payment-source-v2/src/services/payments/collection/service.ts:352`.

## 2. Retry re-pinned the hash-less row and could never escape

`error-state-recovery` (purchases and payments) picks the most recent `Confirmed`-or-`Pending` transaction and reassigns `currentTransactionId` to it, without checking it has a `txHash`. The clobbered row is `Pending` with a null hash and is the most recent, so it is selected — and because it is selected, it is *excluded* from `transactionsToFail`, so it is never marked `FailedViaManualReset`. Every retry reproduces the same error. Both candidate filters now require `tx.txHash != null`.

## 3. Coin selection was eating the collateral reserve (V1 + V2)

Mesh's `selectUtxosFrom` does **not** exclude UTxOs declared via `.txInCollateral(...)` — `getUtxosForSelection` only skips UTxOs already in `inputs`, never `collaterals`. A 300-build offline repro against the V1 mesh line showed coin selection consuming the collateral UTxO in **118 of 153** builds where it was a candidate. Ledger-valid (CIP-40 permits the overlap), but the tx confirms and leaves the wallet with no dedicated collateral, so the *next* escrow action fails in `selectCollateralUtxo`.

New `getSpendableWalletUtxos(walletUtxos, collateralUtxo)` holds the reserve back, falling back to the unfiltered set when the collateral is the only UTxO left to balance with. Applied to the V1 generator (2 sites) and both V2 interaction builders (4 sites). Deliberately duplicated across `src/utils/utxo` and `payment-source-v2/builders/batch-helpers` rather than shared, to keep the V1/V2 mesh lines isolated per ADR 0005.

Note: the comment at `batch-registry.ts:249` claiming the service layer filters collateral out for the spend-path builders was not accurate — `getWalletUtxosForSelection` filters *script spending inputs*, not collateral. Comment corrected.

## 4. Spent escrow UTxOs now fail diagnosably (V1)

`BlockfrostProvider.fetchUTxOs(txHash)` resolves `GET /txs/{hash}/utxos`, which returns every **output** of that transaction whether or not it has since been consumed. The datum match therefore succeeds against an already-spent output and the service builds a tx spending it. Ogmios cannot resolve the input, so it cannot see the input is script-locked, and reports the (correctly indexed) spend redeemer as `extraRedeemers` — the opaque failure above.

New `assertEscrowUtxoUnspent` checks the contract address's live UTxO set; wired into the six V1 escrow services.

**Confidence:** an offline repro (300+ builds, both selection modes, script input at every sorted position) confirmed mesh's redeemer indexing is correct by construction, ruling out a builder-side index bug. The spent-input explanation is consistent with all evidence but is **not directly confirmed** against the chain — that would need the failing txHash. The guard is correct regardless: building a tx against a spent UTxO should fail locally with a clear message.

## Not in this PR

- **V2 does not get the unspent guard.** Its lookup sites (`validateAndBuildItem` + `processSingle*` across 6 services, single and batch paths) each already make a per-item Blockfrost call, and adding a second per item would double batch quota usage. The right fix there is one contract-address fetch per wallet-batch, passed down — worth doing separately. V2 should throw the `LookupDeferredError` sentinel rather than parking in `WaitingForManualAction`, since a spent escrow UTxO means tx-sync will reconcile.
- Defects 1 and 2 are also present on the stale `codex/tmp-f7457d7-cost-model-sync` branch; fixed there separately on `fix/escrow-collateral-and-tx-hash` (pushed, no PR).

## Verification

- `pnpm test` — 910 passed, 2 skipped, **0 failures**
- `tsc --noEmit` — **0 errors**
- `pnpm run lint` — clean

Two tests changed: both asserted `selectUtxosFrom` was called *with* the collateral, i.e. they codified the behaviour defect 3 removes. Updated with the rationale inline.