### PR TITLE
fix(docker): raise node heap for pkgroll bundle step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ COPY eslint.config.mjs .
 COPY frontend/package.json ./frontend/
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm run build
+# pkgroll bundles both Mesh SDK lines, two @cardano-sdk/core versions, and the
+# x402 packages' viem/@x402 graphs (per-importer bundling is intentional — see
+# docs/adr/0005), which exceeds Node's default ~2GB heap on CI builders.
+RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run build
 RUN pnpm run swagger-json
 
 #RUN pnpm run prisma:migrate


### PR DESCRIPTION
DigitalOcean image builds abort with a V8 OOM (`FATAL ERROR: Reached heap limit`, exit 134) during the backend `pkgroll` step.

## Why it OOMs
The bundle graph legitimately carries **both Mesh SDK lines** (V1 `beta.96` + V2 `beta.102`, bundled per-importer by design — see `docs/adr/0005`), **two `@cardano-sdk/core` versions**, and the x402 packages' `viem`/`@x402/*` graphs twice (once per zod flavor). Rollup holds all of it in memory and blows past node 20's default ~2 GB old-space heap on the DO build container. Local builds pass only because node scales its default heap with larger host memory — which is why this only shows up in CI.

## Fix
`NODE_OPTIONS=--max-old-space-size=4096` on the backend build step only. No dependency or bundling changes — externalizing `viem`/`@x402/*` would break the deliberate per-importer version isolation.

Verified locally: `pkgroll` completes cleanly with the flag.

Pre-existing failure (present since the bundle graph grew past the heap limit); the #719 merge deploy was just the run that surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)