### PR TITLE
ci(release): sign and attest the published container image

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -7,12 +7,61 @@ jobs:
   docker_publish:
     runs-on: 'ubuntu-22.04'
 
-    steps:
-      - uses: actions/checkout@v2
+    # `packages` pushes the image and its attestation, `id-token` mints the OIDC
+    # token Sigstore needs to issue a signing certificate, and `attestations`
+    # persists the signed provenance.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
 
-      # https://github.com/marketplace/actions/push-to-ghcr
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to a commit rather than `master`: this action builds the image
+      # that ships, so a moving ref would change the release without review.
+      # de5b1f4 is `master` as of 2026-06-19.
       - name: Build and publish a Docker image for ${{ github.repository }}
-        uses: macbre/push-to-ghcr@master
+        uses: macbre/push-to-ghcr@de5b1f400829a79007e48b901ef7e92a82b6486e
         with:
           image_name: ${{ github.repository }} # it will be lowercased internally
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # push-to-ghcr declares no outputs, so read the digest back from the
+      # registry. On a release it pushes exactly one tag, and it strips every
+      # `v` from the tag name; both are mirrored here so the reference resolves
+      # to the image that was actually pushed.
+      - name: Resolve the published image digest
+        id: image
+        env:
+          REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          NAME="ghcr.io/$(printf '%s' "$REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          TAG="${RELEASE_TAG//v/}"
+          DIGEST="$(docker buildx imagetools inspect "${NAME}:${TAG}" --format '{{.Manifest.Digest}}')"
+          case "$DIGEST" in
+          sha256:*) ;;
+          *)
+            echo "::error::expected a sha256 digest for ${NAME}:${TAG}, got '${DIGEST}'"
+            exit 1
+            ;;
+          esac
+          echo "name=${NAME}" >>"$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >>"$GITHUB_OUTPUT"
+          echo "Attesting ${NAME}@${DIGEST}"
+
+      # Signs a SLSA build provenance statement for the digest above and pushes
+      # it to GHCR alongside the image. Verify a release with:
+      #   gh attestation verify oci://ghcr.io/<owner>/<repo>:<tag> --repo <owner>/<repo>
+      - name: Attest and sign the published image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+          # The storage record is optional enrichment and needs a separate
+          # `artifact-metadata` permission. The signature does not depend on it.
+          create-storage-record: false


### PR DESCRIPTION
## Purpose

Releases are unsigned today, and always have been. `ghcr.yml` builds an image and pushes it, and nothing records what produced it. An operator pulling `ghcr.io/masumi-network/masumi-payment-service:0.28.0` has no way to tell it apart from any other image pushed under that tag.

This adds a signed SLSA build provenance attestation to every published release.

## What changed

One file, `.github/workflows/ghcr.yml`.

1. An explicit `permissions:` block. `packages: write` pushes the image and its attestation, `id-token: write` mints the OIDC token Sigstore needs to issue a signing certificate, `attestations: write` persists the provenance. The repo default is already `write`, so the publish step keeps the access it has now.
2. A step that reads the pushed digest back from the registry, because `macbre/push-to-ghcr` declares no outputs. It mirrors two behaviours of that action: on a `release` event it pushes exactly one tag, and it strips every `v` from the tag name.
3. `actions/attest@v4` with `subject-name` and `subject-digest`, pushing the attestation to GHCR next to the image.
4. `macbre/push-to-ghcr@master` pinned to `de5b1f400829a79007e48b901ef7e92a82b6486e`. It builds the image that ships, so a moving ref would change a release without review. That commit is `master` as of 2026-06-19, so it is the same code that built `0.28.0`.
5. `actions/checkout@v2` to `@v4`.

## Verifying a release afterwards

```bash
gh attestation verify \
  oci://ghcr.io/masumi-network/masumi-payment-service:0.29.0 \
  --repo masumi-network/masumi-payment-service
```

## Choices worth challenging

- **`actions/attest` rather than cosign.** The GitHub path signs through Sigstore, needs no extra tooling in the workflow, and verifies with the `gh` CLI that maintainers already have. Adding `cosign sign` as well would give a second signature over the same digest with a second thing to maintain. Say so if you want `cosign verify` to be the supported command instead.
- **`create-storage-record: false`.** The default is `true`, which needs an `artifact-metadata: write` permission. That key is recent enough that I could not confirm the workflow parser accepts it, and an unknown permission key is a parse error at release time. The storage record is optional enrichment; the signature does not depend on it. Turn it on separately once the key is confirmed.
- **The digest is read back from the registry, not produced by the build.** That is a consequence of `push-to-ghcr` having no outputs. Replacing it with `docker/build-push-action`, which outputs a digest directly, would remove the mirrored tag logic. It would also change the tagging behaviour of every future release, so it does not belong in this change.

## Verification

- `.github/workflows/ghcr.yml` parses as YAML; job permissions and the four steps resolve as intended.
- `prettier --check .github/workflows/ghcr.yml`: clean.
- The name and tag derivation was run with `REPOSITORY=masumi-network/masumi-payment-service` and `RELEASE_TAG=0.29.0`, producing `ghcr.io/masumi-network/masumi-payment-service:0.29.0`.
- Action versions checked against their sources, not from memory: `actions/attest` v4.2.2, `sigstore/cosign-installer` v4.1.2 (not used), and the `subject-name` / `subject-digest` / `push-to-registry` / `create-storage-record` inputs read from `actions/attest/action.yml`.
- Pre-push hooks passed: backend and frontend `tsc`, and no generated-file drift.

The workflow itself cannot run until a release is published, so CI here exercises everything except the signing job.
