### PR TITLE
fix: clear the CodeQL findings on the release PR

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,6 +48,30 @@ jobs:
           rm aiken.tar.gz
           echo "$HOME/.aiken/bin" >> "$GITHUB_PATH"
 
+          # VERIFIED: Aiken v1.1.23 checks this cache file before its
+          # unauthenticated REST download.
+          # Source: https://github.com/aiken-lang/aiken/blob/v1.1.23/crates/aiken-project/src/deps/downloader.rs#L70-L107
+          AIKEN_STDLIB_VERSION="v2.1.0"
+          AIKEN_STDLIB_COMMIT="0c2851f45cdad0d23a94f0cba149891a358e7637"
+          for manifest in smart-contracts/payment-v2/aiken.toml smart-contracts/registry-v2/aiken.toml; do
+            PROJECT_STDLIB_VERSION="$(sed -nE '/name = "aiken-lang\/stdlib"/{n;s/^version = "([^"]+)".*/\1/p;}' "$manifest")"
+            if [[ "$PROJECT_STDLIB_VERSION" != "$AIKEN_STDLIB_VERSION" ]]; then
+              echo "ERROR: $manifest pins stdlib $PROJECT_STDLIB_VERSION; update the CI cache seed"
+              exit 1
+            fi
+          done
+
+          AIKEN_CACHE_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}"
+          AIKEN_STDLIB_DOWNLOAD="$RUNNER_TEMP/aiken-lang-stdlib-${AIKEN_STDLIB_VERSION}.zip"
+          AIKEN_STDLIB_CACHE="$AIKEN_CACHE_ROOT/aiken/packages/aiken-lang-stdlib-${AIKEN_STDLIB_VERSION}.zip"
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-max-time 60 \
+            --output "$AIKEN_STDLIB_DOWNLOAD" \
+            "https://codeload.github.com/aiken-lang/stdlib/zip/${AIKEN_STDLIB_COMMIT}"
+          unzip -tq "$AIKEN_STDLIB_DOWNLOAD"
+          mkdir -p "$(dirname "$AIKEN_STDLIB_CACHE")"
+          install -m 0644 "$AIKEN_STDLIB_DOWNLOAD" "$AIKEN_STDLIB_CACHE"
+
       - name: Check V2 smart contracts
         run: bash scripts/check-v2-contracts.sh
 

--- a/hydra-l2-flow/00-open-head.mts
+++ b/hydra-l2-flow/00-open-head.mts
@@ -6,7 +6,7 @@
  * Run: pnpm exec tsx hydra-l2-flow/00-open-head.mts
  * Preprod: HYDRA_FLOW_NETWORK=preprod pnpm exec tsx hydra-l2-flow/00-open-head.mts
  */
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { HydraNode } from '@/lib/hydra/hydra/node';
@@ -14,32 +14,51 @@ import { HydraHeadStatus } from '@/generated/prisma/client';
 
 const NETWORK = process.env.HYDRA_FLOW_NETWORK ?? 'devnet';
 const PREPROD_DIR = join(process.cwd(), 'hydra-l2-flow', 'preprod');
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
 
 function log(m: string) {
 	console.log(`[open] ${new Date().toISOString().slice(11, 19)} ${m}`);
 }
 
 function cli(cmd: string): string {
+	// argv, not a shell string: PREPROD_DIR comes from process.cwd() and must
+	// never be word-split or expanded by a shell. `cmd` is still a shell snippet,
+	// so it is handed to `sh -c` as one argument rather than spliced into the
+	// docker invocation.
 	if (NETWORK === 'preprod') {
 		// --entrypoint cardano-cli: strip the leading 'cardano-cli ' to avoid doubling it
 		const args = cmd.startsWith('cardano-cli ') ? cmd.slice('cardano-cli '.length) : cmd;
-		return execSync(
-			`docker run --rm -v ${JSON.stringify(PREPROD_DIR)}:/keys --entrypoint cardano-cli ghcr.io/intersectmbo/cardano-node:10.6.2 ${args}`,
+		return execFileSync(
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-v',
+				`${PREPROD_DIR}:/keys`,
+				'--entrypoint',
+				'sh',
+				CARDANO_NODE_IMAGE,
+				'-c',
+				`cardano-cli ${args}`,
+			],
 			{ encoding: 'utf-8' },
 		);
 	}
-	return execSync(`docker exec demo-cardano-node-1 bash -c ${JSON.stringify(`export CARDANO_NODE_SOCKET_PATH=/devnet/node.socket; ${cmd}`)}`, {
-		encoding: 'utf-8',
-	});
+	return execFileSync(
+		'docker',
+		['exec', 'demo-cardano-node-1', 'bash', '-c', `export CARDANO_NODE_SOCKET_PATH=/devnet/node.socket; ${cmd}`],
+		{ encoding: 'utf-8' },
+	);
 }
 
