### PR TITLE
feat(reports): add export workflow

### DIFF
--- a/frontend/src/components/setup/SetupWelcome.tsx
+++ b/frontend/src/components/setup/SetupWelcome.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { useQueryClient } from '@tanstack/react-query';
 import { invalidateAgentQueries } from '@/lib/queries/agent-cache';
+import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
 import { isV2PaymentSource } from '@/lib/payment-source-type';
 import { useRailReadiness } from '@/lib/hooks/useRailReadiness';
 import { STEP_LABELS, type SetupWallet } from '@/components/setup/setup-helpers';
@@ -80,6 +81,7 @@ export function SetupWelcome({ networkType }: { networkType: string }) {
     queryClient.invalidateQueries({ queryKey: ['wallets'] });
     invalidateAgentQueries(queryClient);
     queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    void invalidateTransactionReportFacets(queryClient);
     router.push('/');
   };
 

--- a/frontend/src/components/transactions/DownloadDetailsDialog.tsx
+++ b/frontend/src/components/transactions/DownloadDetailsDialog.tsx
@@ -1,5 +1,15 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Download, FileArchive, FileSpreadsheet, Loader2, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -7,303 +17,462 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Download } from 'lucide-react';
-import { dateRangeUtils, endOfDayLocal, parseDateOnlyLocal } from '@/lib/utils';
-import { useAppContext } from '@/lib/contexts/AppContext';
-import { getPayment, getPurchase, Payment, Purchase } from '@/lib/api/generated';
+import { Textarea } from '@/components/ui/textarea';
+import { cn, shortenAddress } from '@/lib/utils';
+import type { ReportExportKind } from '@/lib/transaction-report/download';
+import { getReportTransactionCountDisplay } from '@/lib/transaction-report/dashboard-metrics';
 import {
-  buildTransactionDownloadQuery,
-  mergeDownloadedTransactions,
+  REPORT_ON_CHAIN_STATES,
+  type ReportDateBasis,
+  type ReportDatePreset,
+  type ReportRevenueMode,
+  type TransactionReportViewDefaults,
 } from './download-details.helpers';
+import { useDownloadDetailsModel } from './useDownloadDetailsModel';
 
-type Transaction =
-  | (Payment & { type: 'payment' })
-  | (Purchase & {
-      type: 'purchase';
-    });
-
-interface DownloadDetailsDialogProps {
+type DownloadDetailsDialogProps = Readonly<{
   open: boolean;
   onClose: () => void;
-  onDownload: (startDate: Date, endDate: Date, transactions: Transaction[]) => void;
-}
+  viewDefaults: TransactionReportViewDefaults;
+}>;
 
