### PR TITLE
fix(frontend): keep V1 source visible before V2 migration

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -43,7 +43,10 @@ import MasumiIconFlat from '@/components/MasumiIconFlat';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { NetworkSourceCard } from '@/components/layout/PaymentSourceSelector';
 import { PaymentSourceTypeBadge } from '@/components/payment-sources/PaymentSourceTypeBadge';
-import { DEFAULT_PAYMENT_SOURCE_TYPE, isV2PaymentSource } from '@/lib/payment-source-type';
+import {
+  DEFAULT_PAYMENT_SOURCE_TYPE,
+  hasLegacyOnlyPaymentSources as networkHasLegacyOnlyPaymentSources,
+} from '@/lib/payment-source-type';
 import { X402SetupBanner } from '@/components/x402/X402SetupBanner';
 import { useX402Networks } from '@/lib/hooks/useX402';
 import { chainsForEnv } from '@/lib/x402-rail';
@@ -149,8 +152,9 @@ export function MainLayout({ children }: MainLayoutProps) {
     [network, paymentSources],
   );
   const hasPaymentSources = currentNetworkPaymentSources.length > 0;
-  const hasV2PaymentSource = currentNetworkPaymentSources.some(isV2PaymentSource);
-  const hasLegacyOnlyPaymentSources = hasPaymentSources && !hasV2PaymentSource;
+  const hasLegacyOnlyPaymentSources = networkHasLegacyOnlyPaymentSources(
+    currentNetworkPaymentSources,
+  );
   const { networks: x402Networks, isLoading: x402Loading } = useX402Networks({
     silentErrors: true,
   });
@@ -694,7 +698,8 @@ export function MainLayout({ children }: MainLayoutProps) {
                         />
                       </div>
                       <p className="opacity-85">
-                        Run the one-time V2 setup, then migrate your agents on the dashboard.
+                        Your V1 payment source stays active. Run the one-time V2 setup when you are
+                        ready to migrate agents.
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/setup/SetupV2Banner.tsx
+++ b/frontend/src/components/setup/SetupV2Banner.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState, useSyncExternalStore } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { ArrowRight, Sparkles, Wand2, ShieldCheck, ArrowUpRight, X } from 'lucide-react';
+import { ArrowRight, Sparkles, Wand2, ShieldCheck, X } from 'lucide-react';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { isV2PaymentSource } from '@/lib/payment-source-type';
@@ -26,7 +26,7 @@ interface SetupV2BannerProps {
   onMigrateClick?: () => void;
 }
 
