### PR TITLE
fix(wallets): stop projected balances from firing false low-balance alerts

### DIFF
--- a/src/services/wallets/low-balance/balance-map.ts
+++ b/src/services/wallets/low-balance/balance-map.ts
@@ -1,4 +1,5 @@
 import { Address, Transaction, Value } from '@emurgo/cardano-serialization-lib-nodejs';
+import type { Credential } from '@emurgo/cardano-serialization-lib-nodejs';
 import type { UTxO } from '@meshsdk/core';
 
 type BalanceMap = Map<string, bigint>;
@@ -120,6 +121,24 @@ function toBalanceMapFromCardanoValue(value: Value): BalanceMap {
 	return balanceMap;
 }
 
+function describePaymentCredential(credential: Credential | undefined): string | null {
+	if (credential == null) {
+		return null;
+	}
+
+	const keyHash = credential.to_keyhash();
+	if (keyHash != null) {
+		return `key:${keyHash.to_hex()}`;
+	}
+
+	const scriptHash = credential.to_scripthash();
+	return scriptHash == null ? null : `script:${scriptHash.to_hex()}`;
+}
+
+function getPaymentCredentialFromAddress(address: Address): string | null {
+	return describePaymentCredential(address.payment_cred());
+}
+
 function projectBalanceMapFromUnsignedTx(
 	walletAddress: string,
 	walletUtxos: ProjectableWalletUtxo[],
@@ -137,10 +156,27 @@ function projectBalanceMapFromUnsignedTx(
 		knownWalletInputs.set(referenceKey, toBalanceMapFromProjectableUtxo(utxo));
 	}
 
-	const walletAddressHex = Address.from_bech32(walletAddress).to_hex();
+	// Change is credited by payment credential rather than by the exact bech32 address:
+	// the address the caller knows about (the DB record or a freshly derived unused
+	// address) is not necessarily byte-identical to the one the transaction builder
+	// picked for change. Missing the change output would subtract the consumed inputs
+	// without adding anything back and report a wallet as empty while it is funded.
+	const walletCredential = getPaymentCredentialFromAddress(Address.from_bech32(walletAddress));
+	if (walletCredential == null) {
+		throw new Error(`Could not derive a payment credential for wallet address ${walletAddress}`);
+	}
+
 	const transaction = Transaction.from_bytes(Buffer.from(unsignedTx, 'hex'));
 	const transactionBody = transaction.body();
 	const inputs = transactionBody.inputs();
+
+	// Without the wallet UTXO set the consumed inputs cannot be identified, so the
+	// projection would only ever add change on top of the confirmed balance. Refuse to
+	// project instead of reporting a made-up balance; callers fall back to the
+	// confirmed balance.
+	if (walletUtxos.length === 0 && inputs.len() > 0) {
+		throw new Error('Cannot project the post-submission balance without the wallet UTXO set');
+	}
 
 	for (let inputIndex = 0; inputIndex < inputs.len(); inputIndex++) {
 		const input = inputs.get(inputIndex);
@@ -160,12 +196,21 @@ function projectBalanceMapFromUnsignedTx(
 	const outputs = transactionBody.outputs();
 	for (let outputIndex = 0; outputIndex < outputs.len(); outputIndex++) {
 		const output = outputs.get(outputIndex);
-		if (output.address().to_hex() !== walletAddressHex) {
+		if (getPaymentCredentialFromAddress(output.address()) !== walletCredential) {
 			continue;
 		}
 
 		for (const [assetUnit, quantity] of toBalanceMapFromCardanoValue(output.amount())) {
 			addQuantity(projectedBalanceMap, assetUnit, quantity);
+		}
+	}
+
+	// A projected balance below zero can only come from an inconsistent input set
+	// (for example a stale UTXO snapshot subtracted from a newer confirmed balance).
+	// Clamp instead of letting a negative amount trip the threshold comparison.
+	for (const [assetUnit, quantity] of projectedBalanceMap) {
+		if (quantity < 0n) {
+			projectedBalanceMap.set(assetUnit, 0n);
 		}
 	}
 

--- a/src/services/wallets/low-balance/service.spec.ts
+++ b/src/services/wallets/low-balance/service.spec.ts
@@ -143,6 +143,7 @@ let WalletLowBalanceMonitorService: typeof import('./service').WalletLowBalanceM
 let projectBalanceMapFromUnsignedTx: typeof import('./service').projectBalanceMapFromUnsignedTx;
 let Address: typeof import('@emurgo/cardano-serialization-lib-nodejs').Address;
 let BigNum: typeof import('@emurgo/cardano-serialization-lib-nodejs').BigNum;
+let EnterpriseAddress: typeof import('@emurgo/cardano-serialization-lib-nodejs').EnterpriseAddress;
 let Transaction: typeof import('@emurgo/cardano-serialization-lib-nodejs').Transaction;
 let TransactionBody: typeof import('@emurgo/cardano-serialization-lib-nodejs').TransactionBody;
 let TransactionHash: typeof import('@emurgo/cardano-serialization-lib-nodejs').TransactionHash;
@@ -165,6 +166,7 @@ describe('WalletLowBalanceMonitorService', () => {
 		({
 			Address,
 			BigNum,
+			EnterpriseAddress,
 			Transaction,
 			TransactionBody,
 			TransactionHash,
@@ -522,5 +524,85 @@ describe('WalletLowBalanceMonitorService', () => {
 
 		expect(projectedBalanceMap.get('lovelace')).toBe(3500000n);
 		expect(projectedBalanceMap.get('usdm')).toBe(1009494700n);
+	});
+
+	it('credits change returned to another address of the same payment credential', () => {
+		const txHash = '22'.repeat(32);
+		const inputs = TransactionInputs.new();
+		inputs.add(TransactionInput.new(TransactionHash.from_bytes(Buffer.from(txHash, 'hex')), 0));
+
+		// Same payment key hash as validWalletAddress, without the delegation part.
+		const walletAddress = Address.from_bech32(validWalletAddress);
+		const changeAddress = EnterpriseAddress.new(walletAddress.network_id(), walletAddress.payment_cred()!)
+			.to_address()
+			.to_bech32();
+
+		const outputs = TransactionOutputs.new();
+		outputs.add(TransactionOutput.new(Address.from_bech32(changeAddress), Value.new(BigNum.from_str('7000000'))));
+
+		const unsignedTx = Buffer.from(
+			Transaction.new(
+				TransactionBody.new(inputs, outputs, BigNum.from_str('1000000')),
+				TransactionWitnessSet.new(),
+				undefined,
+			).to_bytes(),
+		).toString('hex');
+
+		const projectedBalanceMap = projectBalanceMapFromUnsignedTx(
+			validWalletAddress,
+			[
+				{
+					input: { txHash, outputIndex: 0 },
+					output: {
+						amount: [
+							{ unit: 'lovelace', quantity: '8000000' },
+							{ unit: 'usdm', quantity: '656544700' },
+						],
+					},
+				},
+			],
+			unsignedTx,
+			new Map([
+				['lovelace', 8000000n],
+				['usdm', 656544700n],
+			]),
+		);
+
+		expect(projectedBalanceMap.get('lovelace')).toBe(7000000n);
+		expect(projectedBalanceMap.get('usdm')).toBe(0n);
+	});
+
+	it('refuses to project a spending transaction without the wallet UTXO set', async () => {
+		const txHash = '33'.repeat(32);
+		const inputs = TransactionInputs.new();
+		inputs.add(TransactionInput.new(TransactionHash.from_bytes(Buffer.from(txHash, 'hex')), 0));
+
+		const outputs = TransactionOutputs.new();
+		outputs.add(TransactionOutput.new(Address.from_bech32(otherAddress), Value.new(BigNum.from_str('3000000'))));
+
+		const unsignedTx = Buffer.from(
+			Transaction.new(
+				TransactionBody.new(inputs, outputs, BigNum.from_str('1000000')),
+				TransactionWitnessSet.new(),
+				undefined,
+			).to_bytes(),
+		).toString('hex');
+
+		mockHotWalletFindFirst.mockResolvedValueOnce(createWallet(LowBalanceStatus.Healthy));
+
+		await service.evaluateProjectedHotWalletById({
+			hotWalletId: 'wallet-1',
+			walletAddress: validWalletAddress,
+			walletUtxos: [],
+			unsignedTx,
+			checkSource: 'submission',
+			currentBalanceMap: new Map([['lovelace', 1289148400n]]),
+		});
+
+		expect(mockTriggerWalletLowBalance).not.toHaveBeenCalled();
+		expect(mockLoggerWarn).toHaveBeenCalledWith(
+			'Failed to project post-submission wallet balance, falling back to current balance monitoring',
+			expect.objectContaining({ wallet_id: 'wallet-1' }),
+		);
 	});
 });


### PR DESCRIPTION
## Problem

A mainnet purchasing wallet holding **1289 ADA + 656 USDM** fired `WALLET_LOW_BALANCE` reporting `13091181` lovelace and `0` USDM.

Verified against Blockfrost: `13091181` is exactly the lovelace of the change output in the transaction being submitted at that moment (`637375598f...`). The alert was evaluated against a projected post-submission balance that had lost the wallet's entire confirmed balance.

## Root cause

`projectBalanceMapFromUnsignedTx` in `src/services/wallets/low-balance/balance-map.ts` subtracts consumed inputs unconditionally but credits change back only on an **exact bech32 address match**:

```ts
if (output.address().to_hex() !== walletAddressHex) continue;
```

The address handed in is whatever the caller happens to hold — `session.address` from `generateWalletExtended` (a freshly derived unused address) or the DB `walletAddress` — while the confirmed balance map is keyed off the DB record. Any divergence, including an enterprise vs. base address for the same key, silently drops the change output.

Second hole: the projection runs even when `walletUtxos` is empty. Mesh's `BlockfrostProvider.fetchAddressUTxOs` swallows provider errors and returns `[]`, so a transient Blockfrost blip produces a projection with nothing to subtract and a fabricated balance.

Either path leaves `confirmed − inputs` with no change added back, so a funded wallet reads as near-empty and the alert fires.

## Scope

Both V1 and V2 payment sources route submissions through `loadHotWalletSession` → `evaluateProjectedHotWalletById` → `projectBalanceMapFromUnsignedTx`, plus the swap service and both batch-payment services. One shared function, so one fix covers all of them.

## Fix

- Credit change outputs by **payment credential** instead of the full address.
- **Refuse to project** a spending transaction with no wallet UTXO set — throws, and the existing catch falls back to the confirmed balance.
- Clamp negative projections to zero so an inconsistent input set cannot trip the threshold comparison.

## Testing

- `pnpm test src/services/wallets/low-balance/` — 19 pass
- `pnpm test src/services/shared/` — 31 pass
- `tsc --noEmit` and eslint clean
- Two new regression tests, both verified to **fail** without the fix: change credited to another address of the same payment credential, and refusal to project without the UTXO set.