### PR TITLE
fix(e2e): make the client's retry classifier see undici errors

### DIFF
--- a/tests/e2e/utils/apiClient.ts
+++ b/tests/e2e/utils/apiClient.ts
@@ -425,6 +425,22 @@ export interface QueryWalletsResponse {
 	Wallets: WalletListItem[];
 }
 
+/**
+ * The message of anything thrown, or null if it carries none.
+ *
+ * `instanceof Error` cannot be used to reach it. Jest's node environment runs
+ * this module inside a vm context, so its `Error` is not the `Error` that
+ * Node's fetch used to build the rejection, and the check is false for every
+ * error undici raises.
+ */
+function messageOf(error: unknown): string | null {
+	if (typeof error !== 'object' || error === null) {
+		return null;
+	}
+	const message = (error as { message?: unknown }).message;
+	return typeof message === 'string' ? message : null;
+}
+
 export class ApiClient {
 	private config: ApiClientConfig;
 
@@ -493,19 +509,24 @@ export class ApiClient {
 				// `TypeError('fetch failed')`, so the 'fetch failed' fragment in
 				// the message catches the intended case.
 				const transientFragments = /fetch failed|SocketError|ECONNRESET|EPIPE|other side closed/i;
+				// Match on shape, not `instanceof Error`. undici builds its errors in
+				// Node's realm while this module runs inside Jest's, so `instanceof
+				// Error` is false for exactly the socket failures this retry exists
+				// for, and the branch below never ran.
+				const message = messageOf(error);
 				const isTransient =
-					error instanceof Error &&
-					(transientFragments.test(error.message) ||
+					message !== null &&
+					(transientFragments.test(message) ||
 						transientFragments.test(String((error as { cause?: unknown }).cause ?? ''))) &&
-					!/HTTP \d{3}:/.test(error.message);
+					!/HTTP \d{3}:/.test(message);
 				if (isTransient && attempt < maxRetries) {
 					// Exponential backoff with jitter: 100ms, 250ms, 600ms (max).
 					const delay = Math.floor(Math.random() * (100 * Math.pow(2, attempt) + 100));
 					await new Promise((resolve) => setTimeout(resolve, delay));
 					continue;
 				}
-				if (error instanceof Error) {
-					throw new Error(`API request failed: ${error.message}`);
+				if (message !== null) {
+					throw new Error(`API request failed: ${message}`);
 				}
 				throw error;
 			}


### PR DESCRIPTION
The e2e client's retry loop has never run. Found while investigating why #735's e2e job failed.

## The bug

`makeRequest` gates both its retry and its error wrapper on `error instanceof Error`:

```ts
const isTransient =
    error instanceof Error && (transientFragments.test(error.message) || ...) && ...;
...
if (error instanceof Error) {
    throw new Error(`API request failed: ${error.message}`);
}
throw error;
```

Jest's node environment evaluates this module inside a vm context, so the `Error` binding here is not the `Error` that Node's fetch used to construct the rejection. `instanceof Error` is false for every error undici raises, which is exactly the set the retry was written for. The comment above it names them: *"server closed an idle keep-alive socket, TCP RST"*, surfacing as `fetch failed: SocketError: other side closed`.

Measured under this repo's own jest config, catching a real failed fetch:

```
raw message      : fetch failed
OLD isTransient  : false
NEW isTransient  : true
```

`fetch failed` is the first alternative in `transientFragments`, and it was never matching.

## How it showed up

The same gate guards the wrapper below it, so undici errors fell through to `throw error` unwrapped. That is why the e2e failure on #735 printed a bare

```
AbortError: This operation was aborted
```

with no `API request failed:` prefix anywhere in the log. Errors this client raises itself, like `HTTP 404: …`, are constructed in Jest's realm and were wrapped correctly, which is why the gap went unnoticed.

## The fix

Classify and unwrap by shape rather than by prototype identity. Six lines plus a helper.

## What this changes in practice

Retries begin firing for the first time. That is the loop's stated intent, but it is the part worth challenging, so here is the safety argument rather than an assurance:

- A re-sent create cannot duplicate a row. `blockchainIdentifier` is `@unique` on both `PurchaseRequest` and `PaymentRequest`, so re-sending a request that did land fails the constraint instead of creating a second row.
- The consequence is therefore a changed failure mode, not corrupted data: a create that succeeded but whose response was lost will now fail its retry on the unique constraint rather than failing on the socket error.
- HTTP status errors are still excluded by the existing `!/HTTP \d{3}:/` guard, so 4xx and 5xx stay non-retryable.
- Anything thrown without a string `message` still rethrows untouched.

## What this does not fix

It does not stop #735's failure from recurring. That was `AbortError: This operation was aborted`, a 30s client timeout during three concurrent `createPurchase` calls, and `This operation was aborted` matches none of the transient fragments. Adding aborts to that set would retry a request that may still be executing server-side, which is a different decision and not one I want to bundle here. After this change the same failure reports as `API request failed: This operation was aborted`, which at least says which layer gave up.

## Verification

- `tsc --noEmit`: exit 0.
- `eslint --max-warnings=0`: exit 0.
- `prettier --check`: clean.
- The before and after classification above was measured by catching a real failed fetch under the repo's jest config, not reasoned about. The probe also confirmed `HTTP 404: not found` stays non-transient and that a thrown string, `null`, and `{}` all yield `null`.

No test ships with this. `jest.config.ts` roots at `src` and `packages` only, and `tests/` contains no spec files, so a test for e2e harness internals has nowhere to run that matches how this repo is laid out. Giving the e2e utils their own suite is a larger change than this fix.