-export function SetupV2Banner({ onMigrateClick }: SetupV2BannerProps) {
+export function SetupV2Banner({ onMigrateClick: _onMigrateClick }: SetupV2BannerProps) {
   const { network } = useAppContext();
   const { paymentSources, isLoading } = usePaymentSourceExtendedAll();
 
@@ -122,17 +122,6 @@ export function SetupV2Banner({ onMigrateClick }: SetupV2BannerProps) {
         </div>
 
         <div className="flex flex-wrap gap-2 shrink-0">
-          {hasLegacyOnly && onMigrateClick && (
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={onMigrateClick}
-              className="gap-2 btn-hover-lift"
-            >
-              <ArrowUpRight className="h-4 w-4" />
-              Migrate agents
-            </Button>
-          )}
           <Button asChild size="lg" className="gap-2 btn-hover-lift group">
             <Link href={setupHref}>
               <Wand2 className="h-4 w-4" />

--- a/frontend/src/components/setup/SetupWelcome.tsx
+++ b/frontend/src/components/setup/SetupWelcome.tsx
@@ -7,6 +7,7 @@ import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtende
 import { useQueryClient } from '@tanstack/react-query';
 import { invalidateAgentQueries } from '@/lib/queries/agent-cache';
 import { isV2PaymentSource } from '@/lib/payment-source-type';
+import { useRailReadiness } from '@/lib/hooks/useRailReadiness';
 import { STEP_LABELS, type SetupWallet } from '@/components/setup/setup-helpers';
 import { WelcomeScreen } from '@/components/setup/screens/WelcomeScreen';
 import { SeedPhrasesScreen } from '@/components/setup/screens/SeedPhrasesScreen';
@@ -28,6 +29,9 @@ export function SetupWelcome({ networkType }: { networkType: string }) {
   });
   const [hasAiAgent, setHasAiAgent] = useState(false);
   const { paymentSources } = usePaymentSourceExtendedAll();
+  const { cardano: cardanoReadiness, isUnavailable: isReadinessUnavailable } = useRailReadiness({
+    network: networkType as 'Preprod' | 'Mainnet',
+  });
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- Reset wizard state when network changes (user switched network during setup)
@@ -35,17 +39,28 @@ export function SetupWelcome({ networkType }: { networkType: string }) {
     setWallets({ buying: null, selling: null });
   }, [networkType]);
 
-  // If the current network already has a V2 payment source and we're on the welcome step,
-  // exit setup automatically. Legacy V1-only networks should still be able to migrate.
+  // Exit only once V2 is actually ready — a half-created V2 row must not boot
+  // legacy-only operators out of the wizard while migration is still impossible.
   useEffect(() => {
     const hasV2SourceForNetwork = paymentSources.some(
       (ps) => ps.network === networkType && isV2PaymentSource(ps),
     );
-    if (currentStep === 0 && hasV2SourceForNetwork) {
+    const hasReadyV2SourceForNetwork = isReadinessUnavailable
+      ? hasV2SourceForNetwork
+      : cardanoReadiness?.isReady === true && hasV2SourceForNetwork;
+    if (currentStep === 0 && hasReadyV2SourceForNetwork) {
       setIsSetupMode(false);
       router.push('/');
     }
-  }, [networkType, paymentSources, currentStep, setIsSetupMode, router]);
+  }, [
+    networkType,
+    paymentSources,
+    cardanoReadiness?.isReady,
+    isReadinessUnavailable,
+    currentStep,
+    setIsSetupMode,
+    router,
+  ]);
 
   useEffect(() => {
     setSetupWizardStep(currentStep);

--- a/frontend/src/lib/contexts/AppContext.tsx
+++ b/frontend/src/lib/contexts/AppContext.tsx
@@ -7,12 +7,15 @@ import {
   useRef,
   useMemo,
 } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ErrorDialog } from '@/components/ui/error-dialog';
 import { Client, createClient } from '@/lib/api/generated/client';
+import { getRailReadiness } from '@/lib/api/generated';
 import { usePaymentSourceExtendedAllWithParams } from '../hooks/usePaymentSourceExtendedAll';
 import type { PaymentSourceExtended } from '../api/generated';
-import { getPreferredPaymentSource } from '@/lib/payment-source-type';
+import { getOperationalPaymentSource, isV2PaymentSource } from '@/lib/payment-source-type';
+import { railOf } from '@/lib/rail-readiness';
+import { handleApiCall } from '@/lib/utils';
 
 export type NetworkType = 'Preprod' | 'Mainnet';
 
@@ -144,6 +147,30 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     [paymentSources, network],
   );
 
