### PR TITLE
fix(collateral): unify selection across rails and size token-bearing returns

### DIFF
--- a/packages/payment-source-v1/src/services/registry-inbox/deregister/service.ts
+++ b/packages/payment-source-v1/src/services/registry-inbox/deregister/service.ts
@@ -10,7 +10,7 @@ import { advancedRetry, delayErrorResolver, RetryResult } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { extractAssetName } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { pickCollateralUtxo, sortAndLimitUtxos } from '@/utils/utxo';
 import {
 	createMeshProvider,
 	createPendingTransaction,
@@ -120,7 +120,11 @@ export async function deRegisterInboxAgentV1() {
 
 						const tokenUtxo = findRegistryTokenUtxo(utxos, deregistrationRequest.agentIdentifier);
 						const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-						const collateralUtxo = limitedFilteredUtxos[0];
+						// Rank within the same pool the builder spends from, so the collateral
+						// keeps its existing relationship to the inputs while still preferring a
+						// pure-ADA, smallest-qualifying, deterministically-ordered UTxO. Falls
+						// back to the previous behaviour when nothing clears the 5 ADA floor.
+						const collateralUtxo = pickCollateralUtxo(limitedFilteredUtxos) ?? limitedFilteredUtxos[0];
 						if (collateralUtxo == null) {
 							throw new Error('Collateral UTXO not found');
 						}

--- a/packages/payment-source-v1/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v1/src/services/registry/deregister/service.ts
@@ -10,7 +10,7 @@ import { advancedRetry, delayErrorResolver, RetryResult } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { extractAssetName } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { pickCollateralUtxo, sortAndLimitUtxos } from '@/utils/utxo';
 import {
 	createMeshProvider,
 	createPendingTransaction,
@@ -113,7 +113,11 @@ export async function deRegisterAgentV1() {
 
 						const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
 						const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-						const collateralUtxo = limitedFilteredUtxos[0];
+						// Rank within the same pool the builder spends from, so the collateral
+						// keeps its existing relationship to the inputs while still preferring a
+						// pure-ADA, smallest-qualifying, deterministically-ordered UTxO. Falls
+						// back to the previous behaviour when nothing clears the 5 ADA floor.
+						const collateralUtxo = pickCollateralUtxo(limitedFilteredUtxos) ?? limitedFilteredUtxos[0];
 						if (collateralUtxo == null) {
 							throw new Error('Collateral UTXO not found');
 						}

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -4,7 +4,12 @@
 // one — kept consistent with the rest of the V2 builders. See
 // docs/adr/0005-meshsdk-version-pinning-v1-v2.md.
 import type { UTxO } from '@meshsdk/core';
-import { logger } from '@masumi/payment-core/logger';
+// Shared with the V1 rail on purpose. Unlike `getSpendableWalletUtxos` below
+// — duplicated to keep the mesh lines isolated — the collateral RANKING must
+// be identical on both rails, and `@/utils/utxo` carries no mesh runtime
+// (it imports `UTxO` as a type only), so importing it cannot collapse this
+// package onto the V1 mesh line. See the note at the top of that file.
+import { pickCollateralUtxo } from '@/utils/utxo';
 
 /**
  * Lovelace amount routed into a CONDITIONAL "splitter" output that V2 batch
@@ -110,38 +115,6 @@ export function intersectTxWindows(windows: TxWindowBounds[]): TxWindowBounds | 
 	return { invalidBefore, invalidAfter };
 }
 
-/** Internal helper: read the lovelace quantity from a UTxO's asset list. */
-function getLovelace(utxo: UTxO): bigint {
-	const lovelaceAsset = utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '');
-	if (lovelaceAsset == null) return 0n;
-	try {
-		return BigInt(lovelaceAsset.quantity);
-	} catch (parseError) {
-		// A malformed `quantity` string here means blockfrost returned data that
-		// violates our expectations; previously we silently treated the UTxO as
-		// zero-lovelace, which made it look like an invalid collateral
-		// candidate (it got skipped) without any diagnostic. Log loudly so an
-		// operator can investigate; still return 0n so the helper stays total.
-		logger.warn('getLovelace: malformed quantity string on UTxO; treating as 0 [batch-helpers]', {
-			txHash: utxo.input.txHash,
-			outputIndex: utxo.input.outputIndex,
-			rawQuantity: lovelaceAsset.quantity,
-			error: parseError instanceof Error ? parseError.message : parseError,
-		});
-		return 0n;
-	}
-}
-
-/** Internal helper: true iff the UTxO holds only the implicit lovelace asset. */
-function isPureLovelace(utxo: UTxO): boolean {
-	const amount = utxo.output.amount;
-	if (amount.length === 0) return false;
-	for (const asset of amount) {
-		if (asset.unit !== 'lovelace' && asset.unit !== '') return false;
-	}
-	return true;
-}
-
 /** Canonical reference string for a UTxO — must match the format the builders use. */
 function refKey(input: { txHash: string; outputIndex: number }): string {
 	return `${input.txHash}#${input.outputIndex}`;
@@ -193,14 +166,15 @@ export function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTx
 /**
  * Pick a collateral UTxO that is NOT also a script spending input.
  *
- * Preference order:
- *   1. Pure-ADA UTxO, smallest qualifying first — avoids burning a fat UTxO
- *      as collateral and avoids the collateral-return-output overhead that
- *      kicks in for native-token collateral.
- *   2. Native-token-carrying UTxO, smallest qualifying first — fallback when
- *      the wallet has no pure-ADA candidate (typical of selling/purchasing
- *      wallets that have accumulated NFT registration tokens). Mesh-SDK
- *      auto-emits a `collateral_return_output` in this case.
+ * Ordering is defined once, in `rankCollateralCandidates` (`@/utils/utxo`),
+ * and shared by every rail and action: pure-ADA first, then smallest
+ * qualifying lovelace, then `txHash#index` as a deterministic tie-break.
+ *
+ * A native-token-carrying UTxO is a perfectly valid collateral, not a
+ * degraded fallback: Babbage/CIP-40 permits it and the builder's
+ * `setTotalCollateral` declaration makes Mesh emit the `collateral_return`
+ * output that carries the balance back. Pure ADA is merely preferred because
+ * it keeps that return output smaller.
  *
  * The `requiredLovelace` floor accounts for Conway's `collateralPercentage`
  * (typically 150) applied to `sum_of_redeemer_fees`. For batches with N
@@ -235,41 +209,11 @@ export function pickBatchCollateral(
 	excludeSpendingInputs: Array<{ txHash: string; outputIndex: number }>,
 	requiredLovelace: bigint = 5_000_000n,
 ): UTxO | null {
-	const excludeKeys = new Set<string>();
-	for (const ref of excludeSpendingInputs) {
-		excludeKeys.add(refKey(ref));
-	}
-
-	const pureCandidates: Array<{ utxo: UTxO; lovelace: bigint }> = [];
-	const mixedCandidates: Array<{ utxo: UTxO; lovelace: bigint }> = [];
-	for (const utxo of utxos) {
-		if (excludeKeys.has(refKey(utxo.input))) continue;
-		const lovelace = getLovelace(utxo);
-		if (lovelace < requiredLovelace) continue;
-		if (isPureLovelace(utxo)) {
-			pureCandidates.push({ utxo, lovelace });
-		} else {
-			mixedCandidates.push({ utxo, lovelace });
-		}
-	}
-
-	// Prefer pure-ADA; fall back to native-token UTxOs only when the wallet
-	// has none. Within each group, pick the smallest qualifying UTxO so we
-	// don't burn a fat one as collateral.
-	const ascending = (a: { lovelace: bigint }, b: { lovelace: bigint }): number => {
-		if (a.lovelace < b.lovelace) return -1;
-		if (a.lovelace > b.lovelace) return 1;
-		return 0;
-	};
-	if (pureCandidates.length > 0) {
-		pureCandidates.sort(ascending);
-		return pureCandidates[0].utxo;
-	}
-	if (mixedCandidates.length > 0) {
-		mixedCandidates.sort(ascending);
-		return mixedCandidates[0].utxo;
-	}
-	return null;
+	// Delegates to the shared selector so the batch builders, the single-action
+	// builders and the registry paths all rank collateral identically. The
+	// previous local copy differed subtly (no deterministic tie-break), which
+	// let two equal-sized UTxOs swap places between builds.
+	return pickCollateralUtxo(utxos, requiredLovelace, excludeSpendingInputs);
 }
 
 /**
@@ -507,9 +451,41 @@ export const MIN_TOTAL_COLLATERAL_LOVELACE = 3_000_000n;
  * Min-ADA headroom kept aside on the collateral input when clamping declared
  * total collateral, so the resulting collateral-return output still satisfies
  * the ledger's min-UTxO rule. 1 ADA comfortably exceeds the min-ADA of a
- * pure-ADA output at current `coinsPerUtxoSize`.
+ * PURE-ADA output at current `coinsPerUtxoSize`.
  */
 export const COLLATERAL_RETURN_MIN_LOVELACE = 1_000_000n;
+
+/**
+ * Extra min-ADA headroom per distinct native asset carried by the collateral.
+ *
+ * Mesh's collateral return carries the FULL value of the collateral input,
+ * tokens included (verified against both pinned mesh lines: `addCollateralReturn`
+ * merges `toValue(collateral.txIn.amount)` into the return). Each distinct
+ * asset therefore grows the return output, and the ledger's
+ * `(160 + outputSize) * coinsPerUtxoByte` floor grows with it — while Mesh
+ * never min-ADA-checks the collateral return itself (`sanitizeOutputs` only
+ * walks `meshTxBuilderBody.outputs`).
+ *
+ * A flat 1 ADA floor is therefore only correct for pure-ADA collateral. Sized
+ * generously: ~50 bytes per asset at `coinsPerUtxoSize` 4310 is ~215k lovelace,
+ * so 350k leaves margin without meaningfully reducing declarable collateral.
+ */
+export const COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET = 350_000n;
+
+/** Distinct native (non-lovelace) assets carried by a UTxO. */
+export function nativeAssetCount(utxo: UTxO): number {
+	return utxo.output.amount.filter((asset) => asset.unit !== 'lovelace' && asset.unit !== '').length;
+}
+
+/**
+ * Min-ADA to reserve for the collateral-return output, given how many native
+ * assets the collateral input carries. Pure-ADA collateral keeps the original
+ * 1 ADA floor.
+ */
+export function collateralReturnMinLovelace(assetCount: number): bigint {
+	if (assetCount <= 0) return COLLATERAL_RETURN_MIN_LOVELACE;
+	return COLLATERAL_RETURN_MIN_LOVELACE + BigInt(assetCount) * COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET;
+}
 
 /**
  * Shape we accept from any of mesh's `Protocol`, the V1 helper's cached
@@ -563,6 +539,7 @@ export function deriveTotalCollateral(
 	budgets: Array<{ mem: number; steps: number }>,
 	protocolParameters: unknown,
 	collateralCapLovelace?: bigint,
+	collateralNativeAssetCount: number = 0,
 ): string {
 	const params = extractCollateralProtocolParams(protocolParameters);
 	if (params == null) {
@@ -579,8 +556,12 @@ export function deriveTotalCollateral(
 	// single-item fallback for any batch of ~4+ legs. Cap to the input value
 	// (leaving a min-ADA collateral-return) so the evaluation build succeeds; the
 	// second pass uses real, far smaller budgets that stay well under the cap.
-	if (collateralCapLovelace != null && collateralCapLovelace > COLLATERAL_RETURN_MIN_LOVELACE) {
-		const cap = collateralCapLovelace - COLLATERAL_RETURN_MIN_LOVELACE;
+	// The reserved headroom scales with the collateral's native assets: mesh
+	// copies them into the collateral return, so a token-bearing return needs
+	// more min-ADA than a pure-ADA one.
+	const returnMinLovelace = collateralReturnMinLovelace(collateralNativeAssetCount);
+	if (collateralCapLovelace != null && collateralCapLovelace > returnMinLovelace) {
+		const cap = collateralCapLovelace - returnMinLovelace;
 		if (cap >= MIN_TOTAL_COLLATERAL_LOVELACE && total > cap) {
 			total = cap;
 		}

--- a/packages/payment-source-v2/src/builders/batch-interaction.ts
+++ b/packages/payment-source-v2/src/builders/batch-interaction.ts
@@ -26,6 +26,7 @@ import {
 	deriveTotalCollateral,
 	getSpendableWalletUtxos,
 	lovelaceFromUtxo,
+	nativeAssetCount,
 	WALLET_SPLITTER_LOVELACE,
 } from './batch-helpers';
 import { isInsufficientBalanceBuildError } from '@masumi/payment-core/insufficient-balance-error';
@@ -453,6 +454,7 @@ async function buildBatchInteractionTx(
 		Array.from(exUnitsByIndex.values()),
 		protocolParameters,
 		lovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
 	);
 	txBuilder
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
@@ -708,6 +710,7 @@ async function buildBatchWithdrawTx(
 		Array.from(exUnitsByIndex.values()),
 		protocolParameters,
 		lovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
 	);
 	txBuilder
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)

--- a/packages/payment-source-v2/src/builders/batch-registry.ts
+++ b/packages/payment-source-v2/src/builders/batch-registry.ts
@@ -15,6 +15,7 @@ import { SERVICE_CONSTANTS } from '@masumi/payment-core/config';
 import { logger } from '@masumi/payment-core/logger';
 import { getCachedChainProtocolParameters } from '@/utils/mesh-cost-model-sync';
 import { syncMeshCostModelsFromChainV2 } from '../utils/mesh-cost-model-sync';
+import { nativeAssetCount } from './batch-helpers';
 import { deriveTotalCollateral, lovelaceFromUtxo, WALLET_SPLITTER_LOVELACE } from './batch-helpers';
 
 // V2 mint contract `Action` enum: MintAction=0, UpdateAction=1, BurnAction=2.
@@ -269,7 +270,12 @@ export async function generateRegistryBatchMintTransaction(
 	// budget. `exUnits` is either the default (first pass) or the chain-
 	// evaluated MINT budget from `evaluateTx` (subsequent calls). See
 	// `deriveTotalCollateral` for the math.
-	const totalCollateral = deriveTotalCollateral([exUnits], protocolParameters, lovelaceFromUtxo(collateralUtxo));
+	const totalCollateral = deriveTotalCollateral(
+		[exUnits],
+		protocolParameters,
+		lovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
+	);
 	txBuilder
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.setTotalCollateral(totalCollateral);
@@ -445,7 +451,12 @@ async function buildBatchDeregisterTx(
 
 	// Conway phase-1 collateral derived from the shared BurnAction MINT-tag
 	// budget. See `deriveTotalCollateral` for the math.
-	const totalCollateral = deriveTotalCollateral([exUnits], protocolParameters, lovelaceFromUtxo(collateralUtxo));
+	const totalCollateral = deriveTotalCollateral(
+		[exUnits],
+		protocolParameters,
+		lovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
+	);
 	txBuilder
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.setTotalCollateral(totalCollateral);
@@ -624,7 +635,12 @@ async function buildBatchUpdateTx(
 		txBuilder.selectUtxosFrom(walletUtxosForSelection);
 	}
 
-	const totalCollateral = deriveTotalCollateral([exUnits], protocolParameters, lovelaceFromUtxo(collateralUtxo));
+	const totalCollateral = deriveTotalCollateral(
+		[exUnits],
+		protocolParameters,
+		lovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
+	);
 	txBuilder
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.setTotalCollateral(totalCollateral);

--- a/packages/payment-source-v2/src/services/registry-inbox/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry-inbox/deregister/service.ts
@@ -12,7 +12,7 @@ import { advancedRetry, delayErrorResolver } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { extractAssetName } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { pickCollateralUtxo, sortAndLimitUtxos } from '@/utils/utxo';
 import {
 	connectExistingTransaction,
 	createMeshProvider,
@@ -206,7 +206,11 @@ async function processSingleDeregistration(
 	}
 	const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
 	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
+	// Rank within the same pool the builder spends from, so the collateral
+	// keeps its existing relationship to the inputs while still preferring a
+	// pure-ADA, smallest-qualifying, deterministically-ordered UTxO. Falls
+	// back to the previous behaviour when nothing clears the 5 ADA floor.
+	const collateralUtxo = pickCollateralUtxo(limitedFilteredUtxos) ?? limitedFilteredUtxos[0];
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -12,7 +12,7 @@ import { advancedRetry, delayErrorResolver } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { extractAssetName } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos } from '@/utils/utxo';
+import { pickCollateralUtxo, sortAndLimitUtxos } from '@/utils/utxo';
 import {
 	connectExistingTransaction,
 	createMeshProvider,
@@ -249,7 +249,11 @@ async function processSingleDeregistration(
 	}
 	const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
 	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8000000);
-	const collateralUtxo = limitedFilteredUtxos[0];
+	// Rank within the same pool the builder spends from, so the collateral
+	// keeps its existing relationship to the inputs while still preferring a
+	// pure-ADA, smallest-qualifying, deterministically-ordered UTxO. Falls
+	// back to the previous behaviour when nothing clears the 5 ADA floor.
+	const collateralUtxo = pickCollateralUtxo(limitedFilteredUtxos) ?? limitedFilteredUtxos[0];
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}

--- a/packages/payment-source-v2/src/services/registry/register/service.ts
+++ b/packages/payment-source-v2/src/services/registry/register/service.ts
@@ -557,12 +557,18 @@ export async function registerAgentV2() {
 					// Collateral ready — clear any transient prep-failure count on every item.
 					await Promise.allSettled(registryRequests.map((request) => resetRegistryPrepFailureCount(request.id)));
 
-					// Pick collateral FIRST (smallest pure-ADA UTxO >= 5 ADA) so the
+					// Pick collateral FIRST (smallest qualifying UTxO >= 5 ADA) so the
 					// remaining sorted-by-lovelace pool can drive distinct
-					// per-item `firstUtxo`s without overlap. Conway rejects
-					// collateral that carries any non-ADA asset, so we never fall
-					// back to a non-pure UTxO — if none exists, defer to the next
-					// tick when the wallet may have more UTxOs.
+					// per-item `firstUtxo`s without overlap.
+					//
+					// Pure ADA is PREFERRED, not required: Babbage/CIP-40 permits
+					// token-bearing collateral, and the builder's
+					// `setTotalCollateral` makes Mesh emit the `collateral_return`
+					// output that hands the balance back. A previous version of
+					// this comment claimed Conway rejects any non-ADA collateral
+					// and that we never fall back — neither was true of the
+					// selector. If NO UTxO clears the 5 ADA floor we defer to the
+					// next tick, when the wallet may have more UTxOs.
 					const collateralUtxo = pickBatchCollateral(utxos, []);
 					if (collateralUtxo == null) {
 						logger.warn(

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -11,7 +11,7 @@ import { advancedRetry, delayErrorResolver } from 'advanced-retry';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
 import { extractAssetName, extractPolicyId } from '@/utils/converter/agent-identifier';
-import { sortAndLimitUtxos, sortUtxosByLovelaceDesc } from '@/utils/utxo';
+import { pickCollateralUtxo, sortAndLimitUtxos, sortUtxosByLovelaceDesc } from '@/utils/utxo';
 import {
 	connectExistingTransaction,
 	createMeshProvider,
@@ -241,7 +241,11 @@ async function processUpdate(
 	// here with a clear message instead.
 	const tokenUtxo = findRegistryTokenUtxo(utxos, request.agentIdentifier);
 	const limitedFilteredUtxos = sortAndLimitUtxos(utxos, 8_000_000);
-	const collateralUtxo = limitedFilteredUtxos[0];
+	// Rank within the same pool the builder spends from, so the collateral
+	// keeps its existing relationship to the inputs while still preferring a
+	// pure-ADA, smallest-qualifying, deterministically-ordered UTxO. Falls
+	// back to the previous behaviour when nothing clears the 5 ADA floor.
+	const collateralUtxo = pickCollateralUtxo(limitedFilteredUtxos) ?? limitedFilteredUtxos[0];
 	if (collateralUtxo == null) {
 		throw new Error('Collateral UTXO not found');
 	}

--- a/src/utils/utxo/index.spec.ts
+++ b/src/utils/utxo/index.spec.ts
@@ -1,5 +1,12 @@
 import type { UTxO } from '@meshsdk/core';
-import { getSpendableWalletUtxos, selectCollateralUtxo, sortAndLimitUtxos, sortUtxosByLovelaceDesc } from './index';
+import {
+	getSpendableWalletUtxos,
+	pickCollateralUtxo,
+	rankCollateralCandidates,
+	selectCollateralUtxo,
+	sortAndLimitUtxos,
+	sortUtxosByLovelaceDesc,
+} from './index';
 
 type AssetSpec = { unit: string; quantity: string };
 
@@ -196,5 +203,70 @@ describe('getSpendableWalletUtxos', () => {
 		const collateral = makeUtxo({ txHash: 'collateral', amount: [lovelace(8_000_000)] });
 
 		expect(getSpendableWalletUtxos([collateral], collateral)).toEqual([collateral]);
+	});
+});
+
+describe('collateral selection determinism', () => {
+	// Registry paths derive the MINTED ASSET NAME from the chosen UTxO, so an
+	// unstable order across builds would change the asset name. These lock the
+	// tie-breaks in place.
+	it('sortUtxosByLovelaceDesc breaks equal-lovelace ties by txHash#index', () => {
+		const a = makeUtxo({ txHash: 'aaaa', outputIndex: 1, amount: [lovelace(9_000_000)] });
+		const b = makeUtxo({ txHash: 'bbbb', outputIndex: 0, amount: [lovelace(9_000_000)] });
+
+		const forward = sortUtxosByLovelaceDesc([a, b]).map((u) => u.input.txHash);
+		const reversed = sortUtxosByLovelaceDesc([b, a]).map((u) => u.input.txHash);
+
+		expect(forward).toEqual(['aaaa', 'bbbb']);
+		// Same result regardless of the order the provider returned them in.
+		expect(reversed).toEqual(forward);
+	});
+
+	it('pickCollateralUtxo breaks equal-size ties deterministically', () => {
+		const a = makeUtxo({ txHash: 'aaaa', outputIndex: 0, amount: [lovelace(6_000_000)] });
+		const b = makeUtxo({ txHash: 'bbbb', outputIndex: 0, amount: [lovelace(6_000_000)] });
+
+		expect(pickCollateralUtxo([a, b])?.input.txHash).toBe('aaaa');
+		expect(pickCollateralUtxo([b, a])?.input.txHash).toBe('aaaa');
+	});
+
+	// Mixed collateral is VALID (Babbage/CIP-40 + collateral_return); pure ADA
+	// is only preferred. A token-bearing UTxO must be selected, not rejected,
+	// when it is the only qualifying candidate.
+	it('selects a token-bearing UTxO when no pure-ADA candidate qualifies', () => {
+		const mixed = makeUtxo({ txHash: 'mixed', amount: [lovelace(10_000_000), token(5)] });
+		const dust = makeUtxo({ txHash: 'dust', amount: [lovelace(1_000_000)] });
+
+		expect(pickCollateralUtxo([dust, mixed])?.input.txHash).toBe('mixed');
+	});
+
+	it('returns null instead of throwing when nothing qualifies', () => {
+		const dust = makeUtxo({ txHash: 'dust', amount: [lovelace(1_000_000)] });
+
+		expect(pickCollateralUtxo([dust])).toBeNull();
+	});
+
+	it('honours the exclusion list so a script input cannot become collateral', () => {
+		const scriptInput = makeUtxo({ txHash: 'script', outputIndex: 2, amount: [lovelace(6_000_000)] });
+		const wallet = makeUtxo({ txHash: 'wallet', outputIndex: 0, amount: [lovelace(7_000_000)] });
+
+		const picked = pickCollateralUtxo([scriptInput, wallet], 5_000_000n, [scriptInput.input]);
+
+		expect(picked?.input.txHash).toBe('wallet');
+	});
+
+	it('rankCollateralCandidates offers a usable second choice', () => {
+		const first = makeUtxo({ txHash: 'first', amount: [lovelace(6_000_000)] });
+		const second = makeUtxo({ txHash: 'second', amount: [lovelace(7_000_000)] });
+
+		expect(rankCollateralCandidates([second, first]).map((u) => u.input.txHash)).toEqual(['first', 'second']);
+	});
+
+	it('treats a malformed lovelace quantity as zero rather than throwing', () => {
+		const malformed = makeUtxo({ txHash: 'bad', amount: [{ unit: 'lovelace', quantity: 'not-a-number' }] });
+		const good = makeUtxo({ txHash: 'good', amount: [lovelace(6_000_000)] });
+
+		expect(() => pickCollateralUtxo([malformed, good])).not.toThrow();
+		expect(pickCollateralUtxo([malformed, good])?.input.txHash).toBe('good');
 	});
 });

--- a/src/utils/utxo/index.ts
+++ b/src/utils/utxo/index.ts
@@ -1,4 +1,13 @@
-import { UTxO } from '@meshsdk/core';
+// Mesh SDK pinning (ADR 0005): this module lives in shared `src/`, which is
+// implicitly V1-pinned, yet the V2 builders consume it too. That is safe ONLY
+// because nothing here touches the mesh RUNTIME — `UTxO` is imported as a
+// TYPE, so the compiled output carries no `@meshsdk/core` import at all and
+// pkgroll cannot collapse the V2 bundle onto the V1 mesh line. Keep it that
+// way: if this file ever needs a mesh VALUE import, the collateral helpers
+// must be duplicated per rail instead (the precedent is
+// `getSpendableWalletUtxos`, which is duplicated in the V2 batch-helpers).
+import type { UTxO } from '@meshsdk/core';
+import { logger } from '@masumi/payment-core/logger';
 
 const DEFAULT_MIN_COLLATERAL_LOVELACE = 5_000_000n;
 
@@ -13,7 +22,25 @@ const DEFAULT_MIN_COLLATERAL_LOVELACE = 5_000_000n;
  * amounts; never use Number for lovelace values.
  */
 export function getLovelaceFromUtxo(utxo: UTxO): bigint {
-	return BigInt(utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '')?.quantity ?? '0');
+	const lovelaceAsset = utxo.output.amount.find((asset) => asset.unit === 'lovelace' || asset.unit === '');
+	if (lovelaceAsset == null) return 0n;
+	try {
+		return BigInt(lovelaceAsset.quantity);
+	} catch (parseError) {
+		// A malformed `quantity` means the provider returned data that violates
+		// our expectations. Stay total and return 0n (the UTxO simply drops out
+		// of collateral/selection candidacy) but log loudly so an operator can
+		// investigate — a bare `BigInt(...)` here would instead throw and abort
+		// the whole batch tick. Behaviour lifted from the V2 batch-helpers copy
+		// so both rails share it.
+		logger.warn('getLovelaceFromUtxo: malformed quantity string on UTxO; treating as 0', {
+			txHash: utxo.input.txHash,
+			outputIndex: utxo.input.outputIndex,
+			rawQuantity: lovelaceAsset.quantity,
+			error: parseError instanceof Error ? parseError.message : parseError,
+		});
+		return 0n;
+	}
 }
 
 function isSameUtxo(left: UTxO, right: UTxO): boolean {
@@ -40,32 +67,90 @@ export function getSpendableWalletUtxos(walletUtxos: UTxO[], collateralUtxo: UTx
 	return spendableUtxos.length > 0 ? spendableUtxos : walletUtxos;
 }
 
+/** Stable `txHash#index` key for a UTxO reference. */
+export function utxoRefKey(ref: { txHash: string; outputIndex: number }): string {
+	return `${ref.txHash}#${ref.outputIndex}`;
+}
+
+/** Whether a UTxO carries lovelace only (no native tokens). */
+export function isPureAdaUtxo(utxo: UTxO): boolean {
+	return utxo.output.amount.every((asset) => asset.unit === 'lovelace' || asset.unit === '');
+}
+
 /**
- * Selects a collateral input.
+ * Ranks the wallet's UTxOs by their suitability as a collateral input, best
+ * first. Every qualifying UTxO is returned, so callers that need a second
+ * choice (e.g. when the best one is already a spending input) can walk the
+ * list instead of re-implementing the ordering.
  *
- * Prefer the smallest qualifying pure-ADA UTxO so native tokens do not need
- * a collateral-return output. If none exists, fall back to the smallest
- * qualifying mixed-asset UTxO: Babbage/CIP-40 permits token-bearing
- * collateral, and Mesh emits the required collateral-return output.
+ * ORDERING — the single definition used by every rail and every action:
+ *
+ *  1. Pure-ADA before mixed. Multi-asset collateral is perfectly valid:
+ *     Babbage/CIP-40 permits it, and the builder declares `setTotalCollateral`
+ *     so a `collateral_return` output carries the balance (including the
+ *     native tokens) back to the wallet. Pure ADA is preferred only because it
+ *     keeps that return output smaller and the fee marginally lower — a
+ *     token-bearing UTxO is a fine collateral, never an error.
+ *  2. Smallest qualifying lovelace first, so a fat UTxO is not tied up as
+ *     collateral when a modest one would do.
+ *  3. `txHash#index` as the final tie-break. This is what makes selection
+ *     DETERMINISTIC: two UTxOs of equal size must not swap places between
+ *     builds, because registry paths derive the minted asset name from the
+ *     chosen input and a reordering there would change the asset name.
  */
-export function selectCollateralUtxo(utxos: UTxO[], minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE): UTxO {
-	const qualifyingUtxos = utxos
-		.filter((utxo) => utxo.output.amount.length > 0 && getLovelaceFromUtxo(utxo) >= minimumLovelace)
-		.map((utxo) => ({
-			utxo,
-			isPureAda: utxo.output.amount.every((asset) => asset.unit === 'lovelace' || asset.unit === ''),
-			lovelace: getLovelaceFromUtxo(utxo),
-		}))
+export function rankCollateralCandidates(
+	utxos: UTxO[],
+	minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE,
+	excludeRefs: Array<{ txHash: string; outputIndex: number }> = [],
+): UTxO[] {
+	const excluded = new Set(excludeRefs.map(utxoRefKey));
+
+	return utxos
+		.filter(
+			(utxo) =>
+				utxo.output.amount.length > 0 &&
+				!excluded.has(utxoRefKey(utxo.input)) &&
+				getLovelaceFromUtxo(utxo) >= minimumLovelace,
+		)
+		.map((utxo) => ({ utxo, isPureAda: isPureAdaUtxo(utxo), lovelace: getLovelaceFromUtxo(utxo) }))
 		.sort((left, right) => {
 			if (left.isPureAda !== right.isPureAda) {
 				return left.isPureAda ? -1 : 1;
 			}
 			if (left.lovelace < right.lovelace) return -1;
 			if (left.lovelace > right.lovelace) return 1;
-			return 0;
-		});
+			return utxoRefKey(left.utxo.input).localeCompare(utxoRefKey(right.utxo.input));
+		})
+		.map((entry) => entry.utxo);
+}
 
-	const collateralUtxo = qualifyingUtxos[0]?.utxo;
+/**
+ * Selects a collateral input, or null when the wallet has none big enough.
+ *
+ * See `rankCollateralCandidates` for the ordering. Returns null rather than
+ * throwing so batch callers can defer to the next tick; `selectCollateralUtxo`
+ * is the throwing variant for single-action paths that cannot defer.
+ */
+export function pickCollateralUtxo(
+	utxos: UTxO[],
+	minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE,
+	excludeRefs: Array<{ txHash: string; outputIndex: number }> = [],
+): UTxO | null {
+	return rankCollateralCandidates(utxos, minimumLovelace, excludeRefs)[0] ?? null;
+}
+
+/**
+ * Selects a collateral input, throwing when none qualifies.
+ *
+ * Same ordering as `pickCollateralUtxo` — this wrapper exists for the paths
+ * that treat "no collateral" as an immediate failure rather than a deferral.
+ */
+export function selectCollateralUtxo(
+	utxos: UTxO[],
+	minimumLovelace: bigint = DEFAULT_MIN_COLLATERAL_LOVELACE,
+	excludeRefs: Array<{ txHash: string; outputIndex: number }> = [],
+): UTxO {
+	const collateralUtxo = pickCollateralUtxo(utxos, minimumLovelace, excludeRefs);
 
 	if (collateralUtxo == null) {
 		throw new Error(`Collateral UTxO not found with at least ${minimumLovelace.toString()} lovelace`);
@@ -91,7 +176,13 @@ export function sortUtxosByLovelaceDesc(utxos: UTxO[]): UTxO[] {
 		.sort((a, b) => {
 			if (b.lovelace > a.lovelace) return 1;
 			if (b.lovelace < a.lovelace) return -1;
-			return 0;
+			// Deterministic tie-break. Registry paths take `[0]` as the tx's
+			// `firstUtxo` and derive the MINTED ASSET NAME from it, so two
+			// equal-lovelace UTxOs must not swap places between builds. Array
+			// sort is stable, but the provider's UTxO order is not guaranteed
+			// stable across calls, so equal sizes previously left the asset name
+			// dependent on whatever order Blockfrost happened to return.
+			return utxoRefKey(a.utxo.input).localeCompare(utxoRefKey(b.utxo.input));
 		})
 		.map((item) => item.utxo);
 }
@@ -100,7 +191,14 @@ function sortUtxosByBloatAsc(utxos: UTxO[]): UTxO[] {
 	// `.slice()` first so the in-place `.sort()` doesn't mutate the caller's
 	// array. `sortUtxosByLovelaceDesc` above already produces a fresh array via
 	// `.map(...).sort()`; mirror that immutability guarantee here.
-	return utxos.slice().sort((a, b) => a.output.amount.length - b.output.amount.length);
+	return utxos.slice().sort((a, b) => {
+		const byBloat = a.output.amount.length - b.output.amount.length;
+		if (byBloat !== 0) return byBloat;
+		// Same deterministic tie-break as `sortUtxosByLovelaceDesc`: callers take
+		// `[0]` off this list as the collateral, and equal-bloat UTxOs must not
+		// reorder between builds.
+		return utxoRefKey(a.input).localeCompare(utxoRefKey(b.input));
+	});
 }
 
 /**


### PR DESCRIPTION
## Premise, verified first

Multi-asset collateral is **valid**. Babbage/CIP-40 permits it, and mesh's `addCollateralReturn` merges the *full* value of every collateral input — tokens included — into the collateral return.

I checked this empirically rather than assuming, by driving the real serializer on both pinned mesh lines with a token-bearing collateral:

```
totalCollateral: 3000000n
collateralReturn present: true
  coin: 10049455838n
  multiasset: aaaa…546f6b656e = 777
```

`addCollateralReturn`, `mergeValue`, `toValue` and `completeInputInfo` are byte-identical between `core-cst` beta.90 (V1) and beta.102 (V2). So there is no V1/V2 divergence in mesh itself, and nothing here needs to avoid token-bearing collateral.

## 1. Three different selection strategies

The split was per-*path*, not per-rail:

| Path | Before |
|---|---|
| Payments / purchases (V1) | `selectCollateralUtxo` — prefers pure, falls back to mixed |
| Payments / purchases (V2) | `pickBatchCollateral` — same idea, separate implementation |
| **Registration / deregistration / update, both rails** | `sortAndLimitUtxos(...)[0]` — **no pure-ADA preference at all** |
| V2 single dereg / update / inbox paths | same `[0]` |

All of them now rank through one definition, `rankCollateralCandidates`: pure-ADA first, then smallest qualifying lovelace, then `txHash#index`. Pure ADA is a **preference** (smaller return output, marginally lower fee), never a correctness requirement.

`pickBatchCollateral` delegates to it rather than keeping a second copy. That crosses the V1/V2 boundary, so worth a reviewer's eye: it is safe specifically because `@/utils/utxo` carries **no mesh runtime** — `UTxO` is now an `import type`, so the compiled output has no `@meshsdk/core` import and pkgroll cannot collapse the V2 bundle onto the V1 line. I documented that constraint at both ends. If that file ever needs a mesh *value* import, the helper must be duplicated per rail instead (the precedent is `getSpendableWalletUtxos`).

## 2. Selection was not deterministic — this changed minted asset names

`sortUtxosByLovelaceDesc` and `sortUtxosByBloatAsc` both returned `0` for ties. Array sort is stable, but **the provider's UTxO order is not stable across calls**, so two equal-sized UTxOs could swap places between builds.

That matters beyond collateral: registry paths take `[0]` as the transaction's `firstUtxo` and derive the **minted asset name** from it. Both sorts now tie-break on `txHash#index`, and there are tests pinning it.

## 3. Token-bearing collateral returns were under-sized

`COLLATERAL_RETURN_MIN_LOVELACE` was a flat 1 ADA — correct only for a pure-ADA return. Because mesh copies the tokens into the return output, a token-bearing return needs more min-ADA, and **mesh never min-ADA-checks the collateral return** (`sanitizeOutputs` only walks `meshTxBuilderBody.outputs`). A token-bearing collateral near the clamp could therefore produce a below-min return. The reserved headroom now scales with the collateral's distinct asset count.

## Comments corrected

They contradicted each other and the code. The V2 register path claimed *"Conway rejects collateral that carries any non-ADA asset, so we never fall back to a non-pure UTxO"* — while the selector it called did exactly that. Aligned everywhere to the verified behaviour.

Separately, `getLovelaceFromUtxo` picks up the malformed-quantity guard that only the V2 copy had, so a bad provider quantity warns and drops the UTxO from candidacy on both rails instead of throwing out of the batch tick.

## Verification

- `pnpm test` — **982 passed**, 2 skipped (7 new tests covering tie-break determinism, mixed-collateral acceptance, exclusion lists, and the malformed-quantity path)
- `pnpm run typecheck`, `pnpm run lint` — clean

## What this does NOT claim to fix

The Preprod e2e failure that started this investigation:

```
ConwayUtxowFailure (UtxoFailure (CollateralContainsNonADA (MaryValue (Coin 10052455838) (MultiAsset ...
```

That error means the collateral balance still contained non-ADA, which given the above points at a transaction built with **no** `collateral_return` at all — i.e. `totalCollateral` falsy at serialization time. Every script path in this tree does pair `txInCollateral` with `setTotalCollateral`, so **I have not pinned the failing call site** and this PR should not be assumed to fix that run. The rejected value (~10,052 ADA) looks like a largest-first pick rather than the smallest-qualifying pick both selectors make, which is itself a clue worth following.

One related landmine found on the way, not addressed here: the deprecated high-level `Transaction` class never calls `setTotalCollateral` at all, so any script-bearing tx built through it emits collateral inputs with no return. The four `new Transaction(` sites here (fund-transfer, fund-distribution, V1/V2 batch-payments) are pure-value sends so `isCollateralNeeded` stays false — but it is a trap if scripts are ever added to them.