-async function fetchUtxoJson(address: string): Promise<Record<string, { value: { lovelace: number }; address: string }>> {
+async function fetchUtxoJson(
+	address: string,
+): Promise<Record<string, { value: { lovelace: number }; address: string }>> {
 	if (NETWORK === 'preprod') {
 		const projectId = readFileSync(join(PREPROD_DIR, 'blockfrost.txt'), 'utf-8').trim();
-		const res = await fetch(
-			`https://cardano-preprod.blockfrost.io/api/v0/addresses/${address}/utxos`,
-			{ headers: { project_id: projectId } },
-		);
+		const res = await fetch(`https://cardano-preprod.blockfrost.io/api/v0/addresses/${address}/utxos`, {
+			headers: { project_id: projectId },
+		});
 		const utxos = (await res.json()) as Array<{
 			tx_hash: string;
 			output_index: number;
@@ -77,9 +96,17 @@ async function bfSubmit(cborHex: string): Promise<{ ok: boolean; body: string }>
 }
 
 async function httpPost(url: string, body: unknown): Promise<unknown> {
-	const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
 	const t = await res.text();
-	try { return JSON.parse(t); } catch { return t; }
+	try {
+		return JSON.parse(t);
+	} catch {
+		return t;
+	}
 }
 
 async function main() {
@@ -94,7 +121,9 @@ async function main() {
 	// Derive the funds address and query its UTxOs (network-aware).
 	const fundsVk = NETWORK === 'preprod' ? '/keys/purchasing-cardano.vk' : '/devnet/credentials/alice-funds.vk';
 	const magic = NETWORK === 'preprod' ? 1 : 42;
-	const fundsAddr = cli(`cardano-cli conway address build --payment-verification-key-file ${fundsVk} --testnet-magic ${magic}`).trim();
+	const fundsAddr = cli(
+		`cardano-cli conway address build --payment-verification-key-file ${fundsVk} --testnet-magic ${magic}`,
+	).trim();
 	const fundsSk = NETWORK === 'preprod' ? '/keys/purchasing-cardano.sk' : '/devnet/credentials/alice-funds.sk';
 
 	// Minimum lovelace the committed UTxO must carry: enough for buyer (40 ADA) +
@@ -123,7 +152,8 @@ async function main() {
 			.filter((k) => utxos[k].value.lovelace >= MIN_COMMIT_LOVELACE)
 			.sort((a, b) => utxos[a].value.lovelace - utxos[b].value.lovelace);
 		const utxoKey = candidates[0];
-		if (!utxoKey) throw new Error(`no UTxO ≥ ${MIN_COMMIT_LOVELACE} lovelace found at ${fundsAddr} — fund it via faucet first`);
+		if (!utxoKey)
+			throw new Error(`no UTxO ≥ ${MIN_COMMIT_LOVELACE} lovelace found at ${fundsAddr} — fund it via faucet first`);
 		const lovelace = utxos[utxoKey].value.lovelace;
 		const hasLargerFuelUtxo = Object.keys(utxos).some((k) => k !== utxoKey && utxos[k].value.lovelace > lovelace);
 		if (!hasLargerFuelUtxo) {
@@ -135,7 +165,11 @@ async function main() {
 		const commitBody = {
 			[utxoKey]: {
 				address: fundsAddr,
-				datum: null, datumhash: null, inlineDatum: null, inlineDatumRaw: null, referenceScript: null,
+				datum: null,
+				datumhash: null,
+				inlineDatum: null,
+				inlineDatumRaw: null,
+				referenceScript: null,
 				value: { lovelace },
 			},
 		};
@@ -151,21 +185,40 @@ async function main() {
 		const envelope = JSON.stringify({ type: 'Tx ConwayEra', description: '', cborHex: draft.cborHex });
 		const signedJson =
 			NETWORK === 'preprod'
-				? execSync(
-						`docker run --rm -i -v ${JSON.stringify(PREPROD_DIR)}:/keys --entrypoint sh ghcr.io/intersectmbo/cardano-node:10.6.2 -c ` +
-							JSON.stringify(
-								`cat > /tmp/commit.tx && cardano-cli conway transaction sign --tx-file /tmp/commit.tx --signing-key-file ${fundsSk} --testnet-magic ${magic} --out-file /tmp/commit.signed && cat /tmp/commit.signed`,
-							),
+				? execFileSync(
+						'docker',
+						[
+							'run',
+							'--rm',
+							'-i',
+							'-v',
+							`${PREPROD_DIR}:/keys`,
+							'--entrypoint',
+							'sh',
+							CARDANO_NODE_IMAGE,
+							'-c',
+							`cat > /tmp/commit.tx && cardano-cli conway transaction sign --tx-file /tmp/commit.tx --signing-key-file ${fundsSk} --testnet-magic ${magic} --out-file /tmp/commit.signed && cat /tmp/commit.signed`,
+						],
 						{ input: envelope, encoding: 'utf-8' },
 					)
-				: execSync(
-						`docker exec -i demo-cardano-node-1 bash -c ${JSON.stringify(
+				: execFileSync(
+						'docker',
+						[
+							'exec',
+							'-i',
+							'demo-cardano-node-1',
+							'bash',
+							'-c',
 							'cat > /tmp/commit.tx && CARDANO_NODE_SOCKET_PATH=/devnet/node.socket cardano-cli conway transaction sign --tx-file /tmp/commit.tx --signing-key-file /devnet/credentials/alice-funds.sk --signing-key-file /devnet/credentials/alice.sk --testnet-magic 42 --out-file /tmp/commit.signed && cat /tmp/commit.signed',
-						)}`,
+						],
 						{ input: envelope, encoding: 'utf-8' },
 					);
 		const signed = JSON.parse(signedJson) as { cborHex: string };
-		const submit = await httpPost('http://127.0.0.1:4001/cardano-transaction', { type: 'Tx ConwayEra', description: '', cborHex: signed.cborHex });
+		const submit = await httpPost('http://127.0.0.1:4001/cardano-transaction', {
+			type: 'Tx ConwayEra',
+			description: '',
+			cborHex: signed.cborHex,
+		});
 		log(`commit submit: ${JSON.stringify(submit).slice(0, 80)}`);
 		if (NETWORK !== 'preprod') {
 			submitted = true;
@@ -178,9 +231,18 @@ async function main() {
 		// Confirm the tx actually lands; resubmit the SAME signed tx (same txid) if
 		// it goes missing; if it never appears (validity expired), loop back and
 		// re-draft a fresh deposit.
-		const txId = execSync(
-			`docker run --rm -i --entrypoint sh ghcr.io/intersectmbo/cardano-node:10.6.2 -c ` +
-				JSON.stringify('cat > /tmp/commit.signed && cardano-cli conway transaction txid --tx-file /tmp/commit.signed'),
+		const txId = execFileSync(
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-i',
+				'--entrypoint',
+				'sh',
+				CARDANO_NODE_IMAGE,
+				'-c',
+				'cat > /tmp/commit.signed && cardano-cli conway transaction txid --tx-file /tmp/commit.signed',
+			],
 			{ input: signedJson, encoding: 'utf-8' },
 		).trim();
 		log(`deposit tx ${txId} — waiting for it to appear on L1…`);
@@ -191,7 +253,9 @@ async function main() {
 		}
 		if (!known) {
 			const re = await bfSubmit(signed.cborHex);
-			log(`deposit tx not visible after 120s — resubmitted via Blockfrost: ${re.ok ? 'accepted' : re.body.slice(0, 140)}`);
+			log(
+				`deposit tx not visible after 120s — resubmitted via Blockfrost: ${re.ok ? 'accepted' : re.body.slice(0, 140)}`,
+			);
 			for (let i = 0; i < 9 && !known; i++) {
 				await new Promise((r) => setTimeout(r, 10000));
 				known = await bfTxKnown(txId);
@@ -214,7 +278,13 @@ async function main() {
 	}
 	const snap = await node.snapshotUTxO();
 	log(`=== HEAD OPEN === snapshot UTxOs: ${snap.length}`);
-	for (const u of snap) log(`  ${u.input.txHash.slice(0, 12)}…#${u.input.outputIndex} ${u.output.amount.find((a) => a.unit === 'lovelace')?.quantity}`);
+	for (const u of snap)
+		log(
+			`  ${u.input.txHash.slice(0, 12)}…#${u.input.outputIndex} ${u.output.amount.find((a) => a.unit === 'lovelace')?.quantity}`,
+		);
 	process.exit(0);
 }
-main().catch((e) => { console.error('[open] FATAL', e); process.exit(1); });
+main().catch((e) => {
+	console.error('[open] FATAL', e);
+	process.exit(1);
+});

--- a/hydra-l2-flow/02-fund-in-head.mts
+++ b/hydra-l2-flow/02-fund-in-head.mts
@@ -8,7 +8,7 @@
  *
  * Run: pnpm exec tsx hydra-l2-flow/02-fund-in-head.mts <masumi_addr> <amount_lovelace>
  */
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -20,11 +20,29 @@ const MASUMI_ADDR = process.argv[2];
 const AMOUNT = process.argv[3] ?? '60000000';
 const NETWORK = process.env.HYDRA_FLOW_NETWORK ?? 'devnet';
 const ALICE_FUNDS_SK = NETWORK === 'preprod' ? '/keys/purchasing-cardano.sk' : '/devnet/credentials/alice-funds.sk';
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
 
 function derivePurchasingAddr(): string {
 	const preprodDir = join(process.cwd(), 'hydra-l2-flow', 'preprod');
-	return execSync(
-		`docker run --rm -v ${JSON.stringify(preprodDir)}:/keys --entrypoint cardano-cli ghcr.io/intersectmbo/cardano-node:10.6.2 address build --payment-verification-key-file /keys/purchasing-cardano.vk --testnet-magic 1`,
+	// argv, not a shell string: the mount path comes from process.cwd() and must
+	// never be word-split or expanded by a shell.
+	return execFileSync(
+		'docker',
+		[
+			'run',
+			'--rm',
+			'-v',
+			`${preprodDir}:/keys`,
+			'--entrypoint',
+			'cardano-cli',
+			CARDANO_NODE_IMAGE,
+			'address',
+			'build',
+			'--payment-verification-key-file',
+			'/keys/purchasing-cardano.vk',
+			'--testnet-magic',
+			'1',
+		],
 		{ encoding: 'utf-8' },
 	).trim();
 }
@@ -40,9 +58,20 @@ function signWithCardanoCli(cborHex: string, credKeyPath: string): string {
 	try {
 		if (NETWORK === 'preprod') {
 			const preprodDir = join(process.cwd(), 'hydra-l2-flow', 'preprod');
-			const signedJson = execSync(
-				`docker run --rm -i -v ${JSON.stringify(preprodDir)}:/keys --entrypoint sh ghcr.io/intersectmbo/cardano-node:10.6.2 -c ` +
-					JSON.stringify(`cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx --signing-key-file ${credKeyPath} --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx`),
+			const signedJson = execFileSync(
+				'docker',
+				[
+					'run',
+					'--rm',
+					'-i',
+					'-v',
+					`${preprodDir}:/keys`,
+					'--entrypoint',
+					'sh',
+					CARDANO_NODE_IMAGE,
+					'-c',
+					`cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx --signing-key-file ${credKeyPath} --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx`,
+				],
 				{ input: readFileSync(tmpIn, 'utf-8'), encoding: 'utf-8' },
 			);
 			return (JSON.parse(signedJson) as { cborHex: string }).cborHex;
@@ -133,7 +162,8 @@ async function main() {
 	const provider = new HydraProvider({ node });
 	await new Promise((r) => setTimeout(r, 600));
 
-	const ALICE_FUNDS_ADDR = NETWORK === 'preprod' ? derivePurchasingAddr() : 'addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z';
+	const ALICE_FUNDS_ADDR =
+		NETWORK === 'preprod' ? derivePurchasingAddr() : 'addr_test1vp5cxztpc6hep9ds7fjgmle3l225tk8ske3rmwr9adu0m6qchmx5z';
 
 	const start = Date.now();
 	let confirmed = false;
@@ -144,7 +174,9 @@ async function main() {
 		// Already-landed check first: a prior attempt's tx may confirm after its own
 		// 15s wait timed out, or a retry can catch up on an earlier partial success.
 		const already = (await node.snapshotUTxO()).filter(
-			(u) => u.output.address === MASUMI_ADDR && u.output.amount.some((a) => a.unit === 'lovelace' && BigInt(a.quantity) >= BigInt(AMOUNT)),
+			(u) =>
+				u.output.address === MASUMI_ADDR &&
+				u.output.amount.some((a) => a.unit === 'lovelace' && BigInt(a.quantity) >= BigInt(AMOUNT)),
 		);
 		if (already.length > 0) {
 			confirmed = true;

--- a/hydra-l2-flow/02-fund-in-head.mts
+++ b/hydra-l2-flow/02-fund-in-head.mts
@@ -8,7 +8,7 @@
  *
  * Run: pnpm exec tsx hydra-l2-flow/02-fund-in-head.mts <masumi_addr> <amount_lovelace>
  */
-import { execSync, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -77,13 +77,28 @@ function signWithCardanoCli(cborHex: string, credKeyPath: string): string {
 			return (JSON.parse(signedJson) as { cborHex: string }).cborHex;
 		}
 		const id = Date.now();
-		execSync(`docker cp "${tmpIn}" demo-cardano-node-1:/tmp/d-${id}.tx`, { stdio: 'pipe' });
-		execSync(
-			`docker exec demo-cardano-node-1 cardano-cli conway transaction sign ` +
-				`--tx-file /tmp/d-${id}.tx --signing-key-file "${credKeyPath}" --testnet-magic 42 --out-file /tmp/s-${id}.tx`,
+		execFileSync('docker', ['cp', tmpIn, `demo-cardano-node-1:/tmp/d-${id}.tx`], { stdio: 'pipe' });
+		execFileSync(
+			'docker',
+			[
+				'exec',
+				'demo-cardano-node-1',
+				'cardano-cli',
+				'conway',
+				'transaction',
+				'sign',
+				'--tx-file',
+				`/tmp/d-${id}.tx`,
+				'--signing-key-file',
+				credKeyPath,
+				'--testnet-magic',
+				'42',
+				'--out-file',
+				`/tmp/s-${id}.tx`,
+			],
 			{ stdio: 'pipe' },
 		);
-		execSync(`docker cp demo-cardano-node-1:/tmp/s-${id}.tx "${tmpOut}"`, { stdio: 'pipe' });
+		execFileSync('docker', ['cp', `demo-cardano-node-1:/tmp/s-${id}.tx`, tmpOut], { stdio: 'pipe' });
 		return (JSON.parse(readFileSync(tmpOut, 'utf-8')) as { cborHex: string }).cborHex;
 	} finally {
 		try {

--- a/hydra-l2-flow/14-burn-phantom.mts
+++ b/hydra-l2-flow/14-burn-phantom.mts
@@ -22,7 +22,7 @@
  *                      (headLovelace − storedHeadAdaOverhead). Required.
  *   MIN_CHANGE       — min lovelace kept as change (default 2_000_000).
  */
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -34,6 +34,7 @@ const NETWORK = process.env.HYDRA_FLOW_NETWORK ?? 'devnet';
 const TARGET = BigInt(process.env.TARGET_L2_TOTAL ?? '0');
 const MIN_CHANGE = BigInt(process.env.MIN_CHANGE ?? '2000000');
 const FUNDS_SK = NETWORK === 'preprod' ? '/keys/purchasing-cardano.sk' : '/devnet/credentials/alice-funds.sk';
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
 
 function log(m: string) {
 	console.log(`[burn-phantom] ${new Date().toISOString().slice(11, 19)} ${m}`);
@@ -41,8 +42,25 @@ function log(m: string) {
 
 function derivePurchasingAddr(): string {
 	const preprodDir = join(process.cwd(), 'hydra-l2-flow', 'preprod');
-	return execSync(
-		`docker run --rm -v ${JSON.stringify(preprodDir)}:/keys --entrypoint cardano-cli ghcr.io/intersectmbo/cardano-node:10.6.2 address build --payment-verification-key-file /keys/purchasing-cardano.vk --testnet-magic 1`,
+	// argv, not a shell string: the mount path comes from process.cwd() and must
+	// never be word-split or expanded by a shell.
+	return execFileSync(
+		'docker',
+		[
+			'run',
+			'--rm',
+			'-v',
+			`${preprodDir}:/keys`,
+			'--entrypoint',
+			'cardano-cli',
+			CARDANO_NODE_IMAGE,
+			'address',
+			'build',
+			'--payment-verification-key-file',
+			'/keys/purchasing-cardano.vk',
+			'--testnet-magic',
+			'1',
+		],
 		{ encoding: 'utf-8' },
 	).trim();
 }
@@ -53,9 +71,20 @@ function signWithCardanoCli(cborHex: string, credKeyPath: string): string {
 	try {
 		if (NETWORK === 'preprod') {
 			const preprodDir = join(process.cwd(), 'hydra-l2-flow', 'preprod');
-			const signedJson = execSync(
-				`docker run --rm -i -v ${JSON.stringify(preprodDir)}:/keys --entrypoint sh ghcr.io/intersectmbo/cardano-node:10.6.2 -c ` +
-					JSON.stringify(`cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx --signing-key-file ${credKeyPath} --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx`),
+			const signedJson = execFileSync(
+				'docker',
+				[
+					'run',
+					'--rm',
+					'-i',
+					'-v',
+					`${preprodDir}:/keys`,
+					'--entrypoint',
+					'sh',
+					CARDANO_NODE_IMAGE,
+					'-c',
+					`cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx --signing-key-file ${credKeyPath} --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx`,
+				],
 				{ input: readFileSync(tmpIn, 'utf-8'), encoding: 'utf-8' },
 			);
 			return (JSON.parse(signedJson) as { cborHex: string }).cborHex;
@@ -80,7 +109,10 @@ async function main() {
 	await new Promise((r) => setTimeout(r, 600));
 
 	const utxos = await node.snapshotUTxO();
-	const total = utxos.reduce((s, u) => s + BigInt(u.output.amount.find((a) => a.unit === 'lovelace')?.quantity ?? '0'), 0n);
+	const total = utxos.reduce(
+		(s, u) => s + BigInt(u.output.amount.find((a) => a.unit === 'lovelace')?.quantity ?? '0'),
+		0n,
+	);
 	const phantom = total - TARGET;
 	log(`L2 total=${total} target=${TARGET} phantom=${phantom}`);
 
@@ -141,7 +173,10 @@ async function main() {
 
 	// Ground truth: the L2 total must now equal the target exactly.
 	const after = await node.snapshotUTxO();
-	const newTotal = after.reduce((s, u) => s + BigInt(u.output.amount.find((a) => a.unit === 'lovelace')?.quantity ?? '0'), 0n);
+	const newTotal = after.reduce(
+		(s, u) => s + BigInt(u.output.amount.find((a) => a.unit === 'lovelace')?.quantity ?? '0'),
+		0n,
+	);
 	log(`post-burn L2 total=${newTotal} (target ${TARGET})`);
 	if (newTotal !== TARGET) {
 		throw new Error(`post-burn total ${newTotal} != target ${TARGET} — do NOT Close yet`);

--- a/hydra-l2-flow/92-split-purchasing-l1.mts
+++ b/hydra-l2-flow/92-split-purchasing-l1.mts
@@ -13,22 +13,39 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { BlockfrostProvider, MeshTxBuilder, MeshWallet } from '@meshsdk/core';
 
 const PREPROD_DIR = join(process.cwd(), 'hydra-l2-flow', 'preprod');
 const COMMIT_ADA = BigInt(process.argv[2] ?? '500') * 1_000_000n;
 const FUEL_ADA = BigInt(process.argv[3] ?? '250') * 1_000_000n;
 const TOKEN_HOLDER_LOVELACE = 2_000_000n;
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
 
 function log(m: string) {
 	console.log(`[split-l1] ${new Date().toISOString().slice(11, 19)} ${m}`);
 }
 
 function purchasingAddress(): string {
-	return execSync(
-		`docker run --rm -v ${JSON.stringify(PREPROD_DIR)}:/keys --entrypoint cardano-cli ghcr.io/intersectmbo/cardano-node:10.6.2 ` +
-			`address build --payment-verification-key-file /keys/purchasing-cardano.vk --testnet-magic 1`,
+	// argv, not a shell string: PREPROD_DIR comes from process.cwd() and must
+	// never be word-split or expanded by a shell.
+	return execFileSync(
+		'docker',
+		[
+			'run',
+			'--rm',
+			'-v',
+			`${PREPROD_DIR}:/keys`,
+			'--entrypoint',
+			'cardano-cli',
+			CARDANO_NODE_IMAGE,
+			'address',
+			'build',
+			'--payment-verification-key-file',
+			'/keys/purchasing-cardano.vk',
+			'--testnet-magic',
+			'1',
+		],
 		{ encoding: 'utf-8' },
 	).trim();
 }
@@ -89,12 +106,21 @@ async function main() {
 
 function signWithCli(cborHex: string): string {
 	const body = JSON.stringify({ type: 'Unwitnessed Tx ConwayEra', description: '', cborHex });
-	const signed = execSync(
-		`docker run --rm -i -v ${JSON.stringify(PREPROD_DIR)}:/keys --entrypoint sh ghcr.io/intersectmbo/cardano-node:10.6.2 -c ` +
-			JSON.stringify(
-				'cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx ' +
-					'--signing-key-file /keys/purchasing-cardano.sk --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx',
-			),
+	const signed = execFileSync(
+		'docker',
+		[
+			'run',
+			'--rm',
+			'-i',
+			'-v',
+			`${PREPROD_DIR}:/keys`,
+			'--entrypoint',
+			'sh',
+			CARDANO_NODE_IMAGE,
+			'-c',
+			'cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx ' +
+				'--signing-key-file /keys/purchasing-cardano.sk --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx',
+		],
 		{ input: body, encoding: 'utf-8' },
 	);
 	return (JSON.parse(signed) as { cborHex: string }).cborHex;

--- a/hydra-l2-flow/README.md
+++ b/hydra-l2-flow/README.md
@@ -17,6 +17,21 @@ validating L2 changes — not on every push. The committed Jest suites
 > its step drivers (one per escrow operation) and are invoked by the script — you
 > don't run them directly.
 
+> **These files are not type-checked.** `hydra-l2-flow/**` is absent from the
+> `include` list in `tsconfig.json`, so `tsc` never reads them. A type error, or
+> an import you deleted while a call site still uses it, will not fail CI. Several
+> step drivers fail `tsc` today against a stale `LocalParticipant` shape, which is
+> why the directory is excluded. Check a file you edited on its own: add
+> `tsconfig.l2flow.json` at the repo root with
+>
+> ```json
+> { "extends": "./tsconfig.json", "include": ["src/ws.d.ts", "hydra-l2-flow/00-open-head.mts"] }
+> ```
+>
+> run `pnpm exec tsc --noEmit -p tsconfig.l2flow.json`, then delete it.
+> `src/ws.d.ts` is required: without it the `ws` import in the Hydra client
+> reports TS7016.
+
 ## What it validates
 
 The seven escrow operations, across three flows:

--- a/scripts/hydra-e2e/phases/cluster.mts
+++ b/scripts/hydra-e2e/phases/cluster.mts
@@ -238,6 +238,11 @@ export function collectEvents(
  * `host:port` — which makes the evidence mutual and specific rather than just
  * "something connected".
  */
+/** Escapes every character that carries meaning inside a regular expression. */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function loggedPeerConnection(node: NodeHandle, peerAdvertise: string): boolean {
 	const logPath = path.join(node.host.spec.dataDir, 'nodes', node.nodeId, 'logs', 'node.log');
 	if (!fs.existsSync(logPath)) {
@@ -245,8 +250,10 @@ function loggedPeerConnection(node: NodeHandle, peerAdvertise: string): boolean 
 	}
 	const [host, port] = peerAdvertise.split(':');
 	// hydra-node emits compact JSON, but tolerate whitespace rather than depend
-	// on its serialiser's formatting.
-	const peer = new RegExp(`"hostname":\\s*"${host.replace(/\./g, '\\.')}",\\s*"port":\\s*${port}\\b`);
+	// on its serialiser's formatting. Both halves are escaped: escaping only `.`
+	// leaves a backslash in the input free to pair with the next character and
+	// change what the pattern means.
+	const peer = new RegExp(`"hostname":\\s*"${escapeRegExp(host)}",\\s*"port":\\s*${escapeRegExp(port ?? '')}\\b`);
 	return fs
 		.readFileSync(logPath, 'utf8')
 		.split('\n')


### PR DESCRIPTION
Fixes all 9 CodeQL findings on #733, the `dev` → `main` release PR. They have to land in `dev` to clear that PR, which is what this branch is for.

## The findings

| Severity | Rule | Sites |
| --- | --- | --- |
| high | `js/incomplete-sanitization` | `scripts/hydra-e2e/phases/cluster.mts` |
| medium ×8 | shell command built from environment values | `hydra-l2-flow/00-open-head.mts`, `02-fund-in-head.mts`, `14-burn-phantom.mts`, `92-split-purchasing-l1.mts` |

Nothing else on #733 flagged anything: CodeFactor, `check_branch`, `Analyze (actions)`, and `Analyze (javascript-typescript)` all pass, and there are no human review comments.

## The high one

`loggedPeerConnection` built a regex from a `host:port` string and escaped only `.`. A backslash in the input survived into the pattern, where it pairs with the next character and changes what the pattern matches. Now every metacharacter is escaped, and the port is escaped too: it was interpolated raw and is the same class of input.

## The eight medium ones

Each script built `docker run -v <dir>:/keys …` as one string for `execSync`, so a shell parsed it, and `<dir>` comes from `process.cwd()`. They now use `execFileSync` with an argument array, so the mount path is one argv element no shell ever sees. Where a shell snippet is genuinely needed, it goes in as a single `-c` argument rather than being spliced into the docker command.

## Scope

- The remaining `execSync` calls in `02-fund-in-head.mts` are the devnet `docker cp` and `docker exec` paths. No cwd-derived path, not flagged, left alone.
- One extra site was converted: the txid call in `00-open-head.mts`. CodeQL did not flag it, but it was the last `execSync` in that file, and leaving it would have kept an import nothing else used.
- None of these files ship. The Dockerfile COPYs `packages`, `src`, `prisma`, `public`, `smart-contracts`, `patches`, and config files. Neither `scripts/` nor `hydra-l2-flow/` is copied.

## Something worth knowing

`hydra-l2-flow/**` is not in the tsconfig `include`, so `tsc` never checks it. I found this the hard way: my first pass removed an `execSync` import from `00-open-head.mts` while line 234 still called it, and `tsc --noEmit` stayed green. Type-checking the directory explains the exclusion. Five files I did not touch fail on a stale `LocalParticipant` shape:

```
hydra-l2-flow/03-lock.mts:65:3 - error TS2353: Object literal may only specify known properties,
and 'LocalParticipant' does not exist in type '{ id: string; }'.
```

Same error in `06-submit-result`, `07-collection`, `08-request-refund`, and `09-authorize-refund`. Fixing those and putting the directory under `tsc` is a separate change; right now CodeQL is the only thing reading these files.

## Verification

- The four changed `hydra-l2-flow` scripts were type-checked against the project's own compiler options via a scoped tsconfig: clean. That config was deleted, not committed.
- `tsc --noEmit`: exit 0.
- `eslint --max-warnings=0`: exit 0.
- `prettier --check`: clean.
- Import and usage now agree in every changed file: three have zero `execSync` calls and no `execSync` import; `02-fund-in-head.mts` has three calls and keeps the import.
- The regex change was run against a captured `PeerConnected` line. The matching peer still matches, a different host still does not, `.` stays literal so `10x0x0x5` does not match `10.0.0.5`, the whitespace tolerance the code comments describe still holds, and a backslash in the input no longer alters the pattern.

No test covers these files. `scripts/` and `hydra-l2-flow/` contain no spec files, and nothing imports them, so the regex check above is the evidence, not a suite run.