+  const railReadinessQuery = useQuery({
+    queryKey: ['rail-readiness', network, true],
+    queryFn: async () => {
+      const response = await handleApiCall(
+        () => getRailReadiness({ client: apiClient, query: { network } }),
+        { onError: () => {} },
+      );
+      const readiness = response?.data?.data;
+      if (readiness == null) {
+        throw new Error('Failed to fetch payment rail readiness');
+      }
+      return readiness;
+    },
+    enabled: !!apiClient && authorized,
+    staleTime: 30000,
+  });
+  const cardanoReadiness = railOf(railReadinessQuery.data ?? null, 'CardanoV2');
+  const isLoadingReadiness = !authorized || railReadinessQuery.isLoading;
+  const isReadinessUnavailable = railReadinessQuery.isError;
+  const hasV2PaymentSource = currentNetworkPaymentSources.some(isV2PaymentSource);
+  const cardanoV2Ready = isReadinessUnavailable
+    ? hasV2PaymentSource
+    : (cardanoReadiness?.isReady ?? false);
+
   const [selectedPaymentSourceId, setSelectedPaymentSourceId] = useState<string | null>(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('selectedPaymentSourceId');
@@ -197,7 +224,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     // source once loading finishes. A FAILED fetch also resolves to an empty
     // list, so bail on error too — otherwise a transient network/API error
     // would clear the persisted selection this guard exists to protect.
-    if (!apiKey || isLoadingPaymentSources || paymentSourcesError) {
+    if (!apiKey || isLoadingPaymentSources || paymentSourcesError || isLoadingReadiness) {
       return;
     }
 
@@ -212,8 +239,13 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     const foundPaymentSource = selectedPaymentSourceId
       ? currentNetworkPaymentSources.find((ps) => ps.id === selectedPaymentSourceId)
       : null;
+    const operationalPaymentSource = getOperationalPaymentSource(currentNetworkPaymentSources, {
+      cardanoV2Ready,
+    });
     const nextPaymentSource =
-      foundPaymentSource ?? getPreferredPaymentSource(currentNetworkPaymentSources);
+      foundPaymentSource && (!isV2PaymentSource(foundPaymentSource) || cardanoV2Ready)
+        ? foundPaymentSource
+        : operationalPaymentSource;
 
     if (!nextPaymentSource) {
       return;
@@ -225,9 +257,11 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, [
     apiKey,
     isLoadingPaymentSources,
+    isLoadingReadiness,
     paymentSourcesError,
     selectedPaymentSourceId,
     currentNetworkPaymentSources,
+    cardanoV2Ready,
     network,
     setSelectedPaymentSourceIdAndPersist,
   ]);

--- a/frontend/src/lib/payment-source-type.test.ts
+++ b/frontend/src/lib/payment-source-type.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getOperationalPaymentSource,
+  getPreferredPaymentSource,
+  hasLegacyOnlyPaymentSources,
+} from './payment-source-type';
+
+const v1A = { paymentSourceType: 'Web3CardanoV1' as const, createdAt: '2024-01-01' };
+const v1B = { paymentSourceType: 'Web3CardanoV1' as const, createdAt: '2024-06-01' };
+const v2A = { paymentSourceType: 'Web3CardanoV2' as const, createdAt: '2024-03-01' };
+const v2B = { paymentSourceType: 'Web3CardanoV2' as const, createdAt: '2024-07-01' };
+
+test('getPreferredPaymentSource prefers V2 over V1', () => {
+  assert.equal(getPreferredPaymentSource([v1A, v2A])?.paymentSourceType, 'Web3CardanoV2');
+});
+
+test('hasLegacyOnlyPaymentSources is true when only V1 exists', () => {
+  assert.equal(hasLegacyOnlyPaymentSources([v1A]), true);
+  assert.equal(hasLegacyOnlyPaymentSources([v1A, v2A]), false);
+});
+
+test('getOperationalPaymentSource keeps the newest V1 when no V2 exists', () => {
+  assert.equal(getOperationalPaymentSource([v1A, v1B])?.paymentSourceType, 'Web3CardanoV1');
+  assert.equal(getOperationalPaymentSource([v1B, v1A])?.createdAt, '2024-06-01');
+});
+
+test('getOperationalPaymentSource keeps V1 while V2 migration is incomplete', () => {
+  assert.equal(
+    getOperationalPaymentSource([v1A, v2B], { cardanoV2Ready: false })?.paymentSourceType,
+    'Web3CardanoV1',
+  );
+});
+
+test('getOperationalPaymentSource switches to V2 once the rail is ready', () => {
+  assert.equal(
+    getOperationalPaymentSource([v1A, v2B], { cardanoV2Ready: true })?.paymentSourceType,
+    'Web3CardanoV2',
+  );
+  assert.equal(
+    getOperationalPaymentSource([v1A, v2B], { cardanoV2Ready: true })?.createdAt,
+    '2024-07-01',
+  );
+});

--- a/frontend/src/lib/payment-source-type.ts
+++ b/frontend/src/lib/payment-source-type.ts
@@ -42,3 +42,53 @@ export function sortPaymentSourcesByPreference<T extends PaymentSourceLike>(sour
 export function getPreferredPaymentSource<T extends PaymentSourceLike>(sources: T[]): T | null {
   return sortPaymentSourcesByPreference(sources)[0] ?? null;
 }
+
+export function partitionPaymentSourcesByVersion<T extends PaymentSourceLike>(
+  sources: T[],
+): {
+  v2Sources: T[];
+  legacySources: T[];
+} {
+  const v2Sources: T[] = [];
+  const legacySources: T[] = [];
+
+  for (const source of sources) {
+    if (isV2PaymentSource(source)) {
+      v2Sources.push(source);
+    } else {
+      legacySources.push(source);
+    }
+  }
+
+  return { v2Sources, legacySources };
+}
+
+export function hasLegacyOnlyPaymentSources<T extends PaymentSourceLike>(sources: T[]): boolean {
+  const { v2Sources, legacySources } = partitionPaymentSourcesByVersion(sources);
+  return legacySources.length > 0 && v2Sources.length === 0;
+}
+
+/**
+ * Pick the payment source the admin UI should act on.
+ *
+ * V2 is preferred only once the Cardano V2 rail is actually ready. Until then,
+ * keep operators on their working V1 source so agents, wallets, and transactions
+ * stay visible while the migrate/setup banner nudges them forward.
+ */
+export function getOperationalPaymentSource<T extends PaymentSourceLike>(
+  sources: T[],
+  options?: { cardanoV2Ready?: boolean },
+): T | null {
+  if (sources.length === 0) {
+    return null;
+  }
+
+  const { v2Sources, legacySources } = partitionPaymentSourcesByVersion(sources);
+  const cardanoV2Ready = options?.cardanoV2Ready ?? false;
+
+  if (legacySources.length > 0 && (v2Sources.length === 0 || !cardanoV2Ready)) {
+    return getPreferredPaymentSource(legacySources);
+  }
+
+  return getPreferredPaymentSource(sources);
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -23,6 +23,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { useX402Networks } from '@/lib/hooks/useX402';
 import { chainsForEnv } from '@/lib/x402-rail';
+import { hasLegacyOnlyPaymentSources, isV2PaymentSource } from '@/lib/payment-source-type';
 
 function App({ Component, pageProps, router }: AppProps) {
   return (
@@ -75,6 +76,7 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
     authorized,
     isSetupMode,
     activeRail,
+    setIsSetupMode,
   } = useAppContext();
 
   // Add dynamic favicon functionality
@@ -104,6 +106,7 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
     if (isLoading) return;
     const currentNetworkPaymentSources =
       network === 'Mainnet' ? mainnetPaymentSources : preprodPaymentSources;
+    const legacyOnlyPaymentSources = hasLegacyOnlyPaymentSources(currentNetworkPaymentSources);
     // Pages accessible even without payment sources (shown in setup sidebar)
     const setupAccessiblePages = ['/api-keys', '/developers', '/settings', '/x402-setup'];
     // The x402 rail stands alone, so don't force Cardano setup for it. Two strengths:
@@ -121,12 +124,25 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
         router.replace('/setup?network=' + (network === 'Mainnet' ? 'Mainnet' : 'Preprod'));
       }
     }
+    // Legacy-only operators should keep using the full admin UI with their V1
+    // source visible. Setup mode is only for the /setup wizard, not a persisted
+    // trap that hides the dashboard behind the V2 setup rail.
+    if (
+      apiKey &&
+      isHealthy &&
+      isSetupMode &&
+      legacyOnlyPaymentSources &&
+      router.pathname !== '/setup'
+    ) {
+      setIsSetupMode(false);
+    }
     // If setup mode is active (persisted from before reload), redirect back to setup
     // but allow access to pages shown in the setup sidebar
     if (
       apiKey &&
       isHealthy &&
       isSetupMode &&
+      !legacyOnlyPaymentSources &&
       router.pathname !== '/setup' &&
       !setupAccessiblePages.includes(router.pathname)
     ) {
@@ -153,6 +169,7 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
     preprodPaymentSources,
     isSetupMode,
     activeRail,
+    setIsSetupMode,
     x402Loading,
     x402Networks,
   ]);

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -49,6 +49,7 @@ import { PaymentSourceSyncBadge } from '@/components/payment-sources/PaymentSour
 import {
   DEFAULT_PAYMENT_SOURCE_TYPE,
   getPaymentSourceTypeLabel,
+  hasLegacyOnlyPaymentSources,
   isV2PaymentSource,
 } from '@/lib/payment-source-type';
 
@@ -197,7 +198,7 @@ export default function PaymentSourcesPage() {
     [paymentSources],
   );
   const hasV2Source = v2Sources.length > 0;
-  const hasLegacyOnly = legacySources.length > 0 && !hasV2Source;
+  const hasLegacyOnly = hasLegacyOnlyPaymentSources(paymentSources);
   // "A V2 row exists" is not the same as "V2 works": a source with no selling
   // wallet, no Blockfrost key or a retired contract would still have shown the
   // green "ready" banner. Readiness is the backend's call; the row count only
@@ -214,6 +215,7 @@ export default function PaymentSourcesPage() {
   const firstBlockingCheck = cardanoReadiness?.Checks.find((check) => !check.isComplete) ?? null;
   // Stay neutral rather than alarming while readiness is still resolving.
   const needsV2Setup = !isLoadingReadiness && !isV2Ready;
+  const showLegacyOperationalBanner = hasLegacyOnly && needsV2Setup;
 
   const [sourceToSelect, setSourceToSelect] = useState<PaymentSourceExtended | undefined>(
     undefined,
@@ -323,7 +325,7 @@ export default function PaymentSourcesPage() {
                         : hasV2Source
                           ? 'Finish V2 payment source setup'
                           : hasLegacyOnly
-                            ? 'Set up V2 before migrating agents'
+                            ? 'V1 source active — set up V2 when you are ready to migrate'
                             : 'Set up V2 for new agents'}
                     </p>
                     <PaymentSourceTypeBadge
@@ -334,9 +336,11 @@ export default function PaymentSourcesPage() {
                   <p className="max-w-3xl text-sm opacity-85">
                     {hasV2Source && !isV2Ready && firstBlockingCheck
                       ? `${firstBlockingCheck.label}: ${firstBlockingCheck.detail ?? 'not configured yet'}`
-                      : legacySources.length > 0
-                        ? 'V2 is the default for new agents. Create the V2 source, migrate V1 agents to the V2 registry, then delete the old source after it is no longer used.'
-                        : 'V2 is the default for new agents. Create a V2 source to use the new registry metadata and zero-fee payment source behavior.'}
+                      : showLegacyOperationalBanner
+                        ? `Your ${getPaymentSourceTypeLabel('Web3CardanoV1')} remains available below. Run V2 setup when you want to migrate agents to the new registry.`
+                        : legacySources.length > 0
+                          ? 'V2 is the default for new agents. Create the V2 source, migrate V1 agents to the V2 registry, then delete the old source after it is no longer used.'
+                          : 'V2 is the default for new agents. Create a V2 source to use the new registry metadata and zero-fee payment source behavior.'}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

 ## **Overview of Changes**
- Prefer operational V1 payment sources until the Cardano V2 rail is ready
- clear legacy-only setup-mode traps and keep migrate/setup banners without forcing the V2 setup rail over existing V1 data.

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