-type PresetOption = '24h' | '7d' | '30d' | '90d' | 'custom';
-
-const PRESET_OPTIONS = [
+const DATE_PRESETS: ReadonlyArray<{ value: ReportDatePreset; label: string }> = [
   { value: '24h', label: 'Last 24 hours' },
-  { value: '7d', label: 'Last week' },
-  { value: '30d', label: 'Last month' },
-  { value: '90d', label: 'Last 3 months' },
-  { value: 'custom', label: 'Custom range' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 90 days' },
+  { value: 'custom', label: 'Custom dates' },
 ];
 
-export function DownloadDetailsDialog({ open, onClose, onDownload }: DownloadDetailsDialogProps) {
-  const { apiClient, network } = useAppContext();
-  const [selectedPreset, setSelectedPreset] = useState<PresetOption>('24h');
-  const [customStartDate, setCustomStartDate] = useState('');
-  const [customEndDate, setCustomEndDate] = useState('');
+const DATE_BASES: ReadonlyArray<{ value: ReportDateBasis; label: string; detail: string }> = [
+  { value: 'RevenueRecognizedAt', label: 'Revenue recognized', detail: 'Economic events' },
+  { value: 'FundsLockedAt', label: 'Funds locked', detail: 'Escrow cohort' },
+  { value: 'CreatedAt', label: 'Request created', detail: 'Request cohort' },
+];
 
-  const fetchAllTransactions = useCallback(async (): Promise<Transaction[]> => {
-    const allTx: Transaction[] = [];
-    let purchaseCursor: string | null = null;
-    let paymentCursor: string | null = null;
-    let hasMorePurchases = true;
-    let hasMorePayments = true;
+const REVENUE_MODES: ReadonlyArray<{
+  value: ReportRevenueMode;
+  label: string;
+  detail: string;
+}> = [
+  { value: 'Billable', label: 'Billable', detail: 'Earned after unlock' },
+  { value: 'CashReceived', label: 'Cash received', detail: 'Withdrawn payouts' },
+  { value: 'RequestedGross', label: 'Requested gross', detail: 'All requested value' },
+];
 
-    try {
-      // Fetch all purchases with pagination. Failures are console-only (no
-      // toast) and end the loop with whatever pages already arrived — same
-      // contract as the previous handleApiCall onError override.
-      while (hasMorePurchases) {
-        const purchases: Awaited<ReturnType<typeof getPurchase>> | null = await getPurchase({
-          client: apiClient,
-          query: buildTransactionDownloadQuery(network, purchaseCursor || undefined),
-        }).catch((error: unknown) => {
-          console.error('Failed to fetch purchases:', error);
-          return null;
-        });
-        if (purchases && 'error' in purchases && purchases.error) {
-          console.error('Failed to fetch purchases:', purchases.error);
-          break;
-        }
+const EXPORT_KINDS: ReadonlyArray<{
+  value: ReportExportKind;
+  label: string;
+  detail: string;
+}> = [
+  {
+    value: 'transactions',
+    label: 'Transactions CSV',
+    detail: 'One buyer or seller row per request',
+  },
+  {
+    value: 'wallet-summary',
+    label: 'Wallet summary CSV',
+    detail: 'Totals by managed wallet and role',
+  },
+  { value: 'totals', label: 'Totals CSV', detail: 'One payment source total' },
+  { value: 'zip', label: 'Complete ZIP', detail: 'All three CSV files from one snapshot' },
+];
 
-        if (purchases?.data?.data?.Purchases) {
-          const nextPurchases = purchases.data.data.Purchases.map(
-            (purchase) =>
-              ({
-                ...purchase,
-                type: 'purchase',
-              }) as Transaction,
-          );
-          const mergedPurchases = mergeDownloadedTransactions(allTx, nextPurchases);
-          allTx.length = 0;
-          allTx.push(...mergedPurchases);
-          hasMorePurchases = purchases.data.data.Purchases.length === 100;
-          purchaseCursor =
-            purchases.data.data.Purchases[purchases.data.data.Purchases.length - 1]?.id;
-        } else {
-          hasMorePurchases = false;
-        }
-      }
+function humanize(value: string): string {
+  return value.replace(/([A-Z])/g, ' $1').trim();
+}
 
-      // Fetch all payments with pagination (same failure contract as above).
-      while (hasMorePayments) {
-        const payments: Awaited<ReturnType<typeof getPayment>> | null = await getPayment({
-          client: apiClient,
-          query: buildTransactionDownloadQuery(network, paymentCursor || undefined),
-        }).catch((error: unknown) => {
-          console.error('Failed to fetch payments:', error);
-          return null;
-        });
-        if (payments && 'error' in payments && payments.error) {
-          console.error('Failed to fetch payments:', payments.error);
-          break;
-        }
+function todayAsDateInput(): string {
+  const today = new Date();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${today.getFullYear()}-${month}-${day}`;
+}
 
-        if (payments?.data?.data?.Payments) {
-          const nextPayments = payments.data.data.Payments.map(
-            (payment) =>
-              ({
-                ...payment,
-                type: 'payment',
-              }) as Transaction,
-          );
-          const mergedPayments = mergeDownloadedTransactions(allTx, nextPayments);
-          allTx.length = 0;
-          allTx.push(...mergedPayments);
-          hasMorePayments = payments.data.data.Payments.length === 100;
-          paymentCursor = payments.data.data.Payments[payments.data.data.Payments.length - 1]?.id;
-        } else {
-          hasMorePayments = false;
-        }
-      }
-
-      return allTx;
-    } catch (error) {
-      console.error('Error fetching transactions:', error);
-      return allTx;
-    }
-  }, [apiClient, network]);
-
-  // Refetches on every dialog open (enabled flip + zero staleTime), matching
-  // the previous fetch-on-open effect.
-  const { data: allTransactions = [], isFetching: isLoading } = useQuery<Transaction[]>({
-    queryKey: ['download-transactions', network],
-    queryFn: fetchAllTransactions,
-    enabled: open,
-    staleTime: 0,
-  });
-  // Calculate filtered transactions for display
-  const getFilteredTransactions = useCallback(() => {
-    let startDate: Date;
-    let endDate: Date = new Date();
-
-    if (selectedPreset === 'custom') {
-      if (!customStartDate || !customEndDate) {
-        return [];
-      }
-      // Parse the date-only inputs as a local-time range (start of the start
-      // day to end of the end day); UTC parsing would drop the whole end day
-      // for users west of UTC.
-      const start = parseDateOnlyLocal(customStartDate);
-      const end = parseDateOnlyLocal(customEndDate);
-      if (!start || !end) {
-        return [];
-      }
-      startDate = start;
-      endDate = endOfDayLocal(end);
-    } else {
-      const range = dateRangeUtils.getPresetRange(selectedPreset);
-      startDate = range.start;
-      endDate = range.end;
-    }
-
-    const filtered = allTransactions.filter((tx) => {
-      const txDate = new Date(tx.createdAt);
-      return txDate >= startDate && txDate <= endDate;
-    });
-
-    return filtered;
-  }, [allTransactions, selectedPreset, customStartDate, customEndDate]);
-  // Pure derived state: recomputes from the fetched transactions and the
-  // selected range. Empty while the dialog is closed.
-  const filteredTransactions = useMemo(
-    () => (open ? getFilteredTransactions() : []),
-    [open, getFilteredTransactions],
+export function DownloadDetailsDialog({ open, onClose, viewDefaults }: DownloadDetailsDialogProps) {
+  const model = useDownloadDetailsModel({ open, onClose, viewDefaults });
+  const previewCountDisplay = model.preview
+    ? getReportTransactionCountDisplay(
+        model.preview.totals.transactionCount,
+        model.preview.totals.transactionCountCompleteness,
+        'filtered transaction',
+      )
+    : null;
+  const selectedExport = EXPORT_KINDS.find((option) => option.value === model.exportKind);
+  const selectedSource = model.paymentSources.find(
+    (source) => source.id === model.form.paymentSourceId,
   );
-
-  const handleDownload = () => {
-    let startDate: Date;
-    let endDate: Date = new Date();
-
-    if (selectedPreset === 'custom') {
-      if (!customStartDate || !customEndDate) {
-        return; // Don't download if custom dates are not set
-      }
-      // Same local-time range as the preview count in getFilteredTransactions.
-      const start = parseDateOnlyLocal(customStartDate);
-      const end = parseDateOnlyLocal(customEndDate);
-      if (!start || !end) {
-        return;
-      }
-      startDate = start;
-      endDate = endOfDayLocal(end);
-    } else {
-      // Calculate start date based on preset
-      const range = dateRangeUtils.getPresetRange(selectedPreset);
-      startDate = range.start;
-      endDate = range.end;
-    }
-
-    // Use the same filtered transactions
-    const filteredTransactions = getFilteredTransactions();
-
-    onDownload(startDate, endDate, filteredTransactions);
-    onClose();
-  };
-
-  const handleReset = () => {
-    setSelectedPreset('24h');
-    setCustomStartDate('');
-    setCustomEndDate('');
-  };
+  const maxDate = todayAsDateInput();
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Download transactions as CSV</DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-6">
-          <div className="space-y-4">
-            <Label className="text-sm font-medium">Select Date Range</Label>
-            <Select
-              value={selectedPreset}
-              onValueChange={(value) => setSelectedPreset(value as PresetOption)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Choose a date range" />
-              </SelectTrigger>
-              <SelectContent>
-                {PRESET_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {selectedPreset === 'custom' && (
-            <div className="space-y-4 p-4 bg-muted/20 border border-muted rounded-lg">
-              <div className="space-y-2">
-                <Label htmlFor="start-date">Start Date</Label>
-                <Input
-                  id="start-date"
-                  type="date"
-                  value={customStartDate}
-                  max={new Date().toISOString().split('T')[0]}
-                  onChange={(e) => setCustomStartDate(e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="end-date">End Date</Label>
-                <Input
-                  id="end-date"
-                  type="date"
-                  value={customEndDate}
-                  max={new Date().toISOString().split('T')[0]}
-                  onChange={(e) => setCustomEndDate(e.target.value)}
-                />
-              </div>
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <DialogContent size="xl" className="gap-0 p-0">
+        <div className="border-b bg-muted/20 px-6 pb-5 pt-9">
+          <DialogHeader>
+            <div className="mb-2 flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+              <FileSpreadsheet className="h-3.5 w-3.5" />
+              Financial reporting
             </div>
-          )}
+            <DialogTitle className="text-xl">Export transaction report</DialogTitle>
+            <DialogDescription>
+              Export revenue, spend, refunds, protocol fees, and Cardano fees from one payment
+              source.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
 
-          <div className="text-sm text-muted-foreground">
-            <p>
-              Transactions:{' '}
-              <span className="font-medium">
-                {isLoading ? 'Loading...' : filteredTransactions?.length || 0}
-              </span>
-              {!isLoading && filteredTransactions && (
-                <span className="text-muted-foreground">
-                  {' '}
-                  (payments: {filteredTransactions.filter((t) => t.type === 'payment').length},
-                  purchases: {filteredTransactions.filter((t) => t.type === 'purchase').length})
-                </span>
+        <div className="grid gap-6 px-6 py-5 lg:grid-cols-2">
+          <section className="space-y-5" aria-labelledby="report-scope-heading">
+            <div>
+              <h3 id="report-scope-heading" className="text-sm font-semibold">
+                Report scope
+              </h3>
+              <p className="text-xs text-muted-foreground">Choose source, period, and wallets.</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="report-payment-source">Payment source</Label>
+              <Select
+                value={model.form.paymentSourceId || undefined}
+                onValueChange={model.setPaymentSource}
+                disabled={model.isLoadingFacets || model.paymentSources.length === 0}
+              >
+                <SelectTrigger id="report-payment-source">
+                  <SelectValue
+                    placeholder={model.isLoadingFacets ? 'Loading sources…' : 'Select a source'}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {model.paymentSources.map((source) => (
+                    <SelectItem key={source.id} value={source.id}>
+                      {source.paymentSourceType === 'Web3CardanoV2' ? 'Cardano V2' : 'Cardano V1'} ·{' '}
+                      {shortenAddress(source.smartContractAddress, 7)}
+                      {source.deletedAt ? ' · Archived' : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {selectedSource && (
+                <p className="font-mono text-[11px] text-muted-foreground">
+                  {selectedSource.network} · fee rate {selectedSource.feeRatePermille / 10}%
+                </p>
               )}
-            </p>
-            <p>
-              Selected range:{' '}
-              <span className="font-medium">
-                {selectedPreset === 'custom'
-                  ? customStartDate && customEndDate
-                    ? `${customStartDate} to ${customEndDate}`
-                    : 'Please select dates'
-                  : PRESET_OPTIONS.find((opt) => opt.value === selectedPreset)?.label}
-              </span>
-            </p>
-          </div>
+            </div>
 
-          <div className="flex justify-between">
-            <Button variant="outline" onClick={handleReset}>
-              Reset
-            </Button>
-            <div className="flex justify-end">
-              <Button
-                onClick={handleDownload}
-                disabled={
-                  isLoading || (selectedPreset === 'custom' && (!customStartDate || !customEndDate))
+            <div className="space-y-2">
+              <Label htmlFor="report-date-preset">Period</Label>
+              <Select
+                value={model.form.datePreset}
+                onValueChange={(value) =>
+                  model.updateForm({ datePreset: value as ReportDatePreset })
                 }
               >
-                <Download className="h-4 w-4 mr-2" />
-                {isLoading ? 'Loading...' : 'Download CSV'}
+                <SelectTrigger id="report-date-preset">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DATE_PRESETS.map((preset) => (
+                    <SelectItem key={preset.value} value={preset.value}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {model.form.datePreset === 'custom' && (
+                <div className="grid grid-cols-2 gap-3 rounded-md border bg-muted/10 p-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="report-start-date" className="text-xs">
+                      First day
+                    </Label>
+                    <Input
+                      id="report-start-date"
+                      type="date"
+                      max={maxDate}
+                      value={model.form.customStartDate}
+                      onChange={(event) =>
+                        model.updateForm({ customStartDate: event.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="report-end-date" className="text-xs">
+                      Last day
+                    </Label>
+                    <Input
+                      id="report-end-date"
+                      type="date"
+                      max={maxDate}
+                      value={model.form.customEndDate}
+                      onChange={(event) => model.updateForm({ customEndDate: event.target.value })}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <fieldset className="relative space-y-2">
+              <legend className="text-sm font-medium">Managed wallets</legend>
+              <button
+                type="button"
+                className="absolute right-0 top-0 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => model.updateForm({ managedWalletIds: [] })}
+              >
+                All wallets
+              </button>
+              <div className="max-h-36 space-y-1 overflow-y-auto rounded-md border p-2">
+                {model.managedWallets.length === 0 ? (
+                  <p className="px-2 py-3 text-xs text-muted-foreground">
+                    No managed wallets belong to this source.
+                  </p>
+                ) : (
+                  model.managedWallets.map((wallet) => (
+                    <label
+                      key={wallet.id}
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted/50"
+                    >
+                      <Checkbox
+                        checked={model.form.managedWalletIds.includes(wallet.id)}
+                        onCheckedChange={() => model.toggleWallet(wallet.id)}
+                      />
+                      <span className="min-w-0 flex-1 truncate">
+                        {wallet.note?.trim()
+                          ? `${wallet.note.trim()} (${shortenAddress(wallet.walletAddress, 8)})`
+                          : shortenAddress(wallet.walletAddress, 8)}{' '}
+                        · ID {shortenAddress(wallet.id, 5)}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {wallet.type === 'Selling' ? 'Seller' : 'Buyer'}
+                        {wallet.deletedAt ? ' · Archived' : ''}
+                      </span>
+                    </label>
+                  ))
+                )}
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                {model.form.managedWalletIds.length === 0
+                  ? 'All accessible wallets are included.'
+                  : `${model.form.managedWalletIds.length} wallet${model.form.managedWalletIds.length === 1 ? '' : 's'} selected.`}
+              </p>
+            </fieldset>
+          </section>
+
+          <section className="space-y-5" aria-labelledby="report-accounting-heading">
+            <div>
+              <h3 id="report-accounting-heading" className="text-sm font-semibold">
+                Accounting rules
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                Set role, event date, and revenue rule.
+              </p>
+            </div>
+
+            <fieldset className="space-y-2">
+              <legend className="text-sm font-medium">Role</legend>
+              <div className="grid grid-cols-2 gap-2">
+                {(['Seller', 'Buyer'] as const).map((role) => (
+                  <label
+                    key={role}
+                    className={cn(
+                      'flex cursor-pointer items-start gap-2 rounded-md border p-3 transition-colors',
+                      model.form.roles.includes(role) && 'border-foreground/40 bg-muted/30',
+                    )}
+                  >
+                    <Checkbox
+                      checked={model.form.roles.includes(role)}
+                      onCheckedChange={() => model.toggleRole(role)}
+                    />
+                    <span>
+                      <span className="block text-sm font-medium">{role}</span>
+                      <span className="block text-[11px] text-muted-foreground">
+                        {role === 'Seller' ? 'Payment requests' : 'Purchase requests'}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="report-date-basis">Date basis</Label>
+                <Select
+                  value={model.form.dateBasis}
+                  onValueChange={(value) =>
+                    model.updateForm({ dateBasis: value as ReportDateBasis })
+                  }
+                >
+                  <SelectTrigger id="report-date-basis">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DATE_BASES.map((basis) => (
+                      <SelectItem key={basis.value} value={basis.value}>
+                        <span>{basis.label}</span>
+                        <span className="ml-2 text-xs text-muted-foreground">{basis.detail}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="report-revenue-mode">Revenue mode</Label>
+                <Select
+                  value={model.form.revenueMode}
+                  onValueChange={(value) =>
+                    model.updateForm({ revenueMode: value as ReportRevenueMode })
+                  }
+                >
+                  <SelectTrigger id="report-revenue-mode">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {REVENUE_MODES.map((mode) => (
+                      <SelectItem key={mode.value} value={mode.value}>
+                        <span>{mode.label}</span>
+                        <span className="ml-2 text-xs text-muted-foreground">{mode.detail}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <fieldset className="relative space-y-2">
+              <legend className="text-sm font-medium">States</legend>
+              <button
+                type="button"
+                className="absolute right-0 top-0 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => model.updateForm({ states: [] })}
+              >
+                All states
+              </button>
+              <div className="grid max-h-36 grid-cols-2 gap-1 overflow-y-auto rounded-md border p-2">
+                {REPORT_ON_CHAIN_STATES.map((state) => (
+                  <label
+                    key={state}
+                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={model.form.states.includes(state)}
+                      onCheckedChange={() => model.toggleState(state)}
+                    />
+                    <span>{humanize(state)}</span>
+                  </label>
+                ))}
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                {model.form.states.length === 0
+                  ? 'All on-chain states are included.'
+                  : `${model.form.states.length} state${model.form.states.length === 1 ? '' : 's'} selected.`}
+              </p>
+            </fieldset>
+
+            <div className="space-y-2">
+              <Label htmlFor="report-external-addresses">External addresses</Label>
+              <Textarea
+                id="report-external-addresses"
+                className="min-h-16 font-mono text-xs"
+                placeholder="Optional. Separate addresses with commas or new lines."
+                value={model.form.externalAddressesText}
+                onChange={(event) =>
+                  model.updateForm({ externalAddressesText: event.target.value })
+                }
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Matches counterparty, payout, and return addresses. Time zone: {model.form.timeZone}
+                .
+              </p>
+            </div>
+          </section>
+        </div>
+
+        <div className="border-t bg-muted/15 px-6 py-4">
+          {viewDefaults.hasUnmappedFilters && (
+            <p className="mb-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+              Search, error type, and manual-action filters do not apply to financial reports.
+              Source, role, and state filters shown here do apply.
+            </p>
+          )}
+
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="min-h-10" aria-live="polite">
+              {model.facetsError ? (
+                <p className="text-sm text-destructive">{model.facetsError}</p>
+              ) : model.isLoadingFacets ? (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading report filters…
+                </p>
+              ) : model.bodyError ? (
+                <p className="text-sm text-destructive">{model.bodyError}</p>
+              ) : model.previewError ? (
+                <p className="text-sm text-destructive">{model.previewError}</p>
+              ) : model.isPreviewLoading ? (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Calculating filtered totals…
+                </p>
+              ) : model.preview ? (
+                <div>
+                  <p className="text-sm font-medium">{previewCountDisplay?.text}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {model.preview.metadata.warnings.length > 0
+                      ? `${model.preview.metadata.warnings.length} completeness warning${model.preview.metadata.warnings.length === 1 ? '' : 's'} will be included.`
+                      : 'One server snapshot will drive every exported value.'}
+                  </p>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">Select a payment source to preview.</p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={model.reset}
+                disabled={model.isDownloading}
+              >
+                <RotateCcw className="h-4 w-4" /> Reset
+              </Button>
+              <div className="min-w-64 space-y-1.5">
+                <Label htmlFor="report-export-kind" className="text-xs">
+                  File
+                </Label>
+                <Select
+                  value={model.exportKind}
+                  onValueChange={(value) => model.setExportKind(value as ReportExportKind)}
+                >
+                  <SelectTrigger id="report-export-kind">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {EXPORT_KINDS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-[11px] text-muted-foreground">{selectedExport?.detail}</p>
+              </div>
+              <Button
+                className="sm:mb-5"
+                onClick={() => model.download()}
+                disabled={
+                  model.isDownloading ||
+                  model.bodyError != null ||
+                  model.facetsError != null ||
+                  model.paymentSources.length === 0
+                }
+              >
+                {model.isDownloading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : model.exportKind === 'zip' ? (
+                  <FileArchive className="h-4 w-4" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+                {model.isDownloading ? 'Preparing…' : 'Download'}
               </Button>
             </div>
           </div>

--- a/frontend/src/components/transactions/download-details.helpers.test.ts
+++ b/frontend/src/components/transactions/download-details.helpers.test.ts
@@ -1,34 +1,207 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-  DOWNLOAD_PAGE_SIZE,
-  buildTransactionDownloadQuery,
-  mergeDownloadedTransactions,
+  buildTransactionReportBody,
+  buildTransactionReportViewDefaults,
+  createTransactionReportForm,
+  filterAccessibleReportWalletIds,
+  toggleReportFilterValue,
+  toggleReportWalletSelection,
 } from './download-details.helpers';
+import { EMPTY_FILTERS } from './TransactionFilters';
 
-test('buildTransactionDownloadQuery keeps the active network in CSV export requests', () => {
-  assert.deepEqual(buildTransactionDownloadQuery('Mainnet', 'cursor-1'), {
-    network: 'Mainnet',
-    cursorId: 'cursor-1',
-    includeHistory: 'true',
-    limit: DOWNLOAD_PAGE_SIZE,
-  });
+test('maps payment and state view filters to seller report defaults', () => {
+  assert.deepEqual(
+    buildTransactionReportViewDefaults(
+      'Purchases',
+      { ...EMPTY_FILTERS, type: 'payment', status: 'Withdrawn' },
+      false,
+    ),
+    {
+      roles: ['Seller'],
+      states: ['Withdrawn'],
+      hasUnmappedFilters: false,
+    },
+  );
 });
 
-test('mergeDownloadedTransactions removes the inclusive cursor overlap row', () => {
-  const merged = mergeDownloadedTransactions(
-    [
-      { id: 'purchase-1', type: 'purchase' },
-      { id: 'payment-1', type: 'payment' },
-    ] as never[],
-    [
-      { id: 'payment-1', type: 'payment' },
-      { id: 'payment-2', type: 'payment' },
-    ] as never[],
+test('maps payment and purchase tabs to seller and buyer roles', () => {
+  assert.deepEqual(buildTransactionReportViewDefaults('Payments', EMPTY_FILTERS, false).roles, [
+    'Seller',
+  ]);
+  assert.deepEqual(buildTransactionReportViewDefaults('Purchases', EMPTY_FILTERS, false).roles, [
+    'Buyer',
+  ]);
+});
+
+test('marks search and action-only filters as unmapped report filters', () => {
+  assert.equal(
+    buildTransactionReportViewDefaults(
+      'Needs Action',
+      { ...EMPTY_FILTERS, errorType: 'NetworkError' },
+      true,
+    ).hasUnmappedFilters,
+    true,
+  );
+});
+
+test('builds default report body and omits all-wallet and all-state filters', () => {
+  const form = createTransactionReportForm(
+    'source-1',
+    { roles: ['Buyer', 'Seller'], states: [], hasUnmappedFilters: false },
+    'Europe/Prague',
+  );
+  const now = new Date('2026-08-24T12:00:00.000Z');
+  const result = buildTransactionReportBody(form, now);
+
+  assert.equal(result.error, null);
+  assert.ok(result.body);
+  assert.equal(result.body.paymentSourceId, 'source-1');
+  assert.equal(result.body.managedWalletIds, undefined);
+  assert.equal(result.body.states, undefined);
+  assert.equal(result.body.timeZone, 'Europe/Prague');
+  assert.equal(result.body.bucket, 'Auto');
+  assert.equal(result.body.to?.getTime(), now.getTime());
+  assert.equal(result.body.from?.getTime(), now.getTime() - 30 * 24 * 60 * 60 * 1000);
+});
+
+test('removes wallet filters that are no longer present in accessible report facets', () => {
+  const wallets = [
+    { id: 'wallet-a', paymentSourceId: 'source-1' },
+    { id: 'wallet-b', paymentSourceId: 'source-2' },
+  ];
+
+  assert.deepEqual(
+    filterAccessibleReportWalletIds(['wallet-a', 'wallet-revoked'], wallets, 'source-1'),
+    ['wallet-a'],
+  );
+  assert.deepEqual(filterAccessibleReportWalletIds(['wallet-b'], wallets, 'source-1'), []);
+});
+
+test('uses the selected IANA time zone for an inclusive custom report range', () => {
+  const form = {
+    ...createTransactionReportForm(
+      'source-1',
+      { roles: ['Buyer'], states: [], hasUnmappedFilters: false },
+      'Pacific/Kiritimati',
+    ),
+    datePreset: 'custom' as const,
+    customStartDate: '2026-01-02',
+    customEndDate: '2026-01-02',
+  };
+  const result = buildTransactionReportBody(form);
+
+  assert.equal(result.error, null);
+  assert.equal(result.body?.from?.toISOString(), '2026-01-01T10:00:00.000Z');
+  assert.equal(result.body?.to?.toISOString(), '2026-01-02T10:00:00.000Z');
+});
+
+test('keeps an inclusive custom range on a 23-hour DST day', () => {
+  const form = {
+    ...createTransactionReportForm(
+      'source-1',
+      { roles: ['Buyer'], states: [], hasUnmappedFilters: false },
+      'America/New_York',
+    ),
+    datePreset: 'custom' as const,
+    customStartDate: '2026-03-08',
+    customEndDate: '2026-03-08',
+  };
+  const result = buildTransactionReportBody(form);
+
+  assert.equal(result.error, null);
+  assert.equal(result.body?.from?.toISOString(), '2026-03-08T05:00:00.000Z');
+  assert.equal(result.body?.to?.toISOString(), '2026-03-09T04:00:00.000Z');
+  assert.equal(
+    (result.body?.to?.getTime() ?? 0) - (result.body?.from?.getTime() ?? 0),
+    23 * 60 * 60 * 1000,
+  );
+});
+
+test('maps wallet, address, role, and state selections without duplicates', () => {
+  const form = {
+    ...createTransactionReportForm(
+      'source-1',
+      { roles: ['Seller'], states: ['Withdrawn'], hasUnmappedFilters: false },
+      'Etc/UTC',
+    ),
+    managedWalletIds: ['wallet-1'],
+    externalAddressesText: 'addr_test1, addr_test2\naddr_test1',
+    bucket: 'Week' as const,
+  };
+  const result = buildTransactionReportBody(form, new Date('2026-08-24T12:00:00.000Z'));
+
+  assert.equal(result.error, null);
+  assert.deepEqual(result.body?.managedWalletIds, ['wallet-1']);
+  assert.deepEqual(result.body?.externalAddresses, ['addr_test1', 'addr_test2']);
+  assert.deepEqual(result.body?.roles, ['Seller']);
+  assert.deepEqual(result.body?.states, ['Withdrawn']);
+  assert.equal(result.body?.bucket, 'Week');
+});
+
+test('maps the Pending report state sentinel', () => {
+  const form = createTransactionReportForm(
+    'source-1',
+    { roles: ['Buyer'], states: ['Pending'], hasUnmappedFilters: false },
+    'Etc/UTC',
   );
 
   assert.deepEqual(
-    merged.map((transaction) => `${transaction.type}:${transaction.id}`),
-    ['purchase:purchase-1', 'payment:payment-1', 'payment:payment-2'],
+    buildTransactionReportBody(form, new Date('2026-08-24T12:00:00.000Z')).body?.states,
+    ['Pending'],
+  );
+});
+
+test('rejects a report with no selected role', () => {
+  const form = {
+    ...createTransactionReportForm(
+      'source-1',
+      { roles: ['Buyer'], states: [], hasUnmappedFilters: false },
+      'Etc/UTC',
+    ),
+    roles: [],
+  };
+
+  assert.deepEqual(buildTransactionReportBody(form), {
+    body: null,
+    error: 'Select at least one role.',
+  });
+});
+
+test('rejects a blank report time zone before requesting a summary', () => {
+  const form = {
+    ...createTransactionReportForm(
+      'source-1',
+      { roles: ['Buyer'], states: [], hasUnmappedFilters: false },
+      'Etc/UTC',
+    ),
+    timeZone: '  ',
+  };
+
+  assert.deepEqual(buildTransactionReportBody(form), {
+    body: null,
+    error: 'Enter an IANA time zone.',
+  });
+});
+
+test('toggles multi-value report filters', () => {
+  assert.deepEqual(toggleReportFilterValue(['Buyer'], 'Seller'), ['Buyer', 'Seller']);
+  assert.deepEqual(toggleReportFilterValue(['Buyer', 'Seller'], 'Buyer'), ['Seller']);
+});
+
+test('adopts an auto-selected payment source before selecting its first wallet', () => {
+  const form = createTransactionReportForm(
+    '',
+    { roles: ['Buyer', 'Seller'], states: [], hasUnmappedFilters: false },
+    'Etc/UTC',
+  );
+
+  const selected = toggleReportWalletSelection(form, 'source-1', 'wallet-1');
+
+  assert.equal(selected.paymentSourceId, 'source-1');
+  assert.deepEqual(selected.managedWalletIds, ['wallet-1']);
+  assert.deepEqual(
+    toggleReportWalletSelection(selected, 'source-1', 'wallet-1').managedWalletIds,
+    [],
   );
 });

--- a/frontend/src/components/transactions/download-details.helpers.ts
+++ b/frontend/src/components/transactions/download-details.helpers.ts
@@ -1,30 +1,294 @@
-import { appendInclusiveCursorPage } from '@/lib/pagination/cursor-pagination';
-import { Payment, Purchase } from '@/lib/api/generated';
+import type { PostReportsSummaryData } from '@/lib/api/generated';
+import type { TransactionFilterState } from './TransactionFilters';
 
-type Transaction =
-  | (Payment & { type: 'payment' })
-  | (Purchase & {
-      type: 'purchase';
-    });
+type ReportBody = PostReportsSummaryData['body'];
 
-export const DOWNLOAD_PAGE_SIZE = 100;
+export type ReportRole = NonNullable<ReportBody['roles']>[number];
+export type ReportOnChainState = NonNullable<ReportBody['states']>[number];
+export type ReportDateBasis = NonNullable<ReportBody['dateBasis']>;
+export type ReportRevenueMode = NonNullable<ReportBody['revenueMode']>;
+export type ReportBucket = NonNullable<ReportBody['bucket']>;
+export type ReportDatePreset = '24h' | '7d' | '30d' | '90d' | 'custom';
 
-export function buildTransactionDownloadQuery(network: 'Preprod' | 'Mainnet', cursorId?: string) {
+export const REPORT_ON_CHAIN_STATES = [
+  'Pending',
+  'FundsLocked',
+  'FundsOrDatumInvalid',
+  'ResultSubmitted',
+  'RefundRequested',
+  'Disputed',
+  'WithdrawAuthorized',
+  'RefundAuthorized',
+  'Withdrawn',
+  'RefundWithdrawn',
+  'DisputedWithdrawn',
+] as const satisfies readonly ReportOnChainState[];
+
+export type TransactionReportViewDefaults = Readonly<{
+  roles: readonly ReportRole[];
+  states: readonly ReportOnChainState[];
+  hasUnmappedFilters: boolean;
+}>;
+
+export type TransactionReportFormState = Readonly<{
+  paymentSourceId: string;
+  managedWalletIds: readonly string[];
+  externalAddressesText: string;
+  roles: readonly ReportRole[];
+  states: readonly ReportOnChainState[];
+  datePreset: ReportDatePreset;
+  customStartDate: string;
+  customEndDate: string;
+  dateBasis: ReportDateBasis;
+  revenueMode: ReportRevenueMode;
+  bucket: ReportBucket;
+  timeZone: string;
+}>;
+
+export type ReportBodyResult =
+  | Readonly<{ body: ReportBody; error: null }>
+  | Readonly<{ body: null; error: string }>;
+
+type ReportWalletFacet = Readonly<{ id: string; paymentSourceId: string }>;
+
+export function filterAccessibleReportWalletIds(
+  selectedWalletIds: readonly string[],
+  wallets: readonly ReportWalletFacet[],
+  paymentSourceId: string,
+): string[] {
+  const accessibleIds = new Set(
+    wallets
+      .filter((wallet) => wallet.paymentSourceId === paymentSourceId)
+      .map((wallet) => wallet.id),
+  );
+  return selectedWalletIds.filter((walletId) => accessibleIds.has(walletId));
+}
+
+type LocalDate = Readonly<{ year: number; month: number; day: number }>;
+
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+const DATE_BOUNDARY_SEARCH_HOURS = 36;
+const PRESET_MILLISECONDS: Record<Exclude<ReportDatePreset, 'custom'>, number> = {
+  '24h': DAY_MILLISECONDS,
+  '7d': 7 * DAY_MILLISECONDS,
+  '30d': 30 * DAY_MILLISECONDS,
+  '90d': 90 * DAY_MILLISECONDS,
+};
+
+function rolesForTransactionType(type: TransactionFilterState['type']): readonly ReportRole[] {
+  if (type === 'payment') return ['Seller'];
+  if (type === 'purchase') return ['Buyer'];
+  return ['Buyer', 'Seller'];
+}
+
+export function buildTransactionReportViewDefaults(
+  activeTab: string,
+  filters: TransactionFilterState,
+  hasSearchFilter: boolean,
+): TransactionReportViewDefaults {
+  const tabType =
+    activeTab === 'Payments' ? 'payment' : activeTab === 'Purchases' ? 'purchase' : null;
+  const tabState =
+    activeTab === 'Refund Requests'
+      ? 'RefundRequested'
+      : activeTab === 'Disputes'
+        ? 'Disputed'
+        : null;
+
   return {
-    network,
-    cursorId,
-    includeHistory: 'true' as const,
-    limit: DOWNLOAD_PAGE_SIZE,
+    roles: rolesForTransactionType(filters.type ?? tabType),
+    states: filters.status ? [filters.status] : tabState ? [tabState] : [],
+    hasUnmappedFilters:
+      hasSearchFilter ||
+      activeTab === 'Needs Action' ||
+      filters.needsAction ||
+      filters.errorType != null,
   };
 }
 
-export function mergeDownloadedTransactions(
-  existingTransactions: readonly Transaction[],
-  nextTransactions: readonly Transaction[],
-) {
-  return appendInclusiveCursorPage(
-    existingTransactions,
-    nextTransactions,
-    (transaction) => `${transaction.type}:${transaction.id ?? ''}`,
-  );
+export function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'Etc/UTC';
+}
+
+export function createTransactionReportForm(
+  paymentSourceId: string,
+  defaults: TransactionReportViewDefaults,
+  timeZone = getBrowserTimeZone(),
+): TransactionReportFormState {
+  return {
+    paymentSourceId,
+    managedWalletIds: [],
+    externalAddressesText: '',
+    roles: [...defaults.roles],
+    states: [...defaults.states],
+    datePreset: '30d',
+    customStartDate: '',
+    customEndDate: '',
+    dateBasis: 'RevenueRecognizedAt',
+    revenueMode: 'Billable',
+    bucket: 'Auto',
+    timeZone,
+  };
+}
+
+function splitExternalAddresses(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((address) => address.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function localDateOrdinal(date: LocalDate): number {
+  const value = new Date(0);
+  value.setUTCFullYear(date.year, date.month - 1, date.day);
+  value.setUTCHours(0, 0, 0, 0);
+  return value.getTime();
+}
+
+function localDateFromOrdinal(ordinal: number): LocalDate {
+  const value = new Date(ordinal);
+  return {
+    year: value.getUTCFullYear(),
+    month: value.getUTCMonth() + 1,
+    day: value.getUTCDate(),
+  };
+}
+
+function parseDateOnly(value: string): LocalDate | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  const parsed = { year: Number(match[1]), month: Number(match[2]), day: Number(match[3]) };
+  const normalized = localDateFromOrdinal(localDateOrdinal(parsed));
+  return normalized.year === parsed.year &&
+    normalized.month === parsed.month &&
+    normalized.day === parsed.day
+    ? parsed
+    : null;
+}
+
+function createLocalDateReader(timeZone: string): (date: Date) => LocalDate {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    calendar: 'iso8601',
+    numberingSystem: 'latn',
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return (date) => {
+    const fields = new Map(
+      formatter
+        .formatToParts(date)
+        .filter((part) => part.type !== 'literal')
+        .map((part) => [part.type, Number(part.value)]),
+    );
+    const year = fields.get('year');
+    const month = fields.get('month');
+    const day = fields.get('day');
+    if (year == null || month == null || day == null) {
+      throw new RangeError('Unable to read local report date');
+    }
+    return { year, month, day };
+  };
+}
+
+function findLocalDateStart(localDate: LocalDate, readLocalDate: (date: Date) => LocalDate): Date {
+  const targetOrdinal = localDateOrdinal(localDate);
+  let low = targetOrdinal - DATE_BOUNDARY_SEARCH_HOURS * 60 * 60 * 1000;
+  let high = targetOrdinal + DATE_BOUNDARY_SEARCH_HOURS * 60 * 60 * 1000;
+  while (localDateOrdinal(readLocalDate(new Date(low))) >= targetOrdinal) low -= DAY_MILLISECONDS;
+  while (localDateOrdinal(readLocalDate(new Date(high))) < targetOrdinal) high += DAY_MILLISECONDS;
+
+  while (high - low > 1) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (localDateOrdinal(readLocalDate(new Date(middle))) >= targetOrdinal) high = middle;
+    else low = middle;
+  }
+  return new Date(high);
+}
+
+function resolveDateRange(
+  form: TransactionReportFormState,
+  now: Date,
+): Readonly<{ from: Date; to: Date }> | null {
+  if (form.datePreset !== 'custom') {
+    return {
+      from: new Date(now.getTime() - PRESET_MILLISECONDS[form.datePreset]),
+      to: new Date(now),
+    };
+  }
+
+  const selectedStart = parseDateOnly(form.customStartDate);
+  const selectedEnd = parseDateOnly(form.customEndDate);
+  if (!selectedStart || !selectedEnd) return null;
+  try {
+    const readLocalDate = createLocalDateReader(form.timeZone.trim());
+    return {
+      from: findLocalDateStart(selectedStart, readLocalDate),
+      to: findLocalDateStart(
+        localDateFromOrdinal(localDateOrdinal(selectedEnd) + DAY_MILLISECONDS),
+        readLocalDate,
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildTransactionReportBody(
+  form: TransactionReportFormState,
+  now = new Date(),
+): ReportBodyResult {
+  if (!form.paymentSourceId) return { body: null, error: 'Select a payment source.' };
+  if (form.roles.length === 0) return { body: null, error: 'Select at least one role.' };
+  if (!form.timeZone.trim()) return { body: null, error: 'Enter an IANA time zone.' };
+
+  const range = resolveDateRange(form, now);
+  if (!range) return { body: null, error: 'Select a valid custom date range.' };
+  if (range.to.getTime() <= range.from.getTime()) {
+    return { body: null, error: 'End date must be after start date.' };
+  }
+
+  const externalAddresses = splitExternalAddresses(form.externalAddressesText);
+  if (externalAddresses.length > 100) {
+    return { body: null, error: 'Use at most 100 external addresses.' };
+  }
+
+  return {
+    error: null,
+    body: {
+      paymentSourceId: form.paymentSourceId,
+      ...(form.managedWalletIds.length > 0 ? { managedWalletIds: [...form.managedWalletIds] } : {}),
+      ...(externalAddresses.length > 0 ? { externalAddresses } : {}),
+      roles: [...form.roles],
+      ...(form.states.length > 0 ? { states: [...form.states] } : {}),
+      from: range.from,
+      to: range.to,
+      dateBasis: form.dateBasis,
+      revenueMode: form.revenueMode,
+      timeZone: form.timeZone.trim(),
+      bucket: form.bucket,
+    },
+  };
+}
+
+export function toggleReportFilterValue<T>(values: readonly T[], value: T): T[] {
+  return values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+}
+
+export function toggleReportWalletSelection(
+  form: TransactionReportFormState,
+  paymentSourceId: string,
+  walletId: string,
+): TransactionReportFormState {
+  const currentWalletIds = form.paymentSourceId === paymentSourceId ? form.managedWalletIds : [];
+  return {
+    ...form,
+    paymentSourceId,
+    managedWalletIds: toggleReportFilterValue(currentWalletIds, walletId),
+  };
 }

--- a/frontend/src/components/transactions/useDownloadDetailsModel.ts
+++ b/frontend/src/components/transactions/useDownloadDetailsModel.ts
@@ -1,0 +1,222 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import {
+  getReportsFacets,
+  postReportsSummary,
+  type GetReportsFacetsResponses,
+  type PostReportsSummaryResponses,
+} from '@/lib/api/generated';
+import { extractApiErrorMessage } from '@/lib/api-error';
+import { useAppContext } from '@/lib/contexts/AppContext';
+import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
+import { TRANSACTION_REPORT_FACETS_QUERY_KEY } from '@/lib/queries/transaction-report-cache';
+import {
+  fetchTransactionReportExport,
+  saveTransactionReportExport,
+  type ReportExportKind,
+} from '@/lib/transaction-report/download';
+import {
+  buildTransactionReportBody,
+  createTransactionReportForm,
+  filterAccessibleReportWalletIds,
+  toggleReportFilterValue,
+  toggleReportWalletSelection,
+  type ReportOnChainState,
+  type ReportRole,
+  type TransactionReportFormState,
+  type TransactionReportViewDefaults,
+} from './download-details.helpers';
+
+type ReportFacets = GetReportsFacetsResponses[200]['data'];
+type ReportSummary = PostReportsSummaryResponses[200]['data'];
+
+type UseDownloadDetailsModelOptions = Readonly<{
+  open: boolean;
+  onClose: () => void;
+  viewDefaults: TransactionReportViewDefaults;
+}>;
+
+function errorMessage(error: unknown, fallback: string): string {
+  return extractApiErrorMessage(error, fallback);
+}
+
+export function useDownloadDetailsModel({
+  open,
+  onClose,
+  viewDefaults,
+}: UseDownloadDetailsModelOptions) {
+  const { apiClient, network, selectedPaymentSourceId } = useAppContext();
+  const [rangeAnchor, setRangeAnchor] = useState(() => new Date());
+  const [form, setForm] = useState<TransactionReportFormState>(() =>
+    createTransactionReportForm(selectedPaymentSourceId ?? '', viewDefaults),
+  );
+  const [exportKind, setExportKind] = useState<ReportExportKind>('transactions');
+
+  const reset = useCallback(
+    (paymentSourceId = selectedPaymentSourceId ?? '') => {
+      setRangeAnchor(new Date());
+      setForm(createTransactionReportForm(paymentSourceId, viewDefaults));
+      setExportKind('transactions');
+    },
+    [selectedPaymentSourceId, viewDefaults],
+  );
+
+  const facetsQuery = useQuery<ReportFacets>({
+    queryKey: TRANSACTION_REPORT_FACETS_QUERY_KEY,
+    queryFn: async ({ signal }) => {
+      const response = await getReportsFacets({ client: apiClient, signal });
+      if (response.error) {
+        throw new Error(errorMessage(response.error, 'Failed to load report filters'));
+      }
+      const facets = response.data?.data;
+      if (!facets) throw new Error('Report filters were missing from the server response.');
+      return facets;
+    },
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const paymentSources = useMemo(
+    () =>
+      (facetsQuery.data?.paymentSources ?? [])
+        .filter((source) => source.network === network)
+        .sort((left, right) => {
+          if (left.deletedAt == null && right.deletedAt != null) return -1;
+          if (left.deletedAt != null && right.deletedAt == null) return 1;
+          return left.id.localeCompare(right.id);
+        }),
+    [facetsQuery.data, network],
+  );
+
+  const effectivePaymentSourceId = paymentSources.some(
+    (source) => source.id === form.paymentSourceId,
+  )
+    ? form.paymentSourceId
+    : (paymentSources.find((source) => source.id === selectedPaymentSourceId)?.id ??
+      paymentSources[0]?.id ??
+      '');
+  const effectiveForm = useMemo(
+    () => ({
+      ...form,
+      paymentSourceId: effectivePaymentSourceId,
+      managedWalletIds:
+        form.paymentSourceId === effectivePaymentSourceId
+          ? filterAccessibleReportWalletIds(
+              form.managedWalletIds,
+              facetsQuery.data?.managedWallets ?? [],
+              effectivePaymentSourceId,
+            )
+          : [],
+    }),
+    [effectivePaymentSourceId, facetsQuery.data?.managedWallets, form],
+  );
+
+  const preferredPaymentSourceId =
+    paymentSources.find((source) => source.id === selectedPaymentSourceId)?.id ??
+    paymentSources[0]?.id ??
+    '';
+
+  const managedWallets = useMemo(
+    () =>
+      (facetsQuery.data?.managedWallets ?? [])
+        .filter((wallet) => wallet.paymentSourceId === effectiveForm.paymentSourceId)
+        .sort(
+          (left, right) => left.type.localeCompare(right.type) || left.id.localeCompare(right.id),
+        ),
+    [effectiveForm.paymentSourceId, facetsQuery.data],
+  );
+
+  const bodyResult = useMemo(
+    () => buildTransactionReportBody(effectiveForm, rangeAnchor),
+    [effectiveForm, rangeAnchor],
+  );
+  const debouncedBody = useDebouncedValue(bodyResult.body, 350);
+
+  const summaryQuery = useQuery<ReportSummary>({
+    queryKey: ['transaction-report-preview', debouncedBody],
+    queryFn: async ({ signal }) => {
+      if (!debouncedBody) throw new Error('Report filters are incomplete.');
+      const response = await postReportsSummary({ client: apiClient, body: debouncedBody, signal });
+      if (response.error) {
+        throw new Error(errorMessage(response.error, 'Failed to preview the report'));
+      }
+      const summary = response.data?.data;
+      if (!summary) throw new Error('Report summary was missing from the server response.');
+      return summary;
+    },
+    enabled: open && bodyResult.body != null && debouncedBody != null,
+    staleTime: 0,
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      if (!bodyResult.body) throw new Error(bodyResult.error);
+      const file = await fetchTransactionReportExport({
+        client: apiClient,
+        body: bodyResult.body,
+        kind: exportKind,
+      });
+      saveTransactionReportExport(file);
+    },
+    onSuccess: () => {
+      toast.success('Report download started');
+      onClose();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const updateForm = useCallback((patch: Partial<TransactionReportFormState>) => {
+    setForm((current) => ({ ...current, ...patch }));
+  }, []);
+
+  const setPaymentSource = useCallback((paymentSourceId: string) => {
+    setForm((current) => ({ ...current, paymentSourceId, managedWalletIds: [] }));
+  }, []);
+
+  const toggleRole = useCallback((role: ReportRole) => {
+    setForm((current) => ({ ...current, roles: toggleReportFilterValue(current.roles, role) }));
+  }, []);
+
+  const toggleState = useCallback((state: ReportOnChainState) => {
+    setForm((current) => ({ ...current, states: toggleReportFilterValue(current.states, state) }));
+  }, []);
+
+  const toggleWallet = useCallback(
+    (walletId: string) => {
+      setForm((current) =>
+        toggleReportWalletSelection(current, effectivePaymentSourceId, walletId),
+      );
+    },
+    [effectivePaymentSourceId],
+  );
+
+  return {
+    bodyError: bodyResult.error,
+    download: exportMutation.mutate,
+    exportKind,
+    facetsError: facetsQuery.error
+      ? errorMessage(facetsQuery.error, 'Failed to load report filters')
+      : null,
+    form: effectiveForm,
+    isDownloading: exportMutation.isPending,
+    isLoadingFacets: facetsQuery.isLoading,
+    isPreviewLoading:
+      bodyResult.body != null && (debouncedBody !== bodyResult.body || summaryQuery.isFetching),
+    managedWallets,
+    paymentSources,
+    preview: summaryQuery.data ?? null,
+    previewError: summaryQuery.error
+      ? errorMessage(summaryQuery.error, 'Failed to preview the report')
+      : null,
+    reset: () => reset(effectiveForm.paymentSourceId || preferredPaymentSourceId),
+    setExportKind,
+    setPaymentSource,
+    toggleRole,
+    toggleState,
+    toggleWallet,
+    updateForm,
+  };
+}

--- a/frontend/src/components/wallets/AddWalletDialog.tsx
+++ b/frontend/src/components/wallets/AddWalletDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { Eye, EyeOff } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { patchPaymentSourceExtended, postWallet } from '@/lib/api/generated';
 import { fetchAllUtxos } from '@/lib/wallet-balance';
 import { toast } from 'react-toastify';
@@ -46,6 +47,7 @@ import {
   getPreferredPaymentSource,
   sortPaymentSourcesByPreference,
 } from '@/lib/payment-source-type';
+import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
 
 interface AddWalletDialogProps {
   open: boolean;
@@ -64,6 +66,7 @@ const walletSchema = z.object({
 type WalletFormValues = z.infer<typeof walletSchema>;
 
 export function AddWalletDialog({ open, onClose, onSuccess, defaultType }: AddWalletDialogProps) {
+  const queryClient = useQueryClient();
   const [type, setType] = useState<HotWalletType>('Purchasing');
   // Covers the pre-submit collection-address check; the API call itself is
   // tracked by addWallet.isPending below.
@@ -232,6 +235,7 @@ export function AddWalletDialog({ open, onClose, onSuccess, defaultType }: AddWa
         });
       if (!response) return;
 
+      void invalidateTransactionReportFacets(queryClient);
       toast.success(`${type} wallet added successfully`);
       onSuccess?.();
       onClose();

--- a/frontend/src/components/wallets/WalletDetailsDialog.tsx
+++ b/frontend/src/components/wallets/WalletDetailsDialog.tsx
@@ -337,11 +337,11 @@ export function WalletDetailsDialog({
 
   useEffect(() => {
     if (isOpen && wallet) {
-      // Reset states when dialog is opened. Token + rule state reset inside
-      // their hooks (fetchTokenBalances resets at call start; resetForNewWallet
-      // clears rule drafts and the add-rule form).
+      // Reset states when the dialog opens or switches wallet. Token, rule and
+      // collection-address state reset inside their hooks (fetchTokenBalances
+      // resets at call start; each resetForNewWallet clears its own drafts).
       setExportedMnemonic(null);
-      collectionAddressEditor.resetSavedCollectionAddress();
+      collectionAddressEditor.resetForNewWallet();
       setSwapTransactions([]);
       setSwapTxCursor(undefined);
       setHasMoreSwapTx(true);

--- a/frontend/src/components/wallets/WalletDetailsDialog.tsx
+++ b/frontend/src/components/wallets/WalletDetailsDialog.tsx
@@ -6,14 +6,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import {
   getWallet,
-  patchWallet,
   getSwapTransactions,
   postSwapCancel,
   postSwapAcknowledgeTimeout,
   getSwapConfirm,
 } from '@/lib/api/generated';
 import { toast } from 'react-toastify';
-import { handleApiCall, validateCardanoAddress } from '@/lib/utils';
+import { handleApiCall } from '@/lib/utils';
 import { extractApiErrorMessage } from '@/lib/api-error';
 import { isHotWalletType } from '@/lib/wallet-type';
 import { WalletLink } from '@/components/ui/wallet-link';
@@ -28,7 +27,6 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
-import { fetchAllUtxos } from '@/lib/wallet-balance';
 import { appendInclusiveCursorPage } from '@/lib/pagination/cursor-pagination';
 import {
   extractSwapAcknowledgePayload,
@@ -58,6 +56,7 @@ import {
 import { WalletExportSection } from '@/components/wallets/sections/WalletExportSection';
 import { CollectionAddressSection } from '@/components/wallets/sections/CollectionAddressSection';
 import { FundTransfersSection } from '@/components/wallets/sections/FundTransfersSection';
+import { useCollectionAddressEditor } from '@/components/wallets/useCollectionAddressEditor';
 
 // Re-exported for the many call sites that import these types from this module.
 export type { TokenBalance, WalletWithBalance } from '@/components/wallets/wallet-details-utils';
@@ -94,14 +93,6 @@ export function WalletDetailsDialog({
   );
   const [exportedMnemonic, setExportedMnemonic] = useState<string | null>(null);
   const [isExporting, setIsExporting] = useState(false);
-  const [isEditingCollectionAddress, setIsEditingCollectionAddress] = useState(false);
-  const [newCollectionAddress, setNewCollectionAddress] = useState('');
-  // Local echo of a just-saved collection address for immediate UI feedback.
-  // `undefined` means "no local save yet" — fall through to the wallet prop.
-  const [savedCollectionAddress, setSavedCollectionAddress] = useState<string | null | undefined>(
-    undefined,
-  );
-
   const [swapTransactions, setSwapTransactions] = useState<SwapTx[]>([]);
   const [swapTxLoading, setSwapTxLoading] = useState(false);
   const [swapTxCursor, setSwapTxCursor] = useState<string | undefined>(undefined);
@@ -128,6 +119,10 @@ export function WalletDetailsDialog({
 
   const balances = useTokenBalances(wallet);
   const rules = useLowBalanceRules({ wallet, invalidateWalletQueries });
+  const collectionAddressEditor = useCollectionAddressEditor({
+    wallet,
+    invalidateWalletQueries,
+  });
 
   const updateSwapTxStatus = useCallback((txId: string, updates: Partial<SwapTx>) => {
     setSwapTransactions((prev) => prev.map((tx) => (tx.id === txId ? { ...tx, ...updates } : tx)));
@@ -346,7 +341,7 @@ export function WalletDetailsDialog({
       // their hooks (fetchTokenBalances resets at call start; resetForNewWallet
       // clears rule drafts and the add-rule form).
       setExportedMnemonic(null);
-      setSavedCollectionAddress(undefined);
+      collectionAddressEditor.resetSavedCollectionAddress();
       setSwapTransactions([]);
       setSwapTxCursor(undefined);
       setHasMoreSwapTx(true);
@@ -422,68 +417,6 @@ export function WalletDetailsDialog({
     a.download = `wallet-export-${wallet.walletAddress}.json`;
     a.click();
     URL.revokeObjectURL(url);
-  };
-
-  const collectionAddress =
-    savedCollectionAddress !== undefined
-      ? savedCollectionAddress
-      : (wallet?.collectionAddress ?? null);
-
-  const handleEditCollectionAddress = () => {
-    setIsEditingCollectionAddress(true);
-    setNewCollectionAddress(collectionAddress || '');
-  };
-
-  const handleSaveCollection = async () => {
-    if (!wallet) return;
-
-    // Validate the address if provided
-    if (newCollectionAddress.trim()) {
-      const validation = validateCardanoAddress(newCollectionAddress.trim(), network);
-      if (!validation.isValid) {
-        toast.error('Invalid collection address: ' + validation.error);
-        return;
-      }
-      let isAddressUnused = false;
-      try {
-        const utxos = await fetchAllUtxos(apiClient, network, newCollectionAddress.trim());
-        isAddressUnused = utxos.length === 0;
-      } catch {
-        isAddressUnused = true;
-      }
-      if (isAddressUnused) {
-        toast.warning(
-          'Collection address has not been used yet, please check if this is the correct address',
-        );
-      }
-    }
-    await handleApiCall(
-      () =>
-        patchWallet({
-          client: apiClient,
-          body: {
-            id: wallet.id,
-            newCollectionAddress: newCollectionAddress.trim() || null,
-          },
-        }),
-      {
-        onSuccess: () => {
-          toast.success('Collection address updated successfully');
-          setIsEditingCollectionAddress(false);
-          setSavedCollectionAddress(newCollectionAddress.trim() || null);
-          void invalidateWalletQueries();
-        },
-        onError: (error: unknown) => {
-          toast.error(extractApiErrorMessage(error, 'Failed to update collection address'));
-        },
-        errorMessage: 'Failed to update collection address',
-      },
-    );
-  };
-
-  const handleCancelEdit = () => {
-    setIsEditingCollectionAddress(false);
-    setNewCollectionAddress('');
   };
 
   const handleDialogClose = useCallback(() => {
@@ -716,13 +649,13 @@ export function WalletDetailsDialog({
               <CollectionAddressSection
                 walletType={wallet.type}
                 network={network}
-                collectionAddress={collectionAddress}
-                isEditing={isEditingCollectionAddress}
-                newCollectionAddress={newCollectionAddress}
-                onNewCollectionAddressChange={setNewCollectionAddress}
-                onSave={handleSaveCollection}
-                onCancelEdit={handleCancelEdit}
-                onStartEdit={handleEditCollectionAddress}
+                collectionAddress={collectionAddressEditor.collectionAddress}
+                isEditing={collectionAddressEditor.isEditing}
+                newCollectionAddress={collectionAddressEditor.draft}
+                onNewCollectionAddressChange={collectionAddressEditor.setDraft}
+                onSave={collectionAddressEditor.save}
+                onCancelEdit={collectionAddressEditor.cancelEdit}
+                onStartEdit={collectionAddressEditor.startEdit}
               />
             )}
           </div>

--- a/frontend/src/components/wallets/useCollectionAddressEditor.test.ts
+++ b/frontend/src/components/wallets/useCollectionAddressEditor.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeCollectionAddress, resolveCollectionAddress } from './useCollectionAddressEditor';
+
+test('normalizes a collection-address draft before saving', () => {
+  assert.equal(normalizeCollectionAddress('  addr_test1example  '), 'addr_test1example');
+  assert.equal(normalizeCollectionAddress('   '), null);
+});
+
+test('uses the wallet value before an editor save', () => {
+  assert.equal(resolveCollectionAddress(undefined, 'addr_test1wallet'), 'addr_test1wallet');
+  assert.equal(resolveCollectionAddress(undefined, undefined), null);
+});
+
+test('keeps a local clear instead of falling back to the stale wallet value', () => {
+  assert.equal(resolveCollectionAddress(null, 'addr_test1wallet'), null);
+  assert.equal(resolveCollectionAddress('addr_test1saved', 'addr_test1wallet'), 'addr_test1saved');
+});

--- a/frontend/src/components/wallets/useCollectionAddressEditor.test.ts
+++ b/frontend/src/components/wallets/useCollectionAddressEditor.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { normalizeCollectionAddress, resolveCollectionAddress } from './useCollectionAddressEditor';
+import {
+  describeCollectionAddressUsage,
+  normalizeCollectionAddress,
+  resolveCollectionAddress,
+} from './useCollectionAddressEditor';
 
 test('normalizes a collection-address draft before saving', () => {
   assert.equal(normalizeCollectionAddress('  addr_test1example  '), 'addr_test1example');
@@ -15,4 +19,16 @@ test('uses the wallet value before an editor save', () => {
 test('keeps a local clear instead of falling back to the stale wallet value', () => {
   assert.equal(resolveCollectionAddress(null, 'addr_test1wallet'), null);
   assert.equal(resolveCollectionAddress('addr_test1saved', 'addr_test1wallet'), 'addr_test1saved');
+});
+
+test('a failed usage lookup never reads as an unused address', () => {
+  assert.equal(
+    describeCollectionAddressUsage(0),
+    'Collection address has not been used yet, please check if this is the correct address',
+  );
+  assert.equal(describeCollectionAddressUsage(3), null);
+  assert.equal(
+    describeCollectionAddressUsage(null),
+    'Could not check this collection address on chain, please verify it yourself',
+  );
 });

--- a/frontend/src/components/wallets/useCollectionAddressEditor.ts
+++ b/frontend/src/components/wallets/useCollectionAddressEditor.ts
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { patchWallet } from '@/lib/api/generated';
+import { extractApiErrorMessage } from '@/lib/api-error';
+import { useAppContext } from '@/lib/contexts/AppContext';
+import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
+import { handleApiCall, validateCardanoAddress } from '@/lib/utils';
+import { fetchAllUtxos } from '@/lib/wallet-balance';
+import type { WalletWithBalance } from '@/components/wallets/wallet-details-utils';
+
+export function normalizeCollectionAddress(value: string): string | null {
+  return value.trim() || null;
+}
+
+export function resolveCollectionAddress(
+  savedCollectionAddress: string | null | undefined,
+  walletCollectionAddress: string | null | undefined,
+): string | null {
+  return savedCollectionAddress !== undefined
+    ? savedCollectionAddress
+    : (walletCollectionAddress ?? null);
+}
+
+export function useCollectionAddressEditor({
+  wallet,
+  invalidateWalletQueries,
+}: {
+  wallet: WalletWithBalance | null;
+  invalidateWalletQueries: () => Promise<void>;
+}) {
+  const queryClient = useQueryClient();
+  const { apiClient, network } = useAppContext();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  // `undefined` means no local save yet. Null means the user cleared the address.
+  const [savedCollectionAddress, setSavedCollectionAddress] = useState<string | null | undefined>(
+    undefined,
+  );
+
+  const collectionAddress = resolveCollectionAddress(
+    savedCollectionAddress,
+    wallet?.collectionAddress,
+  );
+
+  const startEdit = () => {
+    setIsEditing(true);
+    setDraft(collectionAddress || '');
+  };
+
+  const save = async () => {
+    if (!wallet) return;
+
+    const normalizedAddress = normalizeCollectionAddress(draft);
+    if (normalizedAddress) {
+      const validation = validateCardanoAddress(normalizedAddress, network);
+      if (!validation.isValid) {
+        toast.error('Invalid collection address: ' + validation.error);
+        return;
+      }
+
+      let isAddressUnused = false;
+      try {
+        const utxos = await fetchAllUtxos(apiClient, network, normalizedAddress);
+        isAddressUnused = utxos.length === 0;
+      } catch {
+        isAddressUnused = true;
+      }
+      if (isAddressUnused) {
+        toast.warning(
+          'Collection address has not been used yet, please check if this is the correct address',
+        );
+      }
+    }
+
+    await handleApiCall(
+      () =>
+        patchWallet({
+          client: apiClient,
+          body: {
+            id: wallet.id,
+            newCollectionAddress: normalizedAddress,
+          },
+        }),
+      {
+        onSuccess: () => {
+          toast.success('Collection address updated successfully');
+          setIsEditing(false);
+          setSavedCollectionAddress(normalizedAddress);
+          void invalidateWalletQueries();
+          void invalidateTransactionReportFacets(queryClient);
+        },
+        onError: (error: unknown) => {
+          toast.error(extractApiErrorMessage(error, 'Failed to update collection address'));
+        },
+        errorMessage: 'Failed to update collection address',
+      },
+    );
+  };
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setDraft('');
+  };
+
+  return {
+    cancelEdit,
+    collectionAddress,
+    draft,
+    isEditing,
+    resetSavedCollectionAddress: () => setSavedCollectionAddress(undefined),
+    save,
+    setDraft,
+    startEdit,
+  };
+}

--- a/frontend/src/components/wallets/useCollectionAddressEditor.ts
+++ b/frontend/src/components/wallets/useCollectionAddressEditor.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { patchWallet } from '@/lib/api/generated';
@@ -45,6 +45,12 @@ export function useCollectionAddressEditor({
 }) {
   const queryClient = useQueryClient();
   const { apiClient, network } = useAppContext();
+  // save() awaits two network round trips. The dialog can switch wallet in that
+  // time, so the completion has to know which wallet it started on.
+  const activeWalletIdRef = useRef<string | null>(wallet?.id ?? null);
+  useEffect(() => {
+    activeWalletIdRef.current = wallet?.id ?? null;
+  }, [wallet?.id]);
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState('');
   // `undefined` means no local save yet. Null means the user cleared the address.
@@ -64,6 +70,7 @@ export function useCollectionAddressEditor({
 
   const save = async () => {
     if (!wallet) return;
+    const savingWalletId = wallet.id;
 
     const normalizedAddress = normalizeCollectionAddress(draft);
     if (normalizedAddress) {
@@ -97,8 +104,13 @@ export function useCollectionAddressEditor({
       {
         onSuccess: () => {
           toast.success('Collection address updated successfully');
-          setIsEditing(false);
-          setSavedCollectionAddress(normalizedAddress);
+          // Only touch editor state that still belongs to the saved wallet.
+          // Writing it back after a switch showed the previous wallet's address
+          // on the new one, and a later save persisted it there.
+          if (activeWalletIdRef.current === savingWalletId) {
+            setIsEditing(false);
+            setSavedCollectionAddress(normalizedAddress);
+          }
           void invalidateWalletQueries();
           void invalidateTransactionReportFacets(queryClient);
         },

--- a/frontend/src/components/wallets/useCollectionAddressEditor.ts
+++ b/frontend/src/components/wallets/useCollectionAddressEditor.ts
@@ -13,6 +13,20 @@ export function normalizeCollectionAddress(value: string): string | null {
   return value.trim() || null;
 }
 
+/**
+ * Says what an on-chain lookup proved about a collection address. A lookup that
+ * failed proves nothing, so it must never read as "this address is unused".
+ */
+export function describeCollectionAddressUsage(utxoCount: number | null): string | null {
+  if (utxoCount === null) {
+    return 'Could not check this collection address on chain, please verify it yourself';
+  }
+  if (utxoCount === 0) {
+    return 'Collection address has not been used yet, please check if this is the correct address';
+  }
+  return null;
+}
+
 export function resolveCollectionAddress(
   savedCollectionAddress: string | null | undefined,
   walletCollectionAddress: string | null | undefined,
@@ -59,17 +73,15 @@ export function useCollectionAddressEditor({
         return;
       }
 
-      let isAddressUnused = false;
+      let utxoCount: number | null = null;
       try {
-        const utxos = await fetchAllUtxos(apiClient, network, normalizedAddress);
-        isAddressUnused = utxos.length === 0;
+        utxoCount = (await fetchAllUtxos(apiClient, network, normalizedAddress)).length;
       } catch {
-        isAddressUnused = true;
+        // Leave the count unknown. A failed lookup is not evidence of an unused address.
       }
-      if (isAddressUnused) {
-        toast.warning(
-          'Collection address has not been used yet, please check if this is the correct address',
-        );
+      const usageWarning = describeCollectionAddressUsage(utxoCount);
+      if (usageWarning) {
+        toast.warning(usageWarning);
       }
     }
 
@@ -108,7 +120,14 @@ export function useCollectionAddressEditor({
     collectionAddress,
     draft,
     isEditing,
-    resetSavedCollectionAddress: () => setSavedCollectionAddress(undefined),
+    // A dialog that switches to another wallet must drop the whole editor, not
+    // just the saved value: a draft left over from the previous wallet would be
+    // saved onto the new one.
+    resetForNewWallet: () => {
+      setIsEditing(false);
+      setDraft('');
+      setSavedCollectionAddress(undefined);
+    },
     save,
     setDraft,
     startEdit,

--- a/frontend/src/lib/hooks/usePaymentSourceSetup.ts
+++ b/frontend/src/lib/hooks/usePaymentSourceSetup.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { z } from 'zod';
 import { useAppContext } from '@/lib/contexts/AppContext';
@@ -8,6 +9,7 @@ import { extractApiErrorMessage } from '@/lib/api-error';
 import { DEFAULT_ADMIN_WALLETS } from '@/lib/constants/defaultWallets';
 import { DEFAULT_PAYMENT_SOURCE_TYPE } from '@/lib/payment-source-type';
 import type { SetupWallet } from '@/components/setup/setup-helpers';
+import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
 
 export const paymentSourceSchema = z.object({
   blockfrostApiKey: z.string().min(1, 'Blockfrost API key is required'),
@@ -65,6 +67,7 @@ async function validateBlockfrostApiKey(
  */
 export function usePaymentSourceSetup() {
   const { apiClient, network } = useAppContext();
+  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>('');
 
@@ -128,6 +131,7 @@ export function usePaymentSourceSetup() {
         }),
       {
         onSuccess: () => {
+          void invalidateTransactionReportFacets(queryClient);
           toast.success('V2 payment source created successfully');
           onSuccess();
         },

--- a/frontend/src/lib/queries/transaction-report-cache.test.ts
+++ b/frontend/src/lib/queries/transaction-report-cache.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  invalidateTransactionReportFacets,
+  TRANSACTION_REPORT_FACETS_QUERY_KEY,
+} from './transaction-report-cache';
+
+test('report facet invalidation marks the shared query stale after source or wallet changes', async () => {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(TRANSACTION_REPORT_FACETS_QUERY_KEY, { paymentSources: [] });
+
+  await invalidateTransactionReportFacets(queryClient);
+
+  assert.equal(queryClient.getQueryState(TRANSACTION_REPORT_FACETS_QUERY_KEY)?.isInvalidated, true);
+});

--- a/frontend/src/lib/queries/transaction-report-cache.ts
+++ b/frontend/src/lib/queries/transaction-report-cache.ts
@@ -1,0 +1,7 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+export const TRANSACTION_REPORT_FACETS_QUERY_KEY = ['transaction-report-facets'] as const;
+
+export function invalidateTransactionReportFacets(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: TRANSACTION_REPORT_FACETS_QUERY_KEY });
+}

--- a/frontend/src/lib/transaction-report/dashboard-metrics.test.ts
+++ b/frontend/src/lib/transaction-report/dashboard-metrics.test.ts
@@ -1,0 +1,633 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildReportChartPoints,
+  buildReportLinePath,
+  collectReportAssetUnits,
+  formatReportAmount,
+  formatReportCountValue,
+  formatReportMetricValue,
+  getEmptyReportAssetLabel,
+  getReportTransactionCountDisplay,
+  getReportAssetDescriptor,
+  getReportChartDomain,
+  getReportMetricAmount,
+  REPORT_METRICS,
+  resolveReportAssetUnit,
+  scaleReportChartY,
+  type ReportAmount,
+  type ReportMetrics,
+  type ReportSummary,
+} from './dashboard-metrics';
+
+function amount(unit: string, rawAmount = '0'): ReportAmount {
+  return {
+    unit,
+    rawAmount,
+    decimalAmount: null,
+    decimals: null,
+    symbol: null,
+  };
+}
+
+function knownAmount(
+  unit: string,
+  symbol: 'ADA' | 'USDM' | 'USDCx',
+  rawAmount = '0',
+): ReportAmount {
+  return {
+    ...amount(unit, rawAmount),
+    decimalAmount: `${rawAmount}.000000`,
+    decimals: 6,
+    symbol,
+  };
+}
+
+function metrics(overrides: Partial<ReportMetrics> = {}): ReportMetrics {
+  const emptyMetric = () => ({ amounts: [], completeness: 'complete' as const });
+  return {
+    transactionCount: 0,
+    transactionCountCompleteness: 'complete',
+    sellerGrossRevenue: emptyMetric(),
+    protocolFees: emptyMetric(),
+    sellerCardanoFees: emptyMetric(),
+    sellerNetRevenue: emptyMetric(),
+    buyerGrossSpend: emptyMetric(),
+    returnedFunds: emptyMetric(),
+    buyerCardanoFees: emptyMetric(),
+    buyerNetSpend: emptyMetric(),
+    actorCardanoFees: emptyMetric(),
+    adminCardanoFees: emptyMetric(),
+    totalCardanoFees: emptyMetric(),
+    ...overrides,
+  };
+}
+
+function summary(
+  totals: ReportMetrics,
+  history: ReportSummary['history'] = [],
+  wallets: ReportSummary['wallets'] = [],
+): ReportSummary {
+  return { totals, history, wallets } as ReportSummary;
+}
+
+test('exposes every financial report metric with an operator-facing label', () => {
+  assert.deepEqual(REPORT_METRICS, [
+    { key: 'sellerGrossRevenue', label: 'Seller gross revenue' },
+    { key: 'protocolFees', label: 'Protocol fees' },
+    { key: 'sellerCardanoFees', label: 'Seller Cardano fees' },
+    { key: 'sellerNetRevenue', label: 'Seller net revenue' },
+    { key: 'buyerGrossSpend', label: 'Buyer gross spend' },
+    { key: 'returnedFunds', label: 'Returned funds' },
+    { key: 'buyerCardanoFees', label: 'Buyer Cardano fees' },
+    { key: 'buyerNetSpend', label: 'Buyer net spend' },
+    { key: 'actorCardanoFees', label: 'Reconciled actor fees' },
+    { key: 'adminCardanoFees', label: 'Admin Cardano fees' },
+    { key: 'totalCardanoFees', label: 'Total Cardano fees' },
+  ]);
+});
+
+test('collects and orders business asset units without Cardano fee-only units', () => {
+  const report = summary(
+    metrics({
+      sellerGrossRevenue: {
+        amounts: [amount('unit-z'), knownAmount('usdcx-unit', 'USDCx')],
+        completeness: 'complete',
+      },
+      sellerCardanoFees: {
+        amounts: [amount('seller-fee-only-unit')],
+        completeness: 'complete',
+      },
+    }),
+    [
+      {
+        bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+        bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+        metrics: metrics({
+          protocolFees: {
+            amounts: [amount('unit-a')],
+            completeness: 'complete',
+          },
+          buyerGrossSpend: {
+            amounts: [knownAmount('lovelace', 'ADA')],
+            completeness: 'complete',
+          },
+          totalCardanoFees: {
+            amounts: [amount('total-fee-only-unit')],
+            completeness: 'complete',
+          },
+        }),
+      },
+    ],
+    [
+      {
+        managedWallet: null,
+        role: 'Seller',
+        metrics: metrics({
+          sellerNetRevenue: {
+            amounts: [knownAmount('zz-usdm-wallet-unit', 'USDM')],
+            completeness: 'complete',
+          },
+        }),
+      },
+    ],
+  );
+
+  assert.deepEqual(collectReportAssetUnits(report), [
+    'lovelace',
+    'zz-usdm-wallet-unit',
+    'usdcx-unit',
+    'unit-a',
+    'unit-z',
+  ]);
+});
+
+test('uses summary asset metadata to format exact zeros for empty metrics', () => {
+  const report = summary(
+    metrics({
+      sellerGrossRevenue: {
+        amounts: [knownAmount('usdm-policy-unit', 'USDM')],
+        completeness: 'complete',
+      },
+      buyerGrossSpend: {
+        amounts: [knownAmount('usdcx-policy-unit', 'USDCx')],
+        completeness: 'complete',
+      },
+    }),
+  );
+
+  const ada = getReportAssetDescriptor(report, 'lovelace');
+  const usdm = getReportAssetDescriptor(report, 'usdm-policy-unit');
+  const usdcx = getReportAssetDescriptor(report, 'usdcx-policy-unit');
+
+  assert.deepEqual(formatReportAmount(undefined, ada), {
+    value: '0.000000',
+    unitLabel: 'ADA',
+    text: '0.000000 ADA',
+  });
+  assert.deepEqual(formatReportAmount(undefined, usdm), {
+    value: '0.000000',
+    unitLabel: 'USDM',
+    text: '0.000000 USDM',
+  });
+  assert.deepEqual(formatReportAmount(undefined, usdcx), {
+    value: '0.000000',
+    unitLabel: 'USDCx',
+    text: '0.000000 USDCx',
+  });
+});
+
+test('formats exact decimal and atomic amount strings without losing negative signs', () => {
+  const decimal = {
+    ...amount('lovelace', '-9007199254740993000001'),
+    decimalAmount: '-9007199254740993.000001',
+    decimals: 6,
+    symbol: 'ADA',
+  };
+  const atomic = amount('policy.asset', '-9007199254740993000001');
+
+  assert.deepEqual(formatReportAmount(decimal), {
+    value: '-9,007,199,254,740,993.000001',
+    unitLabel: 'ADA',
+    text: '-9,007,199,254,740,993.000001 ADA',
+  });
+  assert.deepEqual(formatReportAmount(atomic), {
+    value: '-9,007,199,254,740,993,000,001',
+    unitLabel: 'policy.asset',
+    text: '-9,007,199,254,740,993,000,001 policy.asset',
+  });
+});
+
+test('partial empty metrics preserve exact units and label the zero as observed', () => {
+  const usdm = { unit: 'usdm-policy-unit', decimals: 6, symbol: 'USDM' } as const;
+
+  assert.deepEqual(
+    formatReportMetricValue({ amounts: [], completeness: 'partial' }, usdm.unit, usdm),
+    {
+      text: '0.000000 USDM observed',
+      isPartial: true,
+      isNegative: false,
+    },
+  );
+  assert.deepEqual(
+    formatReportMetricValue({ amounts: [], completeness: 'complete' }, usdm.unit, usdm),
+    {
+      text: '0.000000 USDM',
+      isPartial: false,
+      isNegative: false,
+    },
+  );
+});
+
+test('partial zero transaction counts remain observed values instead of confirmed empty reports', () => {
+  assert.equal(formatReportCountValue(12, 'partial'), '12 observed');
+  assert.equal(formatReportCountValue(12, 'complete'), '12');
+  assert.deepEqual(getReportTransactionCountDisplay(0, 'partial', 'filtered transaction'), {
+    text: '0 observed filtered transactions',
+    isConfirmedEmpty: false,
+  });
+  assert.deepEqual(getReportTransactionCountDisplay(0, 'complete', 'distinct logical payment'), {
+    text: '0 distinct logical payments',
+    isConfirmedEmpty: true,
+  });
+});
+
+test('empty asset labels and reset selection do not present partial data as no activity', () => {
+  assert.equal(getEmptyReportAssetLabel('partial'), 'Not determined');
+  assert.equal(getEmptyReportAssetLabel('complete'), 'No asset activity');
+  assert.equal(resolveReportAssetUnit(['lovelace', 'unit-a'], 'unit-a'), 'unit-a');
+  assert.equal(resolveReportAssetUnit(['lovelace', 'unit-a'], ''), 'lovelace');
+  assert.equal(resolveReportAssetUnit([], 'unit-a'), null);
+});
+
+test('finds an exact metric amount and formats a missing unit as zero', () => {
+  const totals = metrics({
+    buyerNetSpend: {
+      amounts: [amount('unit-a', '42')],
+      completeness: 'complete',
+    },
+  });
+
+  assert.equal(getReportMetricAmount(totals, 'buyerNetSpend', 'unit-a')?.rawAmount, '42');
+  assert.equal(getReportMetricAmount(totals, 'buyerNetSpend', 'unit-b'), undefined);
+  assert.deepEqual(formatReportAmount(undefined, 'unit-b'), {
+    value: '0',
+    unitLabel: 'unit-b',
+    text: '0 unit-b',
+  });
+});
+
+test('returns no SVG points for empty report history', () => {
+  assert.deepEqual(
+    buildReportChartPoints([], 'sellerNetRevenue', 'lovelace', {
+      width: 100,
+      height: 100,
+      padding: 10,
+    }),
+    [],
+  );
+});
+
+test('plots one negative chart point from a zero baseline and keeps its accessible data', () => {
+  const bucketStart = new Date('2026-01-01T00:00:00.000Z');
+  const bucketEnd = new Date('2026-01-02T00:00:00.000Z');
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart,
+      bucketEnd,
+      metrics: metrics({
+        sellerNetRevenue: {
+          amounts: [
+            {
+              ...amount('lovelace', '-9007199254740993000001'),
+              decimalAmount: '-9007199254740993.000001',
+              decimals: 6,
+              symbol: 'ADA',
+            },
+          ],
+          completeness: 'partial',
+        },
+      }),
+    },
+  ];
+
+  assert.deepEqual(
+    buildReportChartPoints(history, 'sellerNetRevenue', 'lovelace', {
+      width: 100,
+      height: 80,
+      padding: 10,
+    }),
+    [
+      {
+        x: 50,
+        y: 70,
+        bucketStart,
+        bucketEnd,
+        rawAmount: '-9007199254740993000001',
+        valueText: '-9,007,199,254,740,993.000001 ADA',
+        completeness: 'partial',
+      },
+    ],
+  );
+});
+
+test('spreads an all-equal positive series across the zero-based plot', () => {
+  const history: ReportSummary['history'] = [0, 1, 2].map((day) => ({
+    bucketStart: new Date(Date.UTC(2026, 0, day + 1)),
+    bucketEnd: new Date(Date.UTC(2026, 0, day + 2)),
+    metrics: metrics({
+      buyerGrossSpend: {
+        amounts: [amount('unit-a', '7')],
+        completeness: 'complete',
+      },
+    }),
+  }));
+
+  const points = buildReportChartPoints(history, 'buyerGrossSpend', 'unit-a', {
+    width: 100,
+    height: 80,
+    padding: 10,
+  });
+
+  assert.deepEqual(
+    points.map(({ x, y }) => ({ x, y })),
+    [
+      { x: 10, y: 10 },
+      { x: 50, y: 10 },
+      { x: 90, y: 10 },
+    ],
+  );
+});
+
+test('formats a missing stablecoin chart bucket with metadata from its series', () => {
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+      metrics: metrics({
+        protocolFees: {
+          amounts: [],
+          completeness: 'complete',
+        },
+      }),
+    },
+    {
+      bucketStart: new Date('2026-01-02T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-03T00:00:00.000Z'),
+      metrics: metrics({
+        protocolFees: {
+          amounts: [
+            {
+              ...knownAmount('usdm-policy-unit', 'USDM', '1000000'),
+              decimalAmount: '1.000000',
+            },
+          ],
+          completeness: 'complete',
+        },
+      }),
+    },
+  ];
+
+  const points = buildReportChartPoints(history, 'protocolFees', 'usdm-policy-unit', {
+    width: 100,
+    height: 100,
+    padding: 10,
+  });
+
+  assert.deepEqual(
+    points.map(({ rawAmount, valueText }) => ({ rawAmount, valueText })),
+    [
+      { rawAmount: '0', valueText: '0.000000 USDM' },
+      { rawAmount: '1000000', valueText: '1.000000 USDM' },
+    ],
+  );
+});
+
+test('uses an explicit descriptor when every stablecoin chart bucket is empty', () => {
+  const history: ReportSummary['history'] = [0, 1].map((day) => ({
+    bucketStart: new Date(Date.UTC(2026, 0, day + 1)),
+    bucketEnd: new Date(Date.UTC(2026, 0, day + 2)),
+    metrics: metrics({
+      returnedFunds: {
+        amounts: [],
+        completeness: 'complete',
+      },
+    }),
+  }));
+
+  const points = buildReportChartPoints(
+    history,
+    'returnedFunds',
+    'usdcx-policy-unit',
+    { width: 100, height: 80, padding: 10 },
+    undefined,
+    { unit: 'usdcx-policy-unit', decimals: 6, symbol: 'USDCx' },
+  );
+
+  assert.deepEqual(
+    points.map(({ rawAmount, valueText }) => ({ rawAmount, valueText })),
+    [
+      { rawAmount: '0', valueText: '0.000000 USDCx' },
+      { rawAmount: '0', valueText: '0.000000 USDCx' },
+    ],
+  );
+});
+
+test('scales negative and positive atomic amounts around zero without changing their strings', () => {
+  const history: ReportSummary['history'] = ['-10', '0', '10'].map((rawAmount, index) => ({
+    bucketStart: new Date(Date.UTC(2026, 0, index + 1)),
+    bucketEnd: new Date(Date.UTC(2026, 0, index + 2)),
+    metrics: metrics({
+      sellerNetRevenue: {
+        amounts: [amount('unit-a', rawAmount)],
+        completeness: 'complete',
+      },
+    }),
+  }));
+
+  const points = buildReportChartPoints(history, 'sellerNetRevenue', 'unit-a', {
+    width: 100,
+    height: 100,
+    padding: 10,
+  });
+
+  assert.deepEqual(
+    points.map(({ y, rawAmount, valueText }) => ({ y, rawAmount, valueText })),
+    [
+      { y: 90, rawAmount: '-10', valueText: '-10 unit-a' },
+      { y: 50, rawAmount: '0', valueText: '0 unit-a' },
+      { y: 10, rawAmount: '10', valueText: '10 unit-a' },
+    ],
+  );
+});
+
+test('scales signed amounts above Number safe range with BigInt precision', () => {
+  const rawAmounts = ['-9007199254740993000002', '0', '9007199254740993000002'];
+  const history: ReportSummary['history'] = rawAmounts.map((rawAmount, index) => ({
+    bucketStart: new Date(Date.UTC(2026, 0, index + 1)),
+    bucketEnd: new Date(Date.UTC(2026, 0, index + 2)),
+    metrics: metrics({
+      totalCardanoFees: {
+        amounts: [amount('lovelace', rawAmount)],
+        completeness: 'complete',
+      },
+    }),
+  }));
+
+  const points = buildReportChartPoints(history, 'totalCardanoFees', 'lovelace', {
+    width: 100,
+    height: 100,
+    padding: 10,
+  });
+
+  assert.deepEqual(
+    points.map(({ y, rawAmount }) => ({ y, rawAmount })),
+    [
+      { y: 90, rawAmount: rawAmounts[0] },
+      { y: 50, rawAmount: rawAmounts[1] },
+      { y: 10, rawAmount: rawAmounts[2] },
+    ],
+  );
+  assert.ok(points.every(({ x, y }) => x >= 0 && x <= 100 && y >= 0 && y <= 100));
+});
+
+test('builds a zero-inclusive domain for shared formula-series scaling', () => {
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+      metrics: metrics({
+        sellerNetRevenue: {
+          amounts: [amount('unit-a', '-10')],
+          completeness: 'complete',
+        },
+        protocolFees: {
+          amounts: [amount('unit-a', '0')],
+          completeness: 'complete',
+        },
+      }),
+    },
+    {
+      bucketStart: new Date('2026-01-02T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-03T00:00:00.000Z'),
+      metrics: metrics({
+        sellerNetRevenue: {
+          amounts: [amount('unit-a', '10')],
+          completeness: 'complete',
+        },
+        protocolFees: {
+          amounts: [amount('unit-a', '100')],
+          completeness: 'complete',
+        },
+      }),
+    },
+  ];
+  const domain = getReportChartDomain(history, ['sellerNetRevenue', 'protocolFees'], 'unit-a');
+  const dimensions = { width: 100, height: 100, padding: 10 };
+  const sellerPoints = buildReportChartPoints(
+    history,
+    'sellerNetRevenue',
+    'unit-a',
+    dimensions,
+    domain,
+  );
+  const feePoints = buildReportChartPoints(history, 'protocolFees', 'unit-a', dimensions, domain);
+
+  assert.deepEqual(domain, { min: BigInt(-10), max: BigInt(100) });
+  assert.equal(sellerPoints[0].y, 90);
+  assert.equal(feePoints[1].y, 10);
+  assert.equal(feePoints[0].y, 82.727272);
+});
+
+test('places and preserves the visible zero baseline for signed chart domains', () => {
+  const dimensions = { width: 100, height: 100, padding: 10 };
+
+  assert.equal(scaleReportChartY(BigInt(0), { min: BigInt(-10), max: BigInt(10) }, dimensions), 50);
+  assert.equal(scaleReportChartY(BigInt(0), { min: BigInt(0), max: BigInt(10) }, dimensions), 90);
+});
+
+test('uses a centered all-zero fallback domain for empty and zero history', () => {
+  assert.deepEqual(getReportChartDomain([], ['buyerNetSpend'], 'unit-a'), {
+    min: BigInt(0),
+    max: BigInt(0),
+  });
+
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+      metrics: metrics({
+        buyerNetSpend: {
+          amounts: [amount('unit-a', '0')],
+          completeness: 'complete',
+        },
+      }),
+    },
+  ];
+
+  assert.deepEqual(getReportChartDomain(history, ['buyerNetSpend'], 'unit-a'), {
+    min: BigInt(0),
+    max: BigInt(0),
+  });
+  assert.equal(
+    buildReportChartPoints(history, 'buyerNetSpend', 'unit-a', {
+      width: 100,
+      height: 80,
+      padding: 10,
+    })[0].y,
+    40,
+  );
+});
+
+test('uses bounded default SVG dimensions when dimensions are omitted', () => {
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+      metrics: metrics({
+        returnedFunds: {
+          amounts: [amount('unit-a', '1')],
+          completeness: 'complete',
+        },
+      }),
+    },
+  ];
+
+  const [point] = buildReportChartPoints(history, 'returnedFunds', 'unit-a');
+
+  assert.deepEqual({ x: point.x, y: point.y }, { x: 320, y: 16 });
+});
+
+test('builds an SVG line path from bounded chart points', () => {
+  assert.equal(buildReportLinePath([]), '');
+  assert.equal(
+    buildReportLinePath([
+      { x: 10, y: 90 },
+      { x: 50.25, y: 40.5 },
+      { x: 90, y: 10 },
+    ]),
+    'M 10 90 L 50.25 40.5 L 90 10',
+  );
+});
+
+test('breaks chart lines across partial buckets with no observed amount', () => {
+  const history: ReportSummary['history'] = [
+    {
+      bucketStart: new Date('2026-01-01T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-02T00:00:00.000Z'),
+      metrics: metrics({
+        sellerNetRevenue: {
+          amounts: [amount('unit-a', '10')],
+          completeness: 'complete',
+        },
+      }),
+    },
+    {
+      bucketStart: new Date('2026-01-02T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-03T00:00:00.000Z'),
+      metrics: metrics({
+        sellerNetRevenue: { amounts: [], completeness: 'partial' },
+      }),
+    },
+    {
+      bucketStart: new Date('2026-01-03T00:00:00.000Z'),
+      bucketEnd: new Date('2026-01-04T00:00:00.000Z'),
+      metrics: metrics({
+        sellerNetRevenue: {
+          amounts: [amount('unit-a', '20')],
+          completeness: 'complete',
+        },
+      }),
+    },
+  ];
+
+  const points = buildReportChartPoints(history, 'sellerNetRevenue', 'unit-a', {
+    width: 100,
+    height: 100,
+    padding: 10,
+  });
+
+  assert.equal(points[1].isUnknown, true);
+  assert.equal(points[1].valueText, '0 unit-a observed');
+  assert.equal(buildReportLinePath(points), 'M 10 50 M 90 10');
+});

--- a/frontend/src/lib/transaction-report/dashboard-metrics.ts
+++ b/frontend/src/lib/transaction-report/dashboard-metrics.ts
@@ -1,0 +1,379 @@
+import type { PostReportsSummaryResponses } from '@/lib/api/generated';
+
+export type ReportSummary = PostReportsSummaryResponses[200]['data'];
+export type ReportMetrics = ReportSummary['totals'];
+export type ReportMetricKey = Exclude<
+  keyof ReportMetrics,
+  'transactionCount' | 'transactionCountCompleteness'
+>;
+export type ReportMetric = ReportMetrics[ReportMetricKey];
+export type ReportAmount = ReportMetric['amounts'][number];
+export type ReportHistory = ReportSummary['history'];
+
+export type ReportTransactionCountDisplay = Readonly<{
+  text: string;
+  isConfirmedEmpty: boolean;
+}>;
+
+export function formatReportCountValue(
+  count: number,
+  completeness: ReportMetrics['transactionCountCompleteness'],
+): string {
+  return `${count.toLocaleString()}${completeness === 'partial' ? ' observed' : ''}`;
+}
+
+export function getReportTransactionCountDisplay(
+  count: number,
+  completeness: ReportMetrics['transactionCountCompleteness'],
+  singularLabel: string,
+): ReportTransactionCountDisplay {
+  const label = count === 1 ? singularLabel : `${singularLabel}s`;
+  return {
+    text: `${formatReportCountValue(count, completeness)} ${label}`,
+    isConfirmedEmpty: count === 0 && completeness === 'complete',
+  };
+}
+
+export const REPORT_METRICS = [
+  { key: 'sellerGrossRevenue', label: 'Seller gross revenue' },
+  { key: 'protocolFees', label: 'Protocol fees' },
+  { key: 'sellerCardanoFees', label: 'Seller Cardano fees' },
+  { key: 'sellerNetRevenue', label: 'Seller net revenue' },
+  { key: 'buyerGrossSpend', label: 'Buyer gross spend' },
+  { key: 'returnedFunds', label: 'Returned funds' },
+  { key: 'buyerCardanoFees', label: 'Buyer Cardano fees' },
+  { key: 'buyerNetSpend', label: 'Buyer net spend' },
+  { key: 'actorCardanoFees', label: 'Reconciled actor fees' },
+  { key: 'adminCardanoFees', label: 'Admin Cardano fees' },
+  { key: 'totalCardanoFees', label: 'Total Cardano fees' },
+] as const satisfies ReadonlyArray<Readonly<{ key: ReportMetricKey; label: string }>>;
+
+const REPORT_ASSET_METRIC_KEYS = [
+  'sellerGrossRevenue',
+  'protocolFees',
+  'sellerNetRevenue',
+  'buyerGrossSpend',
+  'returnedFunds',
+  'buyerNetSpend',
+] as const satisfies ReadonlyArray<ReportMetricKey>;
+
+const REPORT_ASSET_SYMBOL_ORDER = ['ADA', 'USDM', 'USDCx'] as const;
+
+export type ReportAssetDescriptor = Readonly<{
+  unit: string;
+  decimals: number | null;
+  symbol: string | null;
+}>;
+
+function addMetricUnits(metrics: ReportMetrics, units: Set<string>): void {
+  for (const key of REPORT_ASSET_METRIC_KEYS) {
+    for (const amount of metrics[key].amounts) units.add(amount.unit);
+  }
+}
+
+function getReportMetricSurfaces(summary: ReportSummary): ReportMetrics[] {
+  return [
+    summary.totals,
+    ...summary.history.map((bucket) => bucket.metrics),
+    ...summary.wallets.map((wallet) => wallet.metrics),
+  ];
+}
+
+export function collectReportAssetUnits(summary: ReportSummary): string[] {
+  const units = new Set<string>();
+  for (const metrics of getReportMetricSurfaces(summary)) addMetricUnits(metrics, units);
+  return [...units].sort((left, right) => {
+    const leftSymbol = getReportAssetDescriptor(summary, left).symbol;
+    const rightSymbol = getReportAssetDescriptor(summary, right).symbol;
+    const leftRank = REPORT_ASSET_SYMBOL_ORDER.findIndex((symbol) => symbol === leftSymbol);
+    const rightRank = REPORT_ASSET_SYMBOL_ORDER.findIndex((symbol) => symbol === rightSymbol);
+    const normalizedLeftRank = leftRank === -1 ? REPORT_ASSET_SYMBOL_ORDER.length : leftRank;
+    const normalizedRightRank = rightRank === -1 ? REPORT_ASSET_SYMBOL_ORDER.length : rightRank;
+    if (normalizedLeftRank !== normalizedRightRank) {
+      return normalizedLeftRank - normalizedRightRank;
+    }
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+}
+
+export function resolveReportAssetUnit(
+  assetUnits: readonly string[],
+  requestedUnit: string,
+): string | null {
+  return assetUnits.includes(requestedUnit) ? requestedUnit : (assetUnits[0] ?? null);
+}
+
+export function getEmptyReportAssetLabel(
+  completeness: ReportMetric['completeness'],
+): 'Not determined' | 'No asset activity' {
+  return completeness === 'partial' ? 'Not determined' : 'No asset activity';
+}
+
+function descriptorFromAmount(amount: ReportAmount): ReportAssetDescriptor {
+  return {
+    unit: amount.unit,
+    decimals: amount.decimals,
+    symbol: amount.symbol?.trim() || null,
+  };
+}
+
+function getKnownAssetDescriptor(unit: string): ReportAssetDescriptor {
+  if (unit.toLowerCase() === 'lovelace') {
+    return { unit: 'lovelace', decimals: 6, symbol: 'ADA' };
+  }
+  return { unit, decimals: null, symbol: null };
+}
+
+function findMetricAmount(metrics: ReportMetrics, unit: string): ReportAmount | undefined {
+  for (const { key } of REPORT_METRICS) {
+    const amount = getReportMetricAmount(metrics, key, unit);
+    if (amount != null) return amount;
+  }
+  return undefined;
+}
+
+export function getReportAssetDescriptor(
+  summary: ReportSummary,
+  unit: string,
+): ReportAssetDescriptor {
+  const knownDescriptor = getKnownAssetDescriptor(unit);
+  if (knownDescriptor.symbol != null) return knownDescriptor;
+
+  for (const metrics of getReportMetricSurfaces(summary)) {
+    const amount = findMetricAmount(metrics, unit);
+    if (amount != null) return descriptorFromAmount(amount);
+  }
+  return knownDescriptor;
+}
+
+export function getReportMetricAmount(
+  metrics: ReportMetrics,
+  metricKey: ReportMetricKey,
+  unit: string,
+): ReportAmount | undefined {
+  return metrics[metricKey].amounts.find((amount) => amount.unit === unit);
+}
+
+export type ReportAmountDisplay = Readonly<{
+  value: string;
+  unitLabel: string;
+  text: string;
+}>;
+
+export type ReportAmountFallback = string | ReportAssetDescriptor;
+
+function groupReportAmount(value: string): string {
+  const parts = /^([+-]?)(\d+)(\.\d+)?$/.exec(value);
+  if (parts == null) return value;
+  const [, sign, integer, fraction = ''] = parts;
+  const groupedInteger = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return `${sign}${groupedInteger}${fraction}`;
+}
+
+export function formatReportAmount(
+  amount: ReportAmount | undefined,
+  fallback: ReportAmountFallback = '',
+): ReportAmountDisplay {
+  const fallbackDescriptor =
+    typeof fallback === 'string' ? getKnownAssetDescriptor(fallback) : fallback;
+  const exactValue =
+    amount?.decimalAmount ??
+    amount?.rawAmount ??
+    (fallbackDescriptor.decimals == null
+      ? '0'
+      : fallbackDescriptor.decimals === 0
+        ? '0'
+        : `0.${'0'.repeat(fallbackDescriptor.decimals)}`);
+  const value = groupReportAmount(exactValue);
+  const unitLabel =
+    amount?.symbol?.trim() ||
+    amount?.unit ||
+    fallbackDescriptor.symbol?.trim() ||
+    fallbackDescriptor.unit;
+  return {
+    value,
+    unitLabel,
+    text: unitLabel ? `${value} ${unitLabel}` : value,
+  };
+}
+
+export type ReportMetricValueDisplay = Readonly<{
+  text: string;
+  isPartial: boolean;
+  isNegative: boolean;
+}>;
+
+export function formatReportMetricValue(
+  metric: ReportMetric,
+  unit: string,
+  fallback: ReportAmountFallback = unit,
+): ReportMetricValueDisplay {
+  const amount = metric.amounts.find((candidate) => candidate.unit === unit);
+  const display = formatReportAmount(amount, fallback);
+  const isPartial = metric.completeness === 'partial';
+  return {
+    text: isPartial && amount == null ? `${display.text} observed` : display.text,
+    isPartial,
+    isNegative: BigInt(amount?.rawAmount ?? '0') < BigInt(0),
+  };
+}
+
+export type ReportChartDimensions = Readonly<{
+  width: number;
+  height: number;
+  padding?: number;
+}>;
+
+export type ReportChartDomain = Readonly<{
+  min: bigint;
+  max: bigint;
+}>;
+
+export type ReportChartPoint = Readonly<{
+  x: number;
+  y: number;
+  bucketStart: Date;
+  bucketEnd: Date;
+  rawAmount: string;
+  valueText: string;
+  completeness: ReportMetric['completeness'];
+  isUnknown?: true;
+}>;
+
+export type ReportChartCoordinate = Readonly<{
+  x: number;
+  y: number;
+  isUnknown?: boolean;
+}>;
+
+export const DEFAULT_REPORT_CHART_DIMENSIONS = {
+  width: 640,
+  height: 240,
+  padding: 16,
+} as const satisfies ReportChartDimensions;
+
+const MAX_CHART_DIMENSION = 4_096;
+const CHART_COORDINATE_SCALE = 1_000_000;
+
+function normalizeChartDimension(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(value, MAX_CHART_DIMENSION);
+}
+
+function normalizeChartPadding(value: number | undefined, width: number, height: number): number {
+  const maxPadding = Math.min(width, height) / 2;
+  const defaultPadding = DEFAULT_REPORT_CHART_DIMENSIONS.padding;
+  if (value == null) return Math.min(defaultPadding, maxPadding);
+  if (!Number.isFinite(value)) return Math.min(defaultPadding, maxPadding);
+  return Math.min(Math.max(value, 0), maxPadding);
+}
+
+function rawMetricValue(metrics: ReportMetrics, metricKey: ReportMetricKey, unit: string): bigint {
+  return BigInt(getReportMetricAmount(metrics, metricKey, unit)?.rawAmount ?? '0');
+}
+
+function domainIncludingZero(
+  values: readonly bigint[],
+  requestedDomain?: ReportChartDomain,
+): ReportChartDomain {
+  let min = BigInt(0);
+  let max = BigInt(0);
+  const candidates = requestedDomain
+    ? [requestedDomain.min, requestedDomain.max, ...values]
+    : values;
+  for (const value of candidates) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return { min, max };
+}
+
+export function getReportChartDomain(
+  history: ReportHistory,
+  metricKeys: readonly ReportMetricKey[],
+  unit: string,
+): ReportChartDomain {
+  const values = history.flatMap((bucket) =>
+    metricKeys.map((metricKey) => rawMetricValue(bucket.metrics, metricKey, unit)),
+  );
+  return domainIncludingZero(values);
+}
+
+export function scaleReportChartY(
+  value: bigint,
+  domain: ReportChartDomain,
+  dimensions: ReportChartDimensions = DEFAULT_REPORT_CHART_DIMENSIONS,
+): number {
+  const width = normalizeChartDimension(dimensions.width, DEFAULT_REPORT_CHART_DIMENSIONS.width);
+  const height = normalizeChartDimension(dimensions.height, DEFAULT_REPORT_CHART_DIMENSIONS.height);
+  const padding = normalizeChartPadding(dimensions.padding, width, height);
+  const drawableHeight = height - padding * 2;
+  const chartDomain = domainIncludingZero([value], domain);
+  const range = chartDomain.max - chartDomain.min;
+  if (range === BigInt(0)) return height / 2;
+
+  const drawableHeightScaled = BigInt(Math.round(drawableHeight * CHART_COORDINATE_SCALE));
+  return (
+    padding +
+    Number(((chartDomain.max - value) * drawableHeightScaled) / range) / CHART_COORDINATE_SCALE
+  );
+}
+
+export function buildReportChartPoints(
+  history: ReportHistory,
+  metricKey: ReportMetricKey,
+  unit: string,
+  dimensions: ReportChartDimensions = DEFAULT_REPORT_CHART_DIMENSIONS,
+  domain?: ReportChartDomain,
+  descriptor?: ReportAssetDescriptor,
+): ReportChartPoint[] {
+  if (history.length === 0) return [];
+
+  const width = normalizeChartDimension(dimensions.width, DEFAULT_REPORT_CHART_DIMENSIONS.width);
+  const height = normalizeChartDimension(dimensions.height, DEFAULT_REPORT_CHART_DIMENSIONS.height);
+  const padding = normalizeChartPadding(dimensions.padding, width, height);
+  const drawableWidth = width - padding * 2;
+  const amounts = history.map((bucket) => getReportMetricAmount(bucket.metrics, metricKey, unit));
+  const values = amounts.map((amount) => BigInt(amount?.rawAmount ?? '0'));
+  const descriptorAmount =
+    amounts.find((amount) => amount?.symbol != null || amount?.decimals != null) ??
+    amounts.find((amount) => amount != null);
+  const seriesDescriptor =
+    descriptor ??
+    (descriptorAmount == null
+      ? getKnownAssetDescriptor(unit)
+      : descriptorFromAmount(descriptorAmount));
+  const chartDomain = domainIncludingZero(values, domain);
+
+  return history.map((bucket, index) => {
+    const metric = bucket.metrics[metricKey];
+    const amount = amounts[index];
+    const isUnknown = metric.completeness === 'partial' && amount == null;
+    const y = scaleReportChartY(values[index], chartDomain, dimensions);
+    return {
+      x:
+        history.length === 1 ? width / 2 : padding + (drawableWidth * index) / (history.length - 1),
+      y,
+      bucketStart: bucket.bucketStart,
+      bucketEnd: bucket.bucketEnd,
+      rawAmount: amount?.rawAmount ?? '0',
+      valueText: formatReportMetricValue(metric, unit, seriesDescriptor).text,
+      completeness: metric.completeness,
+      ...(isUnknown ? { isUnknown: true as const } : {}),
+    };
+  });
+}
+
+export function buildReportLinePath(points: readonly ReportChartCoordinate[]): string {
+  const commands: string[] = [];
+  let hasOpenLine = false;
+  for (const point of points) {
+    if (point.isUnknown) {
+      hasOpenLine = false;
+      continue;
+    }
+    commands.push(`${hasOpenLine ? 'L' : 'M'} ${point.x} ${point.y}`);
+    hasOpenLine = true;
+  }
+  return commands.join(' ');
+}

--- a/frontend/src/lib/transaction-report/download.test.ts
+++ b/frontend/src/lib/transaction-report/download.test.ts
@@ -4,6 +4,7 @@ import type { Client } from '@/lib/api/generated/client';
 import type { PostReportsSummaryData } from '@/lib/api/generated';
 import {
   fetchTransactionReportExport,
+  OBJECT_URL_RELEASE_DELAY_MS,
   saveTransactionReportExport,
   type ReportExportKind,
 } from './download';
@@ -155,6 +156,56 @@ test('saveTransactionReportExport always releases its URL when the browser click
     assert.equal(anchor.download, 'masumi-transactions.csv');
     assert.equal(clicked, true);
     assert.equal(removed, true);
+    assert.equal(revokedUrl, 'blob:report');
+  } finally {
+    if (documentDescriptor) {
+      Object.defineProperty(globalThis, 'document', documentDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, 'document');
+    }
+    if (createObjectUrlDescriptor) {
+      Object.defineProperty(URL, 'createObjectURL', createObjectUrlDescriptor);
+    } else {
+      Reflect.deleteProperty(URL, 'createObjectURL');
+    }
+    if (revokeObjectUrlDescriptor) {
+      Object.defineProperty(URL, 'revokeObjectURL', revokeObjectUrlDescriptor);
+    } else {
+      Reflect.deleteProperty(URL, 'revokeObjectURL');
+    }
+  }
+});
+
+test('saveTransactionReportExport keeps its URL alive until the download has started', async () => {
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+  const revokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+  let revokedUrl: string | undefined;
+  const anchor = { href: '', download: '', click: () => {}, remove: () => {} };
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: { createElement: () => anchor, body: { appendChild: () => anchor } },
+  });
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: () => 'blob:report',
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: (url: string) => {
+      revokedUrl = url;
+    },
+  });
+
+  try {
+    saveTransactionReportExport({ blob: new Blob(['csv']), filename: 'masumi-transactions.csv' });
+
+    // Revoking here is what cancels the download in the browsers that read the
+    // blob after the click returns.
+    assert.equal(revokedUrl, undefined);
+
+    await new Promise((resolve) => setTimeout(resolve, OBJECT_URL_RELEASE_DELAY_MS + 50));
     assert.equal(revokedUrl, 'blob:report');
   } finally {
     if (documentDescriptor) {

--- a/frontend/src/lib/transaction-report/download.test.ts
+++ b/frontend/src/lib/transaction-report/download.test.ts
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Client } from '@/lib/api/generated/client';
+import type { PostReportsSummaryData } from '@/lib/api/generated';
+import {
+  fetchTransactionReportExport,
+  saveTransactionReportExport,
+  type ReportExportKind,
+} from './download';
+
+type CapturedRequest = {
+  body?: unknown;
+  responseType?: string;
+  throwOnError?: boolean;
+  url?: string;
+};
+
+const reportBody: PostReportsSummaryData['body'] = {
+  paymentSourceId: 'source-1',
+  from: new Date('2026-01-01T00:00:00.000Z'),
+  to: new Date('2026-02-01T00:00:00.000Z'),
+};
+
+function createClient(handler: (request: CapturedRequest) => Promise<unknown>): Client {
+  return { post: handler } as unknown as Client;
+}
+
+test('report exports use the authenticated client with binary response mode', async () => {
+  const expectedPaths: Record<ReportExportKind, string> = {
+    transactions: '/reports/transactions.csv',
+    'wallet-summary': '/reports/wallet-summary.csv',
+    totals: '/reports/totals.csv',
+    zip: '/reports/export.zip',
+  };
+
+  for (const [kind, expectedPath] of Object.entries(expectedPaths) as Array<
+    [ReportExportKind, string]
+  >) {
+    let capturedRequest: CapturedRequest | undefined;
+    const blob = new Blob([kind]);
+    const client = createClient(async (request) => {
+      capturedRequest = request;
+      return {
+        data: blob,
+        headers: {
+          'content-disposition':
+            'attachment; filename="masumi-report.csv"; filename*=UTF-8\'\'m%C3%A4sumi-report.csv',
+        },
+      };
+    });
+
+    const result = await fetchTransactionReportExport({ client, body: reportBody, kind });
+
+    assert.equal(capturedRequest?.url, expectedPath);
+    assert.equal(capturedRequest?.responseType, 'blob');
+    assert.equal(capturedRequest?.throwOnError, true);
+    assert.equal(capturedRequest?.body, reportBody);
+    assert.equal(result.blob, blob);
+    assert.equal(result.filename, 'mäsumi-report.csv');
+  }
+});
+
+test('report export filenames fall back from unsafe RFC 5987 values to quoted names', async () => {
+  const blob = new Blob(['csv']);
+  const client = createClient(async () => ({
+    data: blob,
+    headers: {
+      'content-disposition':
+        'attachment; filename="safe-report.csv"; filename*=UTF-8\'\'..%2Funsafe.csv',
+    },
+  }));
+
+  const result = await fetchTransactionReportExport({
+    client,
+    body: reportBody,
+    kind: 'transactions',
+  });
+
+  assert.equal(result.filename, 'safe-report.csv');
+});
+
+test('report exports use a safe kind-specific filename when the header is missing', async () => {
+  const client = createClient(async () => ({ data: new Blob(['csv']), headers: {} }));
+
+  const result = await fetchTransactionReportExport({ client, body: reportBody, kind: 'totals' });
+
+  assert.equal(result.filename, 'totals.csv');
+});
+
+test('report exports decode JSON error blobs without losing the server message', async () => {
+  const message = 'Report CSV exceeds 67108864 bytes. Narrow the report filters.';
+  const client = createClient(async () => {
+    throw Object.assign(new Error('Request failed with status code 413'), {
+      response: {
+        data: new Blob([JSON.stringify({ status: 'error', error: { message } })], {
+          type: 'application/json',
+        }),
+      },
+    });
+  });
+
+  await assert.rejects(fetchTransactionReportExport({ client, body: reportBody, kind: 'zip' }), {
+    message,
+  });
+});
+
+test('saveTransactionReportExport always releases its URL when the browser click fails', () => {
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+  const revokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+  let clicked = false;
+  let removed = false;
+  let revokedUrl: string | undefined;
+  const anchor = {
+    href: '',
+    download: '',
+    click: () => {
+      clicked = true;
+      throw new Error('click failed');
+    },
+    remove: () => {
+      removed = true;
+    },
+  };
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      createElement: () => anchor,
+      body: { appendChild: () => anchor },
+    },
+  });
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: () => 'blob:report',
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: (url: string) => {
+      revokedUrl = url;
+    },
+  });
+
+  try {
+    assert.throws(
+      () =>
+        saveTransactionReportExport({
+          blob: new Blob(['csv']),
+          filename: 'masumi-transactions.csv',
+        }),
+      { message: 'click failed' },
+    );
+
+    assert.equal(anchor.href, 'blob:report');
+    assert.equal(anchor.download, 'masumi-transactions.csv');
+    assert.equal(clicked, true);
+    assert.equal(removed, true);
+    assert.equal(revokedUrl, 'blob:report');
+  } finally {
+    if (documentDescriptor) {
+      Object.defineProperty(globalThis, 'document', documentDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, 'document');
+    }
+    if (createObjectUrlDescriptor) {
+      Object.defineProperty(URL, 'createObjectURL', createObjectUrlDescriptor);
+    } else {
+      Reflect.deleteProperty(URL, 'createObjectURL');
+    }
+    if (revokeObjectUrlDescriptor) {
+      Object.defineProperty(URL, 'revokeObjectURL', revokeObjectUrlDescriptor);
+    } else {
+      Reflect.deleteProperty(URL, 'revokeObjectURL');
+    }
+  }
+});

--- a/frontend/src/lib/transaction-report/download.ts
+++ b/frontend/src/lib/transaction-report/download.ts
@@ -1,0 +1,152 @@
+import {
+  postReportsExportZip,
+  postReportsTotalsCsv,
+  postReportsTransactionsCsv,
+  postReportsWalletSummaryCsv,
+  type PostReportsSummaryData,
+} from '@/lib/api/generated';
+import type { Client } from '@/lib/api/generated/client';
+import { extractApiErrorMessage } from '@/lib/api-error';
+import { getOwnValue, isObject } from '@/lib/object-properties';
+
+export type ReportExportKind = 'transactions' | 'wallet-summary' | 'totals' | 'zip';
+
+const FALLBACK_FILENAMES: Record<ReportExportKind, string> = {
+  transactions: 'transactions.csv',
+  'wallet-summary': 'wallet-summary.csv',
+  totals: 'totals.csv',
+  zip: 'transaction-report.zip',
+};
+
+const INVALID_FILENAME_CHARACTER = /[\u0000-\u001f\u007f/\\]/u;
+const MAX_FILENAME_LENGTH = 255;
+
+function safeFilename(value: string): string | null {
+  const filename = value.trim();
+  if (
+    filename.length === 0 ||
+    filename.length > MAX_FILENAME_LENGTH ||
+    filename === '.' ||
+    filename === '..' ||
+    INVALID_FILENAME_CHARACTER.test(filename)
+  ) {
+    return null;
+  }
+  return filename;
+}
+
+function filenameFromContentDisposition(header: string | undefined, fallback: string): string {
+  if (!header) return fallback;
+
+  const encodedMatch = /(?:^|;)\s*filename\*\s*=\s*UTF-8'[^']*'([^;]*)/iu.exec(header);
+  if (encodedMatch) {
+    try {
+      const decoded = safeFilename(decodeURIComponent(encodedMatch[1].trim()));
+      if (decoded) return decoded;
+    } catch {
+      // Use the quoted filename or fixed fallback below.
+    }
+  }
+
+  const quotedMatch = /(?:^|;)\s*filename\s*=\s*"((?:[^"\\]|\\.)*)"/iu.exec(header);
+  const quoted = quotedMatch?.[1].replace(/\\(["\\])/gu, '$1');
+  return (quoted && safeFilename(quoted)) || fallback;
+}
+
+async function decodeErrorPayload(error: unknown): Promise<unknown> {
+  if (!isObject(error)) return error;
+  const response = getOwnValue(error, 'response');
+  if (!isObject(response)) return error;
+  const data = getOwnValue(response, 'data');
+  if (!(data instanceof Blob)) return data ?? error;
+
+  try {
+    const text = await data.text();
+    if (!text) return error;
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return text;
+    }
+  } catch {
+    return error;
+  }
+}
+
+async function requestReportExport({
+  client,
+  body,
+  kind,
+}: {
+  client: Client;
+  body: PostReportsSummaryData['body'];
+  kind: ReportExportKind;
+}) {
+  const options = {
+    client,
+    body,
+    responseType: 'blob' as const,
+    throwOnError: true as const,
+  };
+
+  switch (kind) {
+    case 'transactions':
+      return postReportsTransactionsCsv(options);
+    case 'wallet-summary':
+      return postReportsWalletSummaryCsv(options);
+    case 'totals':
+      return postReportsTotalsCsv(options);
+    case 'zip':
+      return postReportsExportZip(options);
+  }
+}
+
+export async function fetchTransactionReportExport({
+  client,
+  body,
+  kind,
+}: {
+  client: Client;
+  body: PostReportsSummaryData['body'];
+  kind: ReportExportKind;
+}): Promise<{ blob: Blob; filename: string }> {
+  try {
+    const response = await requestReportExport({ client, body, kind });
+    if (!(response.data instanceof Blob)) {
+      throw new Error('Report export returned an invalid binary response');
+    }
+
+    const contentDisposition = response.headers['content-disposition'];
+    return {
+      blob: response.data,
+      filename: filenameFromContentDisposition(
+        typeof contentDisposition === 'string' ? contentDisposition : undefined,
+        FALLBACK_FILENAMES[kind],
+      ),
+    };
+  } catch (error) {
+    const payload = await decodeErrorPayload(error);
+    throw new Error(extractApiErrorMessage(payload, 'Failed to export transaction report'));
+  }
+}
+
+export function saveTransactionReportExport({
+  blob,
+  filename,
+}: {
+  blob: Blob;
+  filename: string;
+}): void {
+  const objectUrl = URL.createObjectURL(blob);
+  let link: HTMLAnchorElement | undefined;
+  try {
+    link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = safeFilename(filename) ?? 'transaction-report-download';
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    link?.remove();
+    URL.revokeObjectURL(objectUrl);
+  }
+}

--- a/frontend/src/lib/transaction-report/download.ts
+++ b/frontend/src/lib/transaction-report/download.ts
@@ -18,6 +18,13 @@ const FALLBACK_FILENAMES: Record<ReportExportKind, string> = {
   zip: 'transaction-report.zip',
 };
 
+/**
+ * How long a finished download keeps its object URL. Some browsers read the
+ * blob after the click returns and cancel the download if the URL is already
+ * gone, so the successful path releases it on a later task instead.
+ */
+export const OBJECT_URL_RELEASE_DELAY_MS = 1_000;
+
 const INVALID_FILENAME_CHARACTER = /[\u0000-\u001f\u007f/\\]/u;
 const MAX_FILENAME_LENGTH = 255;
 
@@ -139,14 +146,21 @@ export function saveTransactionReportExport({
 }): void {
   const objectUrl = URL.createObjectURL(blob);
   let link: HTMLAnchorElement | undefined;
+  let hasStartedDownload = false;
   try {
     link = document.createElement('a');
     link.href = objectUrl;
     link.download = safeFilename(filename) ?? 'transaction-report-download';
     document.body.appendChild(link);
     link.click();
+    hasStartedDownload = true;
   } finally {
     link?.remove();
-    URL.revokeObjectURL(objectUrl);
+    if (hasStartedDownload) {
+      setTimeout(() => URL.revokeObjectURL(objectUrl), OBJECT_URL_RELEASE_DELAY_MS);
+    } else {
+      // Nothing was handed to the browser, so the URL can go immediately.
+      URL.revokeObjectURL(objectUrl);
+    }
   }
 }

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -12,6 +12,7 @@ import { PaymentSourceDialog } from '@/components/payment-sources/PaymentSourceD
 import Link from 'next/link';
 import { useQueryClient } from '@tanstack/react-query';
 import { invalidateAgentQueries } from '@/lib/queries/agent-cache';
+import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import {
   deletePaymentSourceExtended,
@@ -253,6 +254,7 @@ export default function PaymentSourcesPage() {
     queryClient.invalidateQueries({ queryKey: ['wallets'] });
     queryClient.invalidateQueries({ queryKey: ['transactions'] });
     invalidateAgentQueries(queryClient);
+    void invalidateTransactionReportFacets(queryClient);
   };
 
   return (
@@ -578,6 +580,7 @@ export default function PaymentSourcesPage() {
             onClose={() => setSourceToUpdate(null)}
             onSuccess={() => {
               refetch();
+              void invalidateTransactionReportFacets(queryClient);
             }}
             paymentSourceId={sourceToUpdate?.id || ''}
             currentApiKey={sourceToUpdate?.PaymentSourceConfig?.rpcProviderApiKey || ''}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -15,7 +15,6 @@ import { CopyButton } from '@/components/ui/copy-button';
 import TransactionDetailsDialog from '@/components/transactions/TransactionDetailsDialog';
 import { DownloadDetailsDialog } from '@/components/transactions/DownloadDetailsDialog';
 import { Download } from 'lucide-react';
-import { dateRangeUtils } from '@/lib/utils';
 import { useTransactions, OnChainStateFilter, ON_CHAIN_STATES } from '@/lib/hooks/useTransactions';
 import { AnimatedPage } from '@/components/ui/animated-page';
 import { SearchInput } from '@/components/ui/search-input';
@@ -25,7 +24,6 @@ import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
 import { parseAmountSearchRange, parseAmountToBigInt } from '@/lib/parseAmountSearchRange';
 import Link from 'next/link';
 import { PaymentSourceTypeBadge } from '@/components/payment-sources/PaymentSourceTypeBadge';
-import { getPaymentSourceTypeLabel } from '@/lib/payment-source-type';
 import { TransactionAgentIdentifierCell } from '@/components/transactions/TransactionAgentIdentifierCell';
 import { getLatestTxHash } from '@/components/transactions/transaction-format.helpers';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -34,6 +32,7 @@ import {
   EMPTY_FILTERS,
   type TransactionFilterState,
 } from '@/components/transactions/TransactionFilters';
+import { buildTransactionReportViewDefaults } from '@/components/transactions/download-details.helpers';
 import { useBulkClearTransactionErrors } from '@/lib/hooks/useBulkClearTransactionErrors';
 import { toast } from 'react-toastify';
 import { useResync } from '@/lib/hooks/useResync';
@@ -60,23 +59,17 @@ const getTransactionLayerLabel = (transaction: Transaction): 'Hydra L2' | 'L1' |
 const getHydraHeadId = (transaction: Transaction) =>
   transaction.CurrentTransaction?.hydraHeadId ?? null;
 
-const toCsvValue = (value: unknown): string => {
-  if (value == null) return '';
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint')
-    return String(value);
-  if (value instanceof Date) return value.toISOString();
-  return JSON.stringify(value) ?? '';
-};
-
 export default function Transactions() {
-  const { apiClient, selectedPaymentSourceId, network, selectedPaymentSource, capabilities } =
-    useAppContext();
+  const { apiClient, selectedPaymentSourceId, network, capabilities } = useAppContext();
   const resync = useResync();
 
   const [activeTab, setActiveTab] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
   const [filters, setFilters] = useState<TransactionFilterState>(EMPTY_FILTERS);
+  const reportViewDefaults = useMemo(
+    () => buildTransactionReportViewDefaults(activeTab, filters, searchQuery.trim().length > 0),
+    [activeTab, filters, searchQuery],
+  );
   const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const isNeedsActionTab = activeTab === 'Needs Action';
   // Error recovery posts to /payment|purchase/error-state-recovery, both
@@ -361,99 +354,6 @@ export default function Transactions() {
     }
   };
 
-  // Generate CSV data for transactions
-  const generateCSVData = useCallback(
-    (transactions: Transaction[]): string => {
-      const headers = [
-        'Transaction Type',
-        'Transaction Hash',
-        'Agent Name',
-        'Agent Identifier',
-        'Payment Amounts',
-        'Network',
-        'Payment Source Type',
-        'Layer',
-        'Hydra Head ID',
-        'Status',
-        'Date',
-        'Fee rate (%)',
-      ];
-      const rows = transactions.map((transaction) => {
-        // The list is filtered by network + source type only, so rows can
-        // belong to OTHER sources than the selected one. Only stamp the
-        // selected source's fee rate onto rows that actually belong to it.
-        const feeRatePermille =
-          transaction.PaymentSource?.id === selectedPaymentSource?.id
-            ? selectedPaymentSource?.feeRatePermille
-            : undefined;
-        const feeRateDisplay =
-          typeof feeRatePermille === 'number' ? (feeRatePermille / 10).toFixed(1) + '%' : 'Unknown';
-        const paymentAmounts: string[] = [];
-        if (transaction.type === 'payment' && transaction.RequestedFunds) {
-          paymentAmounts.push(
-            ...transaction.RequestedFunds.map((fund) =>
-              formatAssetAmount(fund.amount, fund.unit, network),
-            ),
-          );
-        } else if (transaction.type === 'purchase' && transaction.PaidFunds) {
-          paymentAmounts.push(
-            ...transaction.PaidFunds.map((fund) =>
-              formatAssetAmount(fund.amount, fund.unit, network),
-            ),
-          );
-        }
-        const amount = paymentAmounts.join(', ');
-
-        const hash = getLatestTxHash(transaction) || '—';
-        const agentName = transaction.agentName?.trim() || '—';
-        const agentIdentifier = transaction.agentIdentifier?.trim() || '—';
-        const status = formatStatus(transaction.onChainState);
-        const date = formatDateTime(transaction.createdAt);
-
-        return [
-          transaction.type,
-          hash,
-          agentName,
-          agentIdentifier,
-          amount,
-          transaction.PaymentSource.network,
-          getPaymentSourceTypeLabel(transaction.PaymentSource.paymentSourceType),
-          getTransactionLayerLabel(transaction) ?? '',
-          getHydraHeadId(transaction) ?? '',
-          status,
-          date,
-          feeRateDisplay,
-        ];
-      });
-
-      // RFC 4180: embed a literal `"` by doubling it, and wrap any field
-      // containing `,`, `"`, `\r`, or `\n` in surrounding quotes. We wrap
-      // every field unconditionally for consistency, so only the `"`
-      // doubling is strictly required here — without it, an agent name
-      // or note containing a quote breaks the CSV (parsers see it as a
-      // field terminator and split that row into extra columns).
-      const escapeCsvField = (value: unknown): string =>
-        `"${toCsvValue(value).replace(/"/g, '""')}"`;
-      return [headers, ...rows].map((row) => row.map(escapeCsvField).join(',')).join('\n');
-    },
-    [selectedPaymentSource?.id, selectedPaymentSource?.feeRatePermille, network],
-  );
-
-  // Download CSV file
-  const downloadCSV = (transactions: Transaction[], filename: string = 'transactions.csv') => {
-    const csvData = generateCSVData(transactions);
-    const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', filename);
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
-
   return (
     <MainLayout>
       <Head>
@@ -483,12 +383,11 @@ export default function Transactions() {
               />
               <Button
                 onClick={() => setShowDownloadDialog(true)}
-                disabled={visibleTransactions.length === 0}
                 variant="outline"
                 className="flex items-center gap-2 btn-hover-lift"
               >
                 <Download className="h-4 w-4" />
-                Download CSV
+                Export report
               </Button>
               {/* Developers > Testing creates real payments/purchases via
                   pay-authenticated endpoints, and the tab is hidden for
@@ -799,16 +698,13 @@ export default function Transactions() {
           onRefresh={refreshTransactions}
         />
 
-        <DownloadDetailsDialog
-          open={showDownloadDialog}
-          onClose={() => setShowDownloadDialog(false)}
-          onDownload={(startDate, endDate, filteredTransactions) => {
-            downloadCSV(
-              filteredTransactions,
-              `transactions-${activeTab.toLowerCase()}-${dateRangeUtils.formatDateRange(startDate, endDate).replace(/\s+/g, '-')}.csv`,
-            );
-          }}
-        />
+        {showDownloadDialog && (
+          <DownloadDetailsDialog
+            open
+            onClose={() => setShowDownloadDialog(false)}
+            viewDefaults={reportViewDefaults}
+          />
+        )}
       </AnimatedPage>
     </MainLayout>
   );


### PR DESCRIPTION
## change

- VERIFIED: Replaces browser-side CSV construction with authenticated report downloads.
- VERIFIED: Adds report filters, a server count preview, safe filenames, and JSON error handling for binary responses.
- VERIFIED: Refreshes report facets after Payment Source and managed-wallet changes.

## checks

- VERIFIED: `pnpm -C frontend run test` passed 101 tests on this layer.
- VERIFIED: Frontend typecheck, lint, and format checks passed.

## stack

2 of 4. Base: #739. Next: #741.