### PR TITLE
chore(admin): redirect / to admin UI and soften mobile block

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,37 @@ cp .env.example .env            # then fill in DATABASE_URL, ENCRYPTION_KEY,
 pnpm run prisma:migrate:dev     # apply database migrations
 pnpm run prisma:seed            # seed initial data (admin key, payment source)
 
-pnpm run dev                    # start the API server
+pnpm run dev                    # start the API server on http://localhost:3001
 ```
 
-The admin dashboard is a separate Next.js app with its own install:
+Once the API server is up, open **<http://localhost:3001/>** — browser requests
+to `/` are redirected to the admin interface at `/admin/`. API clients, health
+probes and `curl` are unaffected: the redirect only fires for requests that
+actually ask for HTML.
+
+The admin interface served under `/admin/` is the **built** Next.js bundle
+(`frontend/dist`), so it only exists after the frontend has been built. To work
+on the dashboard itself, run it as its own dev server instead — that gives you
+hot reload on <http://localhost:3000/>:
 
 ```bash
 cd frontend
 pnpm install
-pnpm run dev
+pnpm run dev                    # http://localhost:3000
 ```
+
+In that mode the frontend needs to be told where the API lives, since the
+default `/api/v1` is same-origin and only resolves in production where the
+backend serves the built bundle. Point it at the running backend in
+`frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_PAYMENT_API_BASE_URL=http://localhost:3001/api/v1
+```
+
+The admin interface is designed for desktop. Narrow screens now show a
+dismissible warning rather than being blocked outright, but tables and dialogs
+are still cramped below ~1024px.
 
 Useful commands: `pnpm run test` (unit tests — always via pnpm, not bare
 `npx jest`), `pnpm run lint`, `pnpm run format`, `pnpm run typecheck`. See the

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -14,8 +14,6 @@ import { SidebarProvider } from '@/lib/contexts/SidebarContext';
 import { QueryProvider } from '@/lib/contexts/QueryProvider';
 import { AgentDetailsDialogProvider } from '@/lib/contexts/AgentDetailsDialogContext';
 import { Spinner } from '@/components/ui/spinner';
-import { Header } from '@/components/Header';
-import { Footer } from '@/components/Footer';
 import { RouteProgressBar } from '@/components/layout/RouteProgressBar';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -64,6 +62,7 @@ function ToastWrapper() {
 function ThemedApp({ Component, pageProps, router }: AppProps) {
   const [isHealthy, setIsHealthy] = useState<boolean | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+  const [isMobileWarningDismissed, setIsMobileWarningDismissed] = useState(false);
   const [mounted, setMounted] = useState(false);
   const {
     apiClient,
@@ -292,30 +291,38 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
     );
   }
 
-  if (isMobile) {
-    return (
-      <div className="min-h-screen flex flex-col">
-        <Header />
-        <div className="flex-1 flex items-center justify-center bg-background text-foreground">
-          <div className="text-center space-y-4 p-4">
-            <div className="text-lg text-muted-foreground">
-              Please use a desktop device to <br /> access the Masumi Admin Interface
-            </div>
-            <Button variant="muted">
-              <Link href="https://docs.masumi.io" target="_blank" rel="noopener noreferrer">
-                Learn more
-              </Link>
-            </Button>
-          </div>
-        </div>
-        <Footer />
-      </div>
-    );
-  }
-
   return (
     <>
       <RouteProgressBar />
+      {isMobile && !isMobileWarningDismissed && (
+        <div
+          role="status"
+          className="flex items-start gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-100"
+        >
+          <div className="flex-1">
+            The admin interface is designed for desktop. On a narrow screen some tables and dialogs
+            may be hard to use.{' '}
+            <Link
+              href="https://docs.masumi.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              Learn more
+            </Link>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="Dismiss small screen warning"
+            className="shrink-0 -my-1 text-amber-950/70 hover:bg-amber-100 hover:text-amber-950 dark:text-amber-100/70 dark:hover:bg-amber-900/30 dark:hover:text-amber-100"
+            onClick={() => setIsMobileWarningDismissed(true)}
+          >
+            Dismiss
+          </Button>
+        </div>
+      )}
       {apiKey ? (
         <AgentDetailsDialogProvider>
           <Component {...pageProps} />

--- a/src/app.ts
+++ b/src/app.ts
@@ -313,6 +313,26 @@ export async function startApp() {
 
 			//serve the static admin files
 			const adminDistDir = path.resolve(__dirname, 'frontend/dist');
+
+			// Land browsers on the admin interface instead of a bare 404.
+			//
+			// Deliberately matches on an EXPLICIT html media type rather than
+			// `req.accepts('html')`: the latter also matches the `Accept: */*`
+			// that curl, health probes and most API clients send, which would
+			// redirect them into a static HTML bundle they can't parse. Browsers
+			// always name `text/html` (or `application/xhtml+xml`) outright, so
+			// requiring it keeps the redirect to genuine navigations.
+			app.get('/', (req, res, next) => {
+				const wantsHtmlDocument =
+					req.accepts('html') === 'html' &&
+					/\b(?:text\/html|application\/xhtml\+xml)\b/i.test(req.headers.accept ?? '');
+
+				if (!wantsHtmlDocument) {
+					return next();
+				}
+				res.redirect(302, '/admin/');
+			});
+
 			app.use('/admin', express.static(adminDistDir));
 			app.use('/_next', express.static(path.join(adminDistDir, '_next')));
 			// Catch all routes for admin and serve the correct HTML file for each route


### PR DESCRIPTION
Three local-onboarding rough edges.

## 1. `/` returned a bare 404

Browser navigations to the server root now 302 to `/admin/`.

The check requires an **explicit** `text/html` (or `application/xhtml+xml`) in the Accept header rather than `req.accepts('html')`. That matters: `req.accepts('html')` also matches the `Accept: */*` that curl, health probes and most API clients send, which would have redirected them into a static HTML bundle they cannot parse. Browsers always name `text/html` outright.

Verified across cases:

| Request | Result |
|---|---|
| Chrome/Firefox/Safari Accept | 302 → `/admin/` |
| `curl` default (`*/*`) | unchanged (404) |
| no Accept header | unchanged |
| `application/json` | unchanged |
| `text/plain` | unchanged |
| `text/html;q=0` | unchanged |

## 2. Mobile hard-block softened

Screens under 1024px were blocked outright with "Please use a desktop device" — which also caught anyone on a small laptop window or a split-screen desktop. Replaced with a dismissible warning banner; the app renders either way.

## 3. README

Documents the local admin URL, that `/admin/` serves the **built** bundle (so the frontend needs its own dev server for hot reload), and the `NEXT_PUBLIC_PAYMENT_API_BASE_URL` wiring local dev requires — the default `/api/v1` is same-origin and only resolves in production where the backend serves the bundle.

## Verification

`pnpm run typecheck`, `pnpm run lint`, `pnpm test` (961 passed) and `pnpm -C frontend run build` all clean. Redirect behaviour tested directly against an Express instance with the exact handler.

## Review note

The banner is not verified in a live browser — it needs a running backend, so it is covered by typecheck and a clean production build only. Worth a reviewer glance at how it sits above `MainLayout` on a narrow viewport. Dismissal is component state rather than localStorage, so unlike `SetupV2Banner` / `X402SetupBanner` it returns after a full reload; happy to switch it to localStorage if you'd rather it match that idiom.