### PR TITLE
fix(frontend): complete fund wallet step only after ADA arrives

### DIFF
--- a/frontend/src/components/ui/welcome-banner-fund-step.test.ts
+++ b/frontend/src/components/ui/welcome-banner-fund-step.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isWalletFundStepComplete } from './welcome-banner-fund-step';
+
+test('keeps the fund step incomplete while wallet balances are loading', () => {
+  assert.equal(
+    isWalletFundStepComplete({
+      isLoading: true,
+      wallets: [{ balance: '1000000' }],
+    }),
+    false,
+  );
+});
+
+test('keeps the fund step incomplete when wallets exist but every balance is zero', () => {
+  assert.equal(
+    isWalletFundStepComplete({
+      isLoading: false,
+      wallets: [{ balance: '0' }, { balance: '0' }],
+    }),
+    false,
+  );
+});
+
+test('completes the fund step when at least one wallet has a positive ADA balance', () => {
+  assert.equal(
+    isWalletFundStepComplete({
+      isLoading: false,
+      wallets: [{ balance: '0' }, { balance: '2500000' }],
+    }),
+    true,
+  );
+});
+
+test('does not complete the fund step when every balance is unavailable', () => {
+  assert.equal(
+    isWalletFundStepComplete({
+      isLoading: false,
+      wallets: [
+        { balance: '0', isBalanceUnavailable: true },
+        { balance: '5000000', isBalanceUnavailable: true },
+      ],
+    }),
+    false,
+  );
+});
+
+test('ignores unavailable wallets even when another wallet has zero ADA', () => {
+  assert.equal(
+    isWalletFundStepComplete({
+      isLoading: false,
+      wallets: [{ balance: '0' }, { balance: '9000000', isBalanceUnavailable: true }],
+    }),
+    false,
+  );
+});

--- a/frontend/src/components/ui/welcome-banner-fund-step.ts
+++ b/frontend/src/components/ui/welcome-banner-fund-step.ts
@@ -1,0 +1,24 @@
+export type WalletFundStepBalance = {
+  balance: string;
+  isBalanceUnavailable?: boolean;
+};
+
+export type WalletFundStepInput = {
+  isLoading: boolean;
+  wallets: WalletFundStepBalance[];
+};
+
+/**
+ * The welcome checklist "Fund a wallet" step completes only once at least one
+ * wallet has a confirmed positive ADA balance. Loading and unavailable balances
+ * never count as funded.
+ */
+export function isWalletFundStepComplete({ isLoading, wallets }: WalletFundStepInput): boolean {
+  if (isLoading) {
+    return false;
+  }
+
+  return wallets.some(
+    (wallet) => !wallet.isBalanceUnavailable && BigInt(wallet.balance || '0') > BigInt(0),
+  );
+}

--- a/frontend/src/components/ui/welcome-banner.tsx
+++ b/frontend/src/components/ui/welcome-banner.tsx
@@ -6,7 +6,7 @@ import { useAppContext } from '@/lib/contexts/AppContext';
 
 interface WelcomeBannerProps {
   agentCount: number;
-  walletCount: number;
+  hasFundedWallet: boolean;
   transactionCount: number;
   hasPaymentSource: boolean;
 }
@@ -28,7 +28,7 @@ function subscribe(callback: () => void) {
 
 export function WelcomeBanner({
   agentCount,
-  walletCount,
+  hasFundedWallet,
   transactionCount,
   hasPaymentSource,
 }: WelcomeBannerProps) {
@@ -58,7 +58,7 @@ export function WelcomeBanner({
     {
       label: 'Fund a wallet',
       href: '/wallets',
-      done: walletCount > 0,
+      done: hasFundedWallet,
       icon: Wallet,
       visible: capabilities.canAdmin,
     },

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -44,6 +44,7 @@ import { AnimatedPage } from '@/components/ui/animated-page';
 import { StatCard } from '@/components/ui/stat-card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { WelcomeBanner } from '@/components/ui/welcome-banner';
+import { isWalletFundStepComplete } from '@/components/ui/welcome-banner-fund-step';
 import { SetupV2Banner } from '@/components/setup/SetupV2Banner';
 import { MigrateAgentsDialog } from '@/components/ai-agents/MigrateAgentsDialog';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
@@ -107,6 +108,14 @@ export default function Overview() {
   const totalBalance = useMemo(() => totalBalanceValue || '0', [totalBalanceValue]);
   const totalUsdcxBalance = useMemo(() => totalUsdcxBalanceValue || '0', [totalUsdcxBalanceValue]);
   const isLoadingBalances = isLoadingWallets;
+  const hasFundedWallet = useMemo(
+    () =>
+      isWalletFundStepComplete({
+        isLoading: isLoadingWallets,
+        wallets: walletsList,
+      }),
+    [isLoadingWallets, walletsList],
+  );
   const currentNetworkPaymentSources = useMemo(
     () => paymentSources.filter((source) => source.network === network),
     [paymentSources, network],
@@ -227,7 +236,7 @@ export default function Overview() {
 
             <WelcomeBanner
               agentCount={agents.length}
-              walletCount={walletsList.length}
+              hasFundedWallet={hasFundedWallet}
               transactionCount={transactions.length}
               hasPaymentSource={!!selectedPaymentSource}
             />


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
Mark the welcome checklist fund step done only when at least one wallet has a positive lovelace balance, not merely when wallets exist.
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
