### PR TITLE
feat(reports): add financial dashboard

### DIFF
--- a/frontend/src/components/dashboard/FinancialHistoryCharts.tsx
+++ b/frontend/src/components/dashboard/FinancialHistoryCharts.tsx
@@ -1,0 +1,447 @@
+import { useMemo, useState } from 'react';
+import type { PostReportsSummaryResponses } from '@/lib/api/generated';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  buildReportChartPoints,
+  buildReportLinePath,
+  getReportAssetDescriptor,
+  getReportChartDomain,
+  scaleReportChartY,
+  type ReportChartPoint,
+  type ReportMetricKey,
+} from '@/lib/transaction-report/dashboard-metrics';
+import {
+  decimateReportChartPoints,
+  paginateReportRows,
+  REPORT_CHART_POINT_LIMIT,
+  resetReportTablePageState,
+  type ReportTablePageState,
+} from '@/lib/transaction-report/report-rendering';
+import { ReportTablePagination } from './ReportTablePagination';
+
+type ReportSummary = PostReportsSummaryResponses[200]['data'];
+type ReportRole = ReportSummary['wallets'][number]['role'];
+
+type ChartSeries = Readonly<{
+  key: ReportMetricKey;
+  label: string;
+  className: string;
+  fillClassName: string;
+  dash?: string;
+  marker: 'circle' | 'square' | 'diamond';
+}>;
+
+const CHART_DIMENSIONS = { width: 640, height: 240, padding: 24 } as const;
+
+const SELLER_VALUE_SERIES: readonly ChartSeries[] = [
+  {
+    key: 'sellerGrossRevenue',
+    label: 'Gross revenue',
+    className: 'stroke-emerald-600 dark:stroke-emerald-400',
+    fillClassName: 'fill-emerald-600 dark:fill-emerald-400',
+    marker: 'circle',
+  },
+  {
+    key: 'protocolFees',
+    label: 'Protocol fees',
+    className: 'stroke-amber-600 dark:stroke-amber-400',
+    fillClassName: 'fill-amber-600 dark:fill-amber-400',
+    dash: '8 5',
+    marker: 'square',
+  },
+  {
+    key: 'sellerNetRevenue',
+    label: 'Net revenue',
+    className: 'stroke-teal-700 dark:stroke-teal-300',
+    fillClassName: 'fill-teal-700 dark:fill-teal-300',
+    dash: '2 4',
+    marker: 'diamond',
+  },
+];
+
+const BUYER_VALUE_SERIES: readonly ChartSeries[] = [
+  {
+    key: 'buyerGrossSpend',
+    label: 'Gross spend',
+    className: 'stroke-blue-600 dark:stroke-blue-400',
+    fillClassName: 'fill-blue-600 dark:fill-blue-400',
+    dash: '12 3',
+    marker: 'circle',
+  },
+  {
+    key: 'returnedFunds',
+    label: 'Returned funds',
+    className: 'stroke-violet-600 dark:stroke-violet-400',
+    fillClassName: 'fill-violet-600 dark:fill-violet-400',
+    dash: '6 2 1 2',
+    marker: 'square',
+  },
+  {
+    key: 'buyerNetSpend',
+    label: 'Net spend',
+    className: 'stroke-cyan-700 dark:stroke-cyan-300',
+    fillClassName: 'fill-cyan-700 dark:fill-cyan-300',
+    dash: '1 3',
+    marker: 'diamond',
+  },
+];
+
+const CARDANO_FEE_SERIES: readonly ChartSeries[] = [
+  {
+    key: 'sellerCardanoFees',
+    label: 'Seller fees',
+    className: 'stroke-emerald-600 dark:stroke-emerald-400',
+    fillClassName: 'fill-emerald-600 dark:fill-emerald-400',
+    marker: 'circle',
+  },
+  {
+    key: 'buyerCardanoFees',
+    label: 'Buyer fees',
+    className: 'stroke-blue-600 dark:stroke-blue-400',
+    fillClassName: 'fill-blue-600 dark:fill-blue-400',
+    dash: '8 5',
+    marker: 'square',
+  },
+  {
+    key: 'actorCardanoFees',
+    label: 'Reconciled actor fees',
+    className: 'stroke-rose-600 dark:stroke-rose-400',
+    fillClassName: 'fill-rose-600 dark:fill-rose-400',
+    dash: '10 2 2 2',
+    marker: 'square',
+  },
+  {
+    key: 'adminCardanoFees',
+    label: 'Admin fees',
+    className: 'stroke-amber-600 dark:stroke-amber-400',
+    fillClassName: 'fill-amber-600 dark:fill-amber-400',
+    dash: '2 4',
+    marker: 'diamond',
+  },
+  {
+    key: 'totalCardanoFees',
+    label: 'Total fees',
+    className: 'stroke-violet-600 dark:stroke-violet-400',
+    fillClassName: 'fill-violet-600 dark:fill-violet-400',
+    dash: '12 4 2 4',
+    marker: 'circle',
+  },
+];
+
+function formatBucket(date: Date, timeZone: string, bucket: ReportSummary['bucket']): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    year: 'numeric',
+    month: bucket === 'Month' ? 'short' : 'short',
+    ...(bucket === 'Month' ? {} : { day: 'numeric' as const }),
+  }).format(date);
+}
+
+function SeriesMarker({
+  point,
+  series,
+}: Readonly<{ point: ReportChartPoint; series: ChartSeries }>) {
+  const fillClass = point.completeness === 'partial' ? 'fill-background' : series.fillClassName;
+  if (series.marker === 'square') {
+    return (
+      <rect
+        x={point.x - 3}
+        y={point.y - 3}
+        width="6"
+        height="6"
+        className={`${series.className} ${fillClass}`}
+        strokeWidth="2"
+      />
+    );
+  }
+  if (series.marker === 'diamond') {
+    return (
+      <rect
+        x={point.x - 3}
+        y={point.y - 3}
+        width="6"
+        height="6"
+        transform={`rotate(45 ${point.x} ${point.y})`}
+        className={`${series.className} ${fillClass}`}
+        strokeWidth="2"
+      />
+    );
+  }
+  return (
+    <circle
+      cx={point.x}
+      cy={point.y}
+      r="3.5"
+      className={`${series.className} ${fillClass}`}
+      strokeWidth="2"
+    />
+  );
+}
+
+function HistoryChart({
+  summary,
+  title,
+  unit,
+  series,
+}: Readonly<{
+  summary: ReportSummary;
+  title: string;
+  unit: string;
+  series: readonly ChartSeries[];
+}>) {
+  const [tablePageState, setTablePageState] = useState<ReportTablePageState>(() => ({
+    dataset: summary.history,
+    page: 0,
+  }));
+  const currentTablePageState = resetReportTablePageState(tablePageState, summary.history);
+  if (currentTablePageState !== tablePageState) setTablePageState(currentTablePageState);
+  const { descriptor, domain, fullSeries, plottedSeries } = useMemo(() => {
+    const nextDescriptor = getReportAssetDescriptor(summary, unit);
+    const nextDomain = getReportChartDomain(
+      summary.history,
+      series.map((item) => item.key),
+      unit,
+    );
+    const nextFullSeries = series.map((item) => ({
+      item,
+      points: buildReportChartPoints(
+        summary.history,
+        item.key,
+        unit,
+        CHART_DIMENSIONS,
+        nextDomain,
+        nextDescriptor,
+      ),
+    }));
+    return {
+      descriptor: nextDescriptor,
+      domain: nextDomain,
+      fullSeries: nextFullSeries,
+      plottedSeries: nextFullSeries.map(({ item, points }) => ({
+        item,
+        points: decimateReportChartPoints(points),
+      })),
+    };
+  }, [series, summary, unit]);
+  const zeroY = scaleReportChartY(BigInt(0), domain, CHART_DIMENSIONS);
+  const hasPartial = fullSeries.some(({ points }) =>
+    points.some((point) => point.completeness === 'partial'),
+  );
+  const historyPage = paginateReportRows(summary.history, currentTablePageState.page);
+  const timeZone = summary.metadata.filters.timeZone;
+  const firstBucket = summary.history[0];
+  const lastBucket = summary.history.at(-1);
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="space-y-3 pb-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{descriptor.symbol ?? descriptor.unit}</span>
+            {hasPartial && <Badge variant="warning">Some buckets are partial</Badge>}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs">
+          {series.map((item) => (
+            <span key={item.key} className="flex items-center gap-1.5">
+              <svg width="22" height="8" aria-hidden="true">
+                <line
+                  x1="1"
+                  x2="21"
+                  y1="4"
+                  y2="4"
+                  className={item.className}
+                  strokeWidth="2"
+                  strokeDasharray={item.dash}
+                />
+              </svg>
+              {item.label}
+            </span>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {summary.history.length === 0 ? (
+          <div className="flex h-60 items-center justify-center text-sm text-muted-foreground">
+            No history is available for these filters.
+          </div>
+        ) : (
+          <figure>
+            <figcaption className="sr-only">
+              {title} in {descriptor.symbol ?? descriptor.unit}, grouped by {summary.bucket} using{' '}
+              {summary.metadata.filters.dateBasis} dates in {timeZone}.
+            </figcaption>
+            <svg
+              viewBox={`0 0 ${CHART_DIMENSIONS.width} ${CHART_DIMENSIONS.height}`}
+              className="h-60 w-full overflow-visible"
+              aria-hidden="true"
+              focusable="false"
+            >
+              {[0.25, 0.5, 0.75].map((ratio) => (
+                <line
+                  key={ratio}
+                  x1={CHART_DIMENSIONS.padding}
+                  x2={CHART_DIMENSIONS.width - CHART_DIMENSIONS.padding}
+                  y1={CHART_DIMENSIONS.height * ratio}
+                  y2={CHART_DIMENSIONS.height * ratio}
+                  className="stroke-border"
+                  strokeWidth="1"
+                />
+              ))}
+              <line
+                x1={CHART_DIMENSIONS.padding}
+                x2={CHART_DIMENSIONS.width - CHART_DIMENSIONS.padding}
+                y1={zeroY}
+                y2={zeroY}
+                className="stroke-muted-foreground"
+                strokeWidth="1.5"
+              />
+              <text
+                x={CHART_DIMENSIONS.padding + 3}
+                y={Math.max(12, zeroY - 4)}
+                className="fill-muted-foreground"
+                fontSize="10"
+              >
+                0
+              </text>
+              {plottedSeries.map(({ item, points }) => (
+                <g key={item.key}>
+                  <path
+                    d={buildReportLinePath(points)}
+                    fill="none"
+                    className={item.className}
+                    strokeWidth="2"
+                    strokeDasharray={item.dash}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  {points
+                    .filter((point) => !point.isUnknown)
+                    .map((point) => (
+                      <SeriesMarker
+                        key={`${point.bucketStart.toISOString()}:${item.key}`}
+                        point={point}
+                        series={item}
+                      />
+                    ))}
+                </g>
+              ))}
+            </svg>
+            <div className="flex justify-between font-mono text-[11px] text-muted-foreground">
+              <span>
+                {firstBucket ? formatBucket(firstBucket.bucketStart, timeZone, summary.bucket) : ''}
+              </span>
+              <span>
+                {lastBucket ? formatBucket(lastBucket.bucketStart, timeZone, summary.bucket) : ''}
+              </span>
+            </div>
+            {summary.history.length > REPORT_CHART_POINT_LIMIT && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Long history is sampled in the chart. Chart data keeps every bucket.
+              </p>
+            )}
+            <details className="mt-4 rounded-md border">
+              <summary className="cursor-pointer px-3 py-2 text-sm font-medium">
+                View chart data
+              </summary>
+              <div className="overflow-x-auto border-t">
+                <table className="w-full text-left text-xs">
+                  <thead className="bg-muted/30 text-muted-foreground">
+                    <tr>
+                      <th scope="col" className="px-3 py-2 font-medium">
+                        Bucket
+                      </th>
+                      {series.map((item) => (
+                        <th key={item.key} scope="col" className="px-3 py-2 font-medium">
+                          {item.label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {historyPage.items.map((bucket, index) => {
+                      const sourceIndex = historyPage.startIndex + index;
+                      return (
+                        <tr key={bucket.bucketStart.toISOString()} className="border-t">
+                          <th scope="row" className="whitespace-nowrap px-3 py-2 font-medium">
+                            {formatBucket(bucket.bucketStart, timeZone, summary.bucket)}
+                          </th>
+                          {fullSeries.map(({ item, points }) => (
+                            <td key={item.key} className="whitespace-nowrap px-3 py-2 font-mono">
+                              {points[sourceIndex]?.valueText ??
+                                `0 ${descriptor.symbol ?? descriptor.unit}`}
+                              {points[sourceIndex]?.completeness === 'partial' ? ' (Partial)' : ''}
+                            </td>
+                          ))}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <ReportTablePagination
+                page={historyPage.page}
+                pageCount={historyPage.pageCount}
+                startIndex={historyPage.startIndex}
+                endIndex={historyPage.endIndex}
+                totalCount={historyPage.totalCount}
+                itemLabel="history rows"
+                ariaLabel={`${title} chart data pagination`}
+                onPageChange={(page) => setTablePageState({ dataset: summary.history, page })}
+              />
+            </details>
+          </figure>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function FinancialHistoryCharts({
+  summary,
+  roles,
+  selectedUnit,
+}: Readonly<{
+  summary: ReportSummary;
+  roles: readonly ReportRole[];
+  selectedUnit: string | null;
+}>) {
+  const roleSet = new Set(roles);
+  const valueSeries = [
+    ...(roleSet.has('Seller') ? SELLER_VALUE_SERIES : []),
+    ...(roleSet.has('Buyer') ? BUYER_VALUE_SERIES : []),
+  ];
+  const feeSeries = CARDANO_FEE_SERIES.filter(
+    (series) => series.key !== 'sellerCardanoFees' || roleSet.has('Seller'),
+  ).filter((series) => series.key !== 'buyerCardanoFees' || roleSet.has('Buyer'));
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      {selectedUnit ? (
+        <HistoryChart
+          summary={summary}
+          title="Value history"
+          unit={selectedUnit}
+          series={valueSeries}
+        />
+      ) : (
+        <Card className="shadow-none">
+          <CardHeader>
+            <CardTitle className="text-base">Value history</CardTitle>
+          </CardHeader>
+          <CardContent className="flex h-60 items-center justify-center text-sm text-muted-foreground">
+            No recognized value exists for these filters.
+          </CardContent>
+        </Card>
+      )}
+      <HistoryChart
+        summary={summary}
+        title="Cardano fee history"
+        unit="lovelace"
+        series={feeSeries}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/FinancialMetricCards.tsx
+++ b/frontend/src/components/dashboard/FinancialMetricCards.tsx
@@ -1,0 +1,189 @@
+import type { PostReportsSummaryResponses } from '@/lib/api/generated';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  formatReportMetricValue,
+  getEmptyReportAssetLabel,
+  getReportAssetDescriptor,
+  type ReportAssetDescriptor,
+  type ReportMetric,
+  type ReportMetricKey,
+} from '@/lib/transaction-report/dashboard-metrics';
+
+type ReportSummary = PostReportsSummaryResponses[200]['data'];
+type ReportRole = ReportSummary['wallets'][number]['role'];
+
+type MetricCardDefinition = Readonly<{
+  key: ReportMetricKey;
+  label: string;
+  unitType: 'business' | 'cardano';
+  net?: boolean;
+}>;
+
+const SELLER_CARDS: readonly MetricCardDefinition[] = [
+  { key: 'sellerGrossRevenue', label: 'Seller gross revenue', unitType: 'business' },
+  { key: 'protocolFees', label: 'Protocol fees', unitType: 'business' },
+  { key: 'sellerCardanoFees', label: 'Seller Cardano fees', unitType: 'cardano' },
+  { key: 'sellerNetRevenue', label: 'Seller net revenue', unitType: 'business', net: true },
+];
+
+const BUYER_CARDS: readonly MetricCardDefinition[] = [
+  { key: 'buyerGrossSpend', label: 'Buyer gross spend', unitType: 'business' },
+  { key: 'returnedFunds', label: 'Returned funds', unitType: 'business' },
+  { key: 'buyerCardanoFees', label: 'Buyer Cardano fees', unitType: 'cardano' },
+  { key: 'buyerNetSpend', label: 'Buyer net spend', unitType: 'business', net: true },
+];
+
+const RECONCILIATION_CARDS: readonly MetricCardDefinition[] = [
+  { key: 'actorCardanoFees', label: 'Reconciled actor fees', unitType: 'cardano' },
+  { key: 'adminCardanoFees', label: 'Admin Cardano fees', unitType: 'cardano' },
+  { key: 'totalCardanoFees', label: 'Total Cardano fees', unitType: 'cardano' },
+];
+
+function MetricValue({
+  descriptor,
+  isNet,
+  metric,
+}: Readonly<{
+  descriptor: ReportAssetDescriptor | null;
+  isNet: boolean;
+  metric: ReportMetric;
+}>) {
+  if (!descriptor) {
+    return (
+      <div>
+        <p className="text-lg font-semibold text-muted-foreground">
+          {getEmptyReportAssetLabel(metric.completeness)}
+        </p>
+        {metric.completeness === 'partial' && (
+          <Badge variant="warning" className="mt-2">
+            Partial
+          </Badge>
+        )}
+      </div>
+    );
+  }
+
+  const display = formatReportMetricValue(metric, descriptor.unit, descriptor);
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="break-all font-mono text-xl font-semibold tabular-nums">
+          {display.text}
+        </span>
+        {display.isPartial && <Badge variant="warning">Partial</Badge>}
+      </div>
+      {isNet && display.isNegative && (
+        <p className="mt-1 text-xs font-medium text-destructive">Negative net</p>
+      )}
+    </div>
+  );
+}
+
+function metricAmountForUnit(
+  metric: ReportMetric,
+  unit: string,
+): ReportMetric['amounts'][number] | undefined {
+  return metric.amounts.find((amount) => amount.unit === unit);
+}
+
+function FinancialMetricCard({
+  definition,
+  descriptor,
+  metric,
+}: Readonly<{
+  definition: MetricCardDefinition;
+  descriptor: ReportAssetDescriptor | null;
+  metric: ReportMetric;
+}>) {
+  const amount = descriptor ? metricAmountForUnit(metric, descriptor.unit) : undefined;
+  const scopedMetric = { ...metric, amounts: amount ? [amount] : [] };
+
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {definition.label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <MetricValue
+          descriptor={descriptor}
+          isNet={definition.net ?? false}
+          metric={scopedMetric}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetricRow({
+  definitions,
+  summary,
+  businessDescriptor,
+  cardanoDescriptor,
+}: Readonly<{
+  definitions: readonly MetricCardDefinition[];
+  summary: ReportSummary;
+  businessDescriptor: ReportAssetDescriptor | null;
+  cardanoDescriptor: ReportAssetDescriptor;
+}>) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {definitions.map((definition) => (
+        <FinancialMetricCard
+          key={definition.key}
+          definition={definition}
+          descriptor={definition.unitType === 'cardano' ? cardanoDescriptor : businessDescriptor}
+          metric={summary.totals[definition.key]}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function FinancialMetricCards({
+  summary,
+  roles,
+  selectedUnit,
+}: Readonly<{
+  summary: ReportSummary;
+  roles: readonly ReportRole[];
+  selectedUnit: string | null;
+}>) {
+  const roleSet = new Set(roles);
+  const businessDescriptor = selectedUnit ? getReportAssetDescriptor(summary, selectedUnit) : null;
+  const cardanoDescriptor = getReportAssetDescriptor(summary, 'lovelace');
+
+  return (
+    <div className="space-y-3">
+      {roleSet.has('Seller') && (
+        <MetricRow
+          definitions={SELLER_CARDS}
+          summary={summary}
+          businessDescriptor={businessDescriptor}
+          cardanoDescriptor={cardanoDescriptor}
+        />
+      )}
+      {roleSet.has('Buyer') && (
+        <MetricRow
+          definitions={BUYER_CARDS}
+          summary={summary}
+          businessDescriptor={businessDescriptor}
+          cardanoDescriptor={cardanoDescriptor}
+        />
+      )}
+      <div className="grid gap-3 border-t pt-3 sm:grid-cols-3">
+        {RECONCILIATION_CARDS.map((definition) => (
+          <FinancialMetricCard
+            key={definition.key}
+            definition={definition}
+            descriptor={cardanoDescriptor}
+            metric={summary.totals[definition.key]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/FinancialReportFilters.tsx
+++ b/frontend/src/components/dashboard/FinancialReportFilters.tsx
@@ -1,0 +1,376 @@
+import type { GetReportsFacetsResponses, PostReportsSummaryResponses } from '@/lib/api/generated';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { cn, shortenAddress } from '@/lib/utils';
+import {
+  REPORT_ON_CHAIN_STATES,
+  type ReportBucket,
+  type ReportDateBasis,
+  type ReportDatePreset,
+  type ReportOnChainState,
+  type ReportRevenueMode,
+  type ReportRole,
+  type TransactionReportFormState,
+} from '@/components/transactions/download-details.helpers';
+
+type ReportFacets = GetReportsFacetsResponses[200]['data'];
+type ReportPaymentSourceSnapshot =
+  PostReportsSummaryResponses[200]['data']['metadata']['paymentSource'];
+
+type FinancialReportFiltersProps = Readonly<{
+  form: TransactionReportFormState;
+  isLoading: boolean;
+  managedWallets: ReportFacets['managedWallets'];
+  paymentSources: ReportFacets['paymentSources'];
+  snapshotPaymentSource: ReportPaymentSourceSnapshot | null;
+  onSetPaymentSource: (paymentSourceId: string) => void;
+  onToggleRole: (role: ReportRole) => void;
+  onToggleState: (state: ReportOnChainState) => void;
+  onToggleWallet: (walletId: string) => void;
+  onUpdate: (patch: Partial<TransactionReportFormState>) => void;
+}>;
+
+const DATE_PRESETS: ReadonlyArray<{ value: ReportDatePreset; label: string }> = [
+  { value: '24h', label: 'Last 24 hours' },
+  { value: '7d', label: 'Last 7 days' },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 90 days' },
+  { value: 'custom', label: 'Custom dates' },
+];
+
+const DATE_BASES: ReadonlyArray<{ value: ReportDateBasis; label: string }> = [
+  { value: 'RevenueRecognizedAt', label: 'Revenue recognized' },
+  { value: 'FundsLockedAt', label: 'Funds locked' },
+  { value: 'CreatedAt', label: 'Request created' },
+];
+
+const REVENUE_MODES: ReadonlyArray<{ value: ReportRevenueMode; label: string }> = [
+  { value: 'Billable', label: 'Billable' },
+  { value: 'CashReceived', label: 'Cash received' },
+  { value: 'RequestedGross', label: 'Requested gross' },
+];
+
+const REPORT_BUCKETS: ReadonlyArray<{ value: ReportBucket; label: string }> = [
+  { value: 'Auto', label: 'Automatic buckets' },
+  { value: 'Day', label: 'Daily' },
+  { value: 'Week', label: 'Weekly' },
+  { value: 'Month', label: 'Monthly' },
+];
+
+function humanize(value: string): string {
+  return value.replace(/([A-Z])/g, ' $1').trim();
+}
+
+function todayAsDateInput(): string {
+  const today = new Date();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${today.getFullYear()}-${month}-${day}`;
+}
+
+export function FinancialReportFilters({
+  form,
+  isLoading,
+  managedWallets,
+  paymentSources,
+  snapshotPaymentSource,
+  onSetPaymentSource,
+  onToggleRole,
+  onToggleState,
+  onToggleWallet,
+  onUpdate,
+}: FinancialReportFiltersProps) {
+  const selectedSource = paymentSources.find((source) => source.id === form.paymentSourceId);
+  const provenanceSource =
+    snapshotPaymentSource?.id === form.paymentSourceId ? snapshotPaymentSource : selectedSource;
+  const maxDate = todayAsDateInput();
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-muted/10 p-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        <div className="space-y-1.5 md:col-span-2 xl:col-span-1">
+          <Label htmlFor="dashboard-report-source">Payment source</Label>
+          <Select
+            value={form.paymentSourceId || undefined}
+            onValueChange={onSetPaymentSource}
+            disabled={isLoading || paymentSources.length === 0}
+          >
+            <SelectTrigger id="dashboard-report-source">
+              <SelectValue placeholder={isLoading ? 'Loading sources…' : 'Select a source'} />
+            </SelectTrigger>
+            <SelectContent>
+              {paymentSources.map((source) => (
+                <SelectItem key={source.id} value={source.id}>
+                  {source.paymentSourceType === 'Web3CardanoV2' ? 'Cardano V2' : 'Cardano V1'} ·{' '}
+                  {shortenAddress(source.smartContractAddress, 7)}
+                  {source.deletedAt ? ' · Archived' : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {provenanceSource && (
+            <p className="font-mono text-[11px] text-muted-foreground">
+              {snapshotPaymentSource?.id === form.paymentSourceId ? 'Report snapshot' : 'Source'} ·{' '}
+              {provenanceSource.paymentSourceType === 'Web3CardanoV2' ? 'Cardano V2' : 'Cardano V1'}{' '}
+              · {provenanceSource.network} · fee rate {provenanceSource.feeRatePermille / 10}%
+              {provenanceSource.deletedAt ? ' · Archived' : ''}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="dashboard-report-period">Period</Label>
+          <Select
+            value={form.datePreset}
+            onValueChange={(value) => onUpdate({ datePreset: value as ReportDatePreset })}
+          >
+            <SelectTrigger id="dashboard-report-period">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DATE_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="dashboard-report-date-basis">Date basis</Label>
+          <Select
+            value={form.dateBasis}
+            onValueChange={(value) => onUpdate({ dateBasis: value as ReportDateBasis })}
+          >
+            <SelectTrigger id="dashboard-report-date-basis">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DATE_BASES.map((basis) => (
+                <SelectItem key={basis.value} value={basis.value}>
+                  {basis.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="dashboard-report-revenue-mode">Revenue mode</Label>
+          <Select
+            value={form.revenueMode}
+            onValueChange={(value) => onUpdate({ revenueMode: value as ReportRevenueMode })}
+          >
+            <SelectTrigger id="dashboard-report-revenue-mode">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REVENUE_MODES.map((mode) => (
+                <SelectItem key={mode.value} value={mode.value}>
+                  {mode.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="dashboard-report-bucket">History buckets</Label>
+          <Select
+            value={form.bucket}
+            onValueChange={(value) => onUpdate({ bucket: value as ReportBucket })}
+          >
+            <SelectTrigger id="dashboard-report-bucket">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REPORT_BUCKETS.map((bucket) => (
+                <SelectItem key={bucket.value} value={bucket.value}>
+                  {bucket.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {form.datePreset === 'custom' && (
+        <div className="grid gap-3 rounded-md border bg-background p-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="dashboard-report-start-date" className="text-xs">
+              First day
+            </Label>
+            <Input
+              id="dashboard-report-start-date"
+              type="date"
+              max={maxDate}
+              value={form.customStartDate}
+              onChange={(event) => onUpdate({ customStartDate: event.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="dashboard-report-end-date" className="text-xs">
+              Last day
+            </Label>
+            <Input
+              id="dashboard-report-end-date"
+              type="date"
+              max={maxDate}
+              value={form.customEndDate}
+              onChange={(event) => onUpdate({ customEndDate: event.target.value })}
+            />
+          </div>
+        </div>
+      )}
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Roles</legend>
+        <div className="flex flex-wrap gap-2">
+          {(['Seller', 'Buyer'] as const).map((role) => (
+            <label
+              key={role}
+              className={cn(
+                'flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm',
+                form.roles.includes(role) && 'border-foreground/40 bg-background',
+              )}
+            >
+              <Checkbox
+                checked={form.roles.includes(role)}
+                onCheckedChange={() => onToggleRole(role)}
+              />
+              {role}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <details className="group rounded-md border bg-background">
+        <summary className="cursor-pointer select-none px-3 py-2 text-sm font-medium">
+          Wallet, state, and address filters
+          <span className="ml-2 font-normal text-muted-foreground">
+            {form.managedWalletIds.length > 0
+              ? `${form.managedWalletIds.length} wallets`
+              : 'All wallets'}
+            {' · '}
+            {form.states.length > 0 ? `${form.states.length} states` : 'All states'}
+            {' · '}
+            {form.externalAddressesText.trim() ? 'Address filter active' : 'All addresses'}
+          </span>
+        </summary>
+        <div className="grid gap-5 border-t p-4 lg:grid-cols-2">
+          <fieldset className="relative space-y-2">
+            <legend className="text-sm font-medium">Managed wallets</legend>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-auto px-1 py-0 text-xs"
+              onClick={() => onUpdate({ managedWalletIds: [] })}
+            >
+              All wallets
+            </Button>
+            <div className="max-h-44 space-y-1 overflow-y-auto rounded-md border p-2">
+              {managedWallets.length === 0 ? (
+                <p className="px-2 py-3 text-xs text-muted-foreground">
+                  No managed wallets belong to this source.
+                </p>
+              ) : (
+                managedWallets.map((wallet) => (
+                  <label
+                    key={wallet.id}
+                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={form.managedWalletIds.includes(wallet.id)}
+                      onCheckedChange={() => onToggleWallet(wallet.id)}
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {wallet.note?.trim()
+                        ? `${wallet.note.trim()} (${shortenAddress(wallet.walletAddress, 8)})`
+                        : shortenAddress(wallet.walletAddress, 8)}{' '}
+                      · ID {shortenAddress(wallet.id, 5)}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {wallet.type === 'Selling' ? 'Seller' : 'Buyer'}
+                      {wallet.deletedAt ? ' · Archived' : ''}
+                    </span>
+                  </label>
+                ))
+              )}
+            </div>
+          </fieldset>
+
+          <fieldset className="relative space-y-2">
+            <legend className="text-sm font-medium">States</legend>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-auto px-1 py-0 text-xs"
+              onClick={() => onUpdate({ states: [] })}
+            >
+              All states
+            </Button>
+            <div className="grid max-h-44 grid-cols-2 gap-1 overflow-y-auto rounded-md border p-2">
+              {REPORT_ON_CHAIN_STATES.map((state) => (
+                <label
+                  key={state}
+                  className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-muted/50"
+                >
+                  <Checkbox
+                    checked={form.states.includes(state)}
+                    onCheckedChange={() => onToggleState(state)}
+                  />
+                  <span>{humanize(state)}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="space-y-2">
+            <Label htmlFor="dashboard-report-addresses">External addresses</Label>
+            <Textarea
+              id="dashboard-report-addresses"
+              className="min-h-16 font-mono text-xs"
+              placeholder="Optional. Separate addresses with commas or new lines."
+              value={form.externalAddressesText}
+              onChange={(event) => onUpdate({ externalAddressesText: event.target.value })}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Matches counterparty, payout, and return addresses.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="dashboard-report-time-zone">IANA time zone</Label>
+            <Input
+              id="dashboard-report-time-zone"
+              list="dashboard-report-time-zones"
+              value={form.timeZone}
+              onChange={(event) => onUpdate({ timeZone: event.target.value })}
+              placeholder="Europe/Prague"
+            />
+            <datalist id="dashboard-report-time-zones">
+              <option value="Etc/UTC" />
+              <option value={form.timeZone} />
+            </datalist>
+            <p className="text-[11px] text-muted-foreground">
+              Bucket boundaries and labels use this time zone.
+            </p>
+          </div>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/FinancialReportSection.tsx
+++ b/frontend/src/components/dashboard/FinancialReportSection.tsx
@@ -1,0 +1,271 @@
+import { useState } from 'react';
+import { Download, Loader2, RefreshCw, RotateCcw, TrendingUp } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { shortenAddress } from '@/lib/utils';
+import {
+  collectReportAssetUnits,
+  getReportAssetDescriptor,
+  getReportTransactionCountDisplay,
+  resolveReportAssetUnit,
+} from '@/lib/transaction-report/dashboard-metrics';
+import { FinancialHistoryCharts } from './FinancialHistoryCharts';
+import { FinancialMetricCards } from './FinancialMetricCards';
+import { FinancialReportFilters } from './FinancialReportFilters';
+import { FinancialWalletTable } from './FinancialWalletTable';
+import { useFinancialReportModel } from './useFinancialReportModel';
+
+function humanize(value: string): string {
+  return value.replace(/([A-Z])/g, ' $1').trim();
+}
+
+function ReportLoadingState() {
+  return (
+    <div className="space-y-4" aria-label="Calculating financial report">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <Card key={index} className="shadow-none">
+            <CardContent className="space-y-3 p-5">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-7 w-40" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
+export function FinancialReportSection() {
+  const model = useFinancialReportModel();
+  const [requestedUnit, setRequestedUnit] = useState('');
+  const assetUnits = model.summary ? collectReportAssetUnits(model.summary) : [];
+  const selectedUnit = resolveReportAssetUnit(assetUnits, requestedUnit);
+  const summary = model.summary;
+  const transactionCountDisplay = summary
+    ? getReportTransactionCountDisplay(
+        summary.totals.transactionCount,
+        summary.totals.transactionCountCompleteness,
+        'distinct logical payment',
+      )
+    : null;
+  const isBusy = model.isLoadingFacets || model.isLoadingSummary || model.isRefetching;
+  const generatedAt = summary
+    ? new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: summary.metadata.filters.timeZone,
+      }).format(summary.metadata.generatedAt)
+    : null;
+  const resetReport = () => {
+    setRequestedUnit('');
+    model.reset();
+  };
+
+  return (
+    <section
+      id="financial-reporting"
+      className="space-y-4"
+      aria-labelledby="financial-reporting-title"
+      aria-busy={isBusy}
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-teal-500/10 text-teal-700 dark:text-teal-300">
+              <TrendingUp className="h-4 w-4" />
+            </div>
+            <h2 id="financial-reporting-title" className="text-lg font-semibold">
+              Financial reporting
+            </h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Revenue, spend, refunds, protocol fees, and Cardano fees from one server snapshot.
+          </p>
+          {summary && generatedAt && (
+            <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+              <span>{transactionCountDisplay?.text}</span>
+              {summary.totals.transactionCountCompleteness === 'partial' && (
+                <Badge variant="warning">Partial count</Badge>
+              )}
+              <span>
+                · {humanize(summary.metadata.filters.dateBasis)} · {summary.bucket} buckets ·{' '}
+                {summary.metadata.filters.timeZone} · generated {generatedAt}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={resetReport}>
+            <RotateCcw className="h-4 w-4" /> Reset
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={model.refresh}
+            disabled={isBusy || model.body == null}
+          >
+            <RefreshCw className={isBusy ? 'h-4 w-4 animate-spin' : 'h-4 w-4'} />
+            Refresh
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => model.exportZip()}
+            disabled={model.isExporting || summary == null || model.body == null}
+          >
+            {model.isExporting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+            {model.isExporting ? 'Preparing…' : 'Download ZIP'}
+          </Button>
+        </div>
+      </div>
+
+      <FinancialReportFilters
+        form={model.form}
+        isLoading={model.isLoadingFacets}
+        managedWallets={model.managedWallets}
+        paymentSources={model.paymentSources}
+        snapshotPaymentSource={summary?.metadata.paymentSource ?? null}
+        onSetPaymentSource={model.setPaymentSource}
+        onToggleRole={model.toggleRole}
+        onToggleState={model.toggleState}
+        onToggleWallet={model.toggleWallet}
+        onUpdate={model.updateForm}
+      />
+
+      <div className="min-h-6" aria-live="polite">
+        {model.facetsError ? (
+          <p className="text-sm text-destructive">{model.facetsError}</p>
+        ) : model.isLoadingFacets ? (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading report filters…
+          </p>
+        ) : model.bodyError ? (
+          <p className="text-sm text-destructive">{model.bodyError}</p>
+        ) : model.summaryError ? (
+          <p className="text-sm text-destructive">{model.summaryError}</p>
+        ) : model.exportError ? (
+          <p className="text-sm text-destructive">{model.exportError}</p>
+        ) : isBusy ? (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Calculating financial report…
+          </p>
+        ) : model.paymentSources.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No accessible payment source is available on this network.
+          </p>
+        ) : null}
+      </div>
+
+      {isBusy && !summary ? (
+        <ReportLoadingState />
+      ) : summary ? (
+        <div className="space-y-5">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold">Accounting totals</h3>
+              <p className="text-xs text-muted-foreground">
+                Known values remain visible when historical fee allocation is partial.
+              </p>
+            </div>
+            {assetUnits.length > 0 && (
+              <div className="w-full space-y-1.5 sm:w-64">
+                <label htmlFor="financial-report-asset" className="text-xs font-medium">
+                  Business asset
+                </label>
+                <Select value={selectedUnit ?? undefined} onValueChange={setRequestedUnit}>
+                  <SelectTrigger id="financial-report-asset">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {assetUnits.map((unit) => {
+                      const descriptor = getReportAssetDescriptor(summary, unit);
+                      return (
+                        <SelectItem key={unit} value={unit}>
+                          {descriptor.symbol ?? shortenAddress(unit, 8)}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          {transactionCountDisplay?.isConfirmedEmpty && (
+            <Card className="border-dashed shadow-none">
+              <CardContent className="py-8 text-center">
+                <p className="font-medium">No matching transactions</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Change the period, wallet, role, state, or address filters.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          <FinancialMetricCards
+            summary={summary}
+            roles={model.form.roles}
+            selectedUnit={selectedUnit}
+          />
+
+          {summary.metadata.warnings.length > 0 && (
+            <div
+              id="financial-report-warnings"
+              className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4"
+            >
+              <div className="mb-2 flex items-center gap-2">
+                <Badge variant="warning">Partial data</Badge>
+                <h3 className="text-sm font-semibold">Report warnings</h3>
+              </div>
+              <ul className="space-y-1 text-sm text-amber-900 dark:text-amber-100">
+                {summary.metadata.warnings.map((warning, index) => (
+                  <li key={`${warning.code}:${warning.rowId ?? ''}:${index}`}>{warning.message}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <FinancialHistoryCharts
+            summary={summary}
+            roles={model.form.roles}
+            selectedUnit={selectedUnit}
+          />
+
+          <div>
+            <div className="mb-3">
+              <h3 className="text-sm font-semibold">Wallet and role breakdown</h3>
+              <p className="text-xs text-muted-foreground">
+                Each managed wallet keeps separate Buyer and Seller accounting rows.
+              </p>
+            </div>
+            <FinancialWalletTable
+              summary={summary}
+              facets={{
+                paymentSources: model.paymentSources,
+                managedWallets: model.managedWallets,
+              }}
+              selectedUnit={selectedUnit}
+              roles={model.form.roles}
+            />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/FinancialWalletTable.tsx
+++ b/frontend/src/components/dashboard/FinancialWalletTable.tsx
@@ -1,0 +1,395 @@
+import { useMemo, useState } from 'react';
+import type { GetReportsFacetsResponses, PostReportsSummaryResponses } from '@/lib/api/generated';
+import {
+  formatReportCountValue,
+  formatReportMetricValue,
+  getReportAssetDescriptor,
+  getReportMetricAmount,
+  type ReportAmountFallback,
+  type ReportMetric,
+  type ReportMetricKey,
+  type ReportMetrics,
+} from '@/lib/transaction-report/dashboard-metrics';
+import { shortenAddress } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  paginateReportRows,
+  resetReportTablePageState,
+  type ReportTablePageState,
+} from '@/lib/transaction-report/report-rendering';
+import { ReportTablePagination } from './ReportTablePagination';
+
+type ReportSummary = PostReportsSummaryResponses[200]['data'];
+type ReportFacets = GetReportsFacetsResponses[200]['data'];
+type ReportWallet = ReportSummary['wallets'][number];
+type ReportRole = ReportWallet['role'];
+
+type FinancialWalletTableProps = Readonly<{
+  summary: ReportSummary;
+  facets: ReportFacets | null;
+  selectedUnit: string | null;
+  roles: readonly ReportRole[];
+}>;
+
+type RoleMetricKeys = Readonly<{
+  gross: ReportMetricKey;
+  adjustment: ReportMetricKey;
+  actorCardanoFee: ReportMetricKey;
+  net: ReportMetricKey;
+}>;
+
+const ROLE_METRICS: Record<ReportRole, RoleMetricKeys> = {
+  Seller: {
+    gross: 'sellerGrossRevenue',
+    adjustment: 'protocolFees',
+    actorCardanoFee: 'sellerCardanoFees',
+    net: 'sellerNetRevenue',
+  },
+  Buyer: {
+    gross: 'buyerGrossSpend',
+    adjustment: 'returnedFunds',
+    actorCardanoFee: 'buyerCardanoFees',
+    net: 'buyerNetSpend',
+  },
+};
+
+const CARDANO_UNIT = 'lovelace';
+
+function uniqueRoles(roles: readonly ReportRole[]): ReportRole[] {
+  return [...new Set(roles)];
+}
+
+function walletLabel(wallet: ReportWallet, notesByWalletId: ReadonlyMap<string, string>): string {
+  if (!wallet.managedWallet) return 'Unassigned';
+  return notesByWalletId.get(wallet.managedWallet.id) ?? wallet.managedWallet.walletAddress;
+}
+
+function sortWallets(
+  wallets: readonly ReportWallet[],
+  notesByWalletId: ReadonlyMap<string, string>,
+): ReportWallet[] {
+  const roleOrder: Record<ReportRole, number> = { Seller: 0, Buyer: 1 };
+  return [...wallets].sort((left, right) => {
+    if (!left.managedWallet && right.managedWallet) return 1;
+    if (left.managedWallet && !right.managedWallet) return -1;
+
+    const labelOrder = walletLabel(left, notesByWalletId).localeCompare(
+      walletLabel(right, notesByWalletId),
+      undefined,
+      { sensitivity: 'base' },
+    );
+    if (labelOrder !== 0) return labelOrder;
+
+    const idOrder = (left.managedWallet?.id ?? '').localeCompare(right.managedWallet?.id ?? '');
+    if (idOrder !== 0) return idOrder;
+    return roleOrder[left.role] - roleOrder[right.role];
+  });
+}
+
+function MetricValue({
+  metric,
+  fallback,
+}: Readonly<{ metric: ReportMetric; fallback: ReportAmountFallback | null }>) {
+  const availableAmounts = metric.amounts;
+  const isPartial = metric.completeness === 'partial';
+  const fallbackUnit = typeof fallback === 'string' ? fallback : (fallback?.unit ?? '');
+  const emptyDisplay = formatReportMetricValue(metric, fallbackUnit, fallback ?? '');
+
+  return (
+    <div className="flex min-w-max flex-col items-end gap-1 font-mono text-xs tabular-nums">
+      {availableAmounts.length > 0 ? (
+        availableAmounts.map((amount) => (
+          <span key={amount.unit}>
+            {
+              formatReportMetricValue({ ...metric, amounts: [amount] }, amount.unit, amount.unit)
+                .text
+            }
+          </span>
+        ))
+      ) : (
+        <span>{emptyDisplay.text}</span>
+      )}
+      {isPartial && (
+        <Badge variant="warning" className="px-1.5 py-0 font-sans text-[10px]">
+          Partial
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function metricForUnit(
+  metrics: ReportMetrics,
+  metricKey: ReportMetricKey,
+  unit: string,
+): ReportMetric {
+  const metric = metrics[metricKey];
+  const amount = getReportMetricAmount(metrics, metricKey, unit);
+  return { ...metric, amounts: amount ? [amount] : [] };
+}
+
+function visibleMetricKeys(role: ReportRole): ReportMetricKey[] {
+  const roleMetrics = ROLE_METRICS[role];
+  return [
+    roleMetrics.gross,
+    roleMetrics.adjustment,
+    roleMetrics.actorCardanoFee,
+    roleMetrics.net,
+    'actorCardanoFees',
+    'adminCardanoFees',
+    'totalCardanoFees',
+  ];
+}
+
+function WalletIdentity({
+  wallet,
+  note,
+}: Readonly<{ wallet: ReportWallet['managedWallet']; note: string | null }>) {
+  if (!wallet) {
+    return (
+      <div>
+        <div className="font-medium">Unassigned</div>
+        <div className="text-xs text-muted-foreground">No managed wallet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-48">
+      <div className="flex items-center gap-2">
+        <span className="max-w-52 truncate font-medium" title={note ?? wallet.walletAddress}>
+          {note ?? 'Managed wallet'}
+        </span>
+        {wallet.deletedAt && (
+          <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+            Archived
+          </Badge>
+        )}
+      </div>
+      <div className="font-mono text-xs text-muted-foreground" title={wallet.walletAddress}>
+        {shortenAddress(wallet.walletAddress, 7)}
+      </div>
+      <div className="font-mono text-[11px] text-muted-foreground" title={wallet.id}>
+        ID {shortenAddress(wallet.id, 5)}
+      </div>
+    </div>
+  );
+}
+
+export function FinancialWalletTable({
+  summary,
+  facets,
+  selectedUnit,
+  roles,
+}: FinancialWalletTableProps) {
+  const [tablePageState, setTablePageState] = useState<ReportTablePageState>(() => ({
+    dataset: summary.wallets,
+    page: 0,
+  }));
+  const currentTablePageState = resetReportTablePageState(tablePageState, summary.wallets);
+  if (currentTablePageState !== tablePageState) setTablePageState(currentTablePageState);
+  const selectedRoles = uniqueRoles(roles);
+  const roleSet = new Set(selectedRoles);
+  const showRole = roleSet.has('Buyer') && roleSet.has('Seller');
+  const onlyRole = selectedRoles.length === 1 ? selectedRoles[0] : null;
+  const notesByWalletId = useMemo(
+    () =>
+      new Map(
+        (facets?.managedWallets ?? [])
+          .map((wallet) => [wallet.id, wallet.note?.trim() ?? ''] as const)
+          .filter((entry) => entry[1].length > 0),
+      ),
+    [facets],
+  );
+  const rows = useMemo(
+    () =>
+      sortWallets(
+        summary.wallets.filter((wallet) => roles.includes(wallet.role)),
+        notesByWalletId,
+      ),
+    [notesByWalletId, roles, summary.wallets],
+  );
+  const walletPage = paginateReportRows(rows, currentTablePageState.page);
+  const selectedAsset =
+    selectedUnit == null ? null : getReportAssetDescriptor(summary, selectedUnit);
+
+  const grossHeading =
+    onlyRole === 'Seller' ? 'Gross revenue' : onlyRole === 'Buyer' ? 'Gross spend' : 'Gross';
+  const adjustmentHeading =
+    onlyRole === 'Seller'
+      ? 'Protocol fee'
+      : onlyRole === 'Buyer'
+        ? 'Returned funds'
+        : 'Protocol / returned';
+  const actorFeeHeading =
+    onlyRole === 'Seller'
+      ? 'Seller Cardano fee'
+      : onlyRole === 'Buyer'
+        ? 'Buyer Cardano fee'
+        : 'Actor Cardano fee';
+  const netHeading =
+    onlyRole === 'Seller' ? 'Net revenue' : onlyRole === 'Buyer' ? 'Net spend' : 'Net';
+  const columnCount = showRole ? 11 : 10;
+
+  return (
+    <>
+      <Table>
+        <TableCaption>
+          Counts are distinct logical payments inside each wallet and role group, so group counts
+          are not additive. Reconciled actor, admin, and total fees use the stable owner named by
+          report warnings when a component spans groups.
+        </TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead scope="col">Wallet</TableHead>
+            {showRole && <TableHead scope="col">Role</TableHead>}
+            <TableHead scope="col" className="text-right">
+              Transactions
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              {grossHeading}
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              {adjustmentHeading}
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              {actorFeeHeading}
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              {netHeading}
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Reconciled actor
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Admin fee
+            </TableHead>
+            <TableHead scope="col" className="text-right">
+              Total fee
+            </TableHead>
+            <TableHead scope="col">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={columnCount} className="h-24 text-center text-muted-foreground">
+                No wallet activity matches these report filters.
+              </TableCell>
+            </TableRow>
+          ) : (
+            walletPage.items.map((wallet) => {
+              const roleMetrics = ROLE_METRICS[wallet.role];
+              const visibleKeys = visibleMetricKeys(wallet.role);
+              const isPartial =
+                wallet.metrics.transactionCountCompleteness === 'partial' ||
+                visibleKeys.some(
+                  (metricKey) => wallet.metrics[metricKey].completeness === 'partial',
+                );
+              const businessMetric = (metricKey: ReportMetricKey) =>
+                selectedUnit == null
+                  ? wallet.metrics[metricKey]
+                  : metricForUnit(wallet.metrics, metricKey, selectedUnit);
+
+              return (
+                <TableRow key={`${wallet.managedWallet?.id ?? 'unassigned'}:${wallet.role}`}>
+                  <TableHead scope="row" className="h-auto py-2 text-foreground">
+                    <WalletIdentity
+                      wallet={wallet.managedWallet}
+                      note={
+                        wallet.managedWallet
+                          ? (notesByWalletId.get(wallet.managedWallet.id) ?? null)
+                          : null
+                      }
+                    />
+                  </TableHead>
+                  {showRole && (
+                    <TableHead scope="row" className="h-auto py-2 text-foreground">
+                      <Badge variant="secondary">{wallet.role}</Badge>
+                    </TableHead>
+                  )}
+                  <TableCell className="text-right font-mono text-xs tabular-nums">
+                    {formatReportCountValue(
+                      wallet.metrics.transactionCount,
+                      wallet.metrics.transactionCountCompleteness,
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={businessMetric(roleMetrics.gross)}
+                      fallback={selectedAsset}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={businessMetric(roleMetrics.adjustment)}
+                      fallback={selectedAsset}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={metricForUnit(
+                        wallet.metrics,
+                        roleMetrics.actorCardanoFee,
+                        CARDANO_UNIT,
+                      )}
+                      fallback={CARDANO_UNIT}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={businessMetric(roleMetrics.net)}
+                      fallback={selectedAsset}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={metricForUnit(wallet.metrics, 'actorCardanoFees', CARDANO_UNIT)}
+                      fallback={CARDANO_UNIT}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={metricForUnit(wallet.metrics, 'adminCardanoFees', CARDANO_UNIT)}
+                      fallback={CARDANO_UNIT}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <MetricValue
+                      metric={metricForUnit(wallet.metrics, 'totalCardanoFees', CARDANO_UNIT)}
+                      fallback={CARDANO_UNIT}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={isPartial ? 'warning' : 'success'}>
+                      {isPartial ? 'Partial' : 'Complete'}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+      <ReportTablePagination
+        page={walletPage.page}
+        pageCount={walletPage.pageCount}
+        startIndex={walletPage.startIndex}
+        endIndex={walletPage.endIndex}
+        totalCount={walletPage.totalCount}
+        itemLabel="wallet rows"
+        ariaLabel="Wallet and role breakdown pagination"
+        onPageChange={(page) => setTablePageState({ dataset: summary.wallets, page })}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/ReportTablePagination.test.ts
+++ b/frontend/src/components/dashboard/ReportTablePagination.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ReportTablePagination } from './ReportTablePagination';
+
+test('chart pagers expose unique title-specific navigation landmarks', () => {
+  const sharedProps = {
+    page: 0,
+    pageCount: 2,
+    startIndex: 0,
+    endIndex: 50,
+    totalCount: 100,
+    itemLabel: 'history rows',
+    onPageChange: () => {},
+  };
+  const markup = renderToStaticMarkup(
+    createElement(
+      'div',
+      null,
+      createElement(ReportTablePagination, {
+        ...sharedProps,
+        ariaLabel: 'Value history chart data pagination',
+      }),
+      createElement(ReportTablePagination, {
+        ...sharedProps,
+        ariaLabel: 'Cardano fee history chart data pagination',
+      }),
+    ),
+  );
+
+  assert.match(markup, /aria-label="Value history chart data pagination"/u);
+  assert.match(markup, /aria-label="Cardano fee history chart data pagination"/u);
+  assert.doesNotMatch(markup, /aria-label="history rows pagination"/u);
+});

--- a/frontend/src/components/dashboard/ReportTablePagination.tsx
+++ b/frontend/src/components/dashboard/ReportTablePagination.tsx
@@ -1,0 +1,59 @@
+import { Button } from '@/components/ui/button';
+
+type ReportTablePaginationProps = Readonly<{
+  page: number;
+  pageCount: number;
+  startIndex: number;
+  endIndex: number;
+  totalCount: number;
+  itemLabel: string;
+  ariaLabel: string;
+  onPageChange: (page: number) => void;
+}>;
+
+export function ReportTablePagination({
+  page,
+  pageCount,
+  startIndex,
+  endIndex,
+  totalCount,
+  itemLabel,
+  ariaLabel,
+  onPageChange,
+}: ReportTablePaginationProps) {
+  if (pageCount <= 1) return null;
+
+  return (
+    <nav
+      className="flex flex-wrap items-center justify-between gap-2 border-t px-3 py-2 text-xs"
+      aria-label={ariaLabel}
+    >
+      <span aria-live="polite">
+        Showing {startIndex + 1} to {endIndex} of {totalCount} {itemLabel}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm2"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page === 0}
+        >
+          Previous
+        </Button>
+        <span>
+          Page {page + 1} of {pageCount}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm2"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page + 1 >= pageCount}
+        >
+          Next
+        </Button>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/dashboard/useFinancialReportModel.helpers.test.ts
+++ b/frontend/src/components/dashboard/useFinancialReportModel.helpers.test.ts
@@ -77,16 +77,22 @@ test('report errors preserve server text and add bounded-query guidance', () => 
   );
 });
 
-test('summary data is current only after the exact visible body reaches the debounce', () => {
+test('summary data is current once the visible filters reach the debounce', () => {
   const visibleBody: PostReportsSummaryData['body'] = {
     paymentSourceId: 'source-1',
     from: new Date('2026-07-25T12:00:00.000Z'),
     to: new Date('2026-08-24T12:00:00.000Z'),
   };
 
-  assert.equal(isCurrentFinancialReportBody(visibleBody, { ...visibleBody }), false);
+  // A rebuilt body with the same filters is the same report. Comparing by
+  // identity blanked the dashboard after every facets refetch.
+  assert.equal(isCurrentFinancialReportBody(visibleBody, { ...visibleBody }), true);
   assert.equal(isCurrentFinancialReportBody(visibleBody, visibleBody), true);
   assert.equal(isCurrentFinancialReportBody(null, visibleBody), false);
+  assert.equal(
+    isCurrentFinancialReportBody(visibleBody, { ...visibleBody, paymentSourceId: 'source-2' }),
+    false,
+  );
 });
 
 test('an export error is hidden as soon as the visible report body changes', () => {
@@ -99,7 +105,11 @@ test('an export error is hidden as soon as the visible report body changes', () 
 
   assert.equal(getCurrentFinancialReportExportError(error, attemptedBody, attemptedBody), error);
   assert.equal(
-    getCurrentFinancialReportExportError(error, { ...attemptedBody }, attemptedBody),
+    getCurrentFinancialReportExportError(
+      error,
+      { ...attemptedBody, paymentSourceId: 'source-2' },
+      attemptedBody,
+    ),
     null,
   );
 });

--- a/frontend/src/components/dashboard/useFinancialReportModel.helpers.test.ts
+++ b/frontend/src/components/dashboard/useFinancialReportModel.helpers.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { GetReportsFacetsResponses, PostReportsSummaryData } from '@/lib/api/generated';
+import {
+  getCurrentFinancialReportExportError,
+  getFinancialReportErrorMessage,
+  isCurrentFinancialReportBody,
+  resolveFinancialReportSource,
+} from './useFinancialReportModel';
+
+type ReportSource = GetReportsFacetsResponses[200]['data']['paymentSources'][number];
+
+function source(
+  id: string,
+  network: ReportSource['network'],
+  deletedAt: Date | null = null,
+): ReportSource {
+  return {
+    id,
+    network,
+    paymentSourceType: 'Web3CardanoV2',
+    feeRatePermille: 50,
+    smartContractAddress: `addr_${id}`,
+    deletedAt,
+  };
+}
+
+test('report source selection keeps archived choices and stays on the active network', () => {
+  const archived = source('archived', 'Preprod', new Date('2026-01-01T00:00:00.000Z'));
+  const result = resolveFinancialReportSource(
+    [archived, source('mainnet', 'Mainnet'), source('active', 'Preprod')],
+    'Preprod',
+    'archived',
+    'active',
+  );
+
+  assert.deepEqual(
+    result.paymentSources.map((paymentSource) => paymentSource.id),
+    ['active', 'archived'],
+  );
+  assert.equal(result.effectivePaymentSourceId, 'archived');
+});
+
+test('report source selection prefers the dashboard source before the first accessible fallback', () => {
+  const paymentSources = [source('first', 'Preprod'), source('selected', 'Preprod')];
+
+  assert.equal(
+    resolveFinancialReportSource(paymentSources, 'Preprod', 'missing', 'selected')
+      .effectivePaymentSourceId,
+    'selected',
+  );
+  assert.equal(
+    resolveFinancialReportSource(paymentSources, 'Preprod', 'missing', 'also-missing')
+      .effectivePaymentSourceId,
+    'first',
+  );
+});
+
+test('report errors preserve server text and add bounded-query guidance', () => {
+  const serverLimit = 'Report exceeds the 50,000 row limit.';
+  const serverTimeout = 'Report calculation timed out.';
+
+  assert.equal(
+    getFinancialReportErrorMessage({ error: { message: serverLimit } }, 'fallback', 413),
+    `${serverLimit} Use a shorter period or select fewer wallets, roles, or states.`,
+  );
+  assert.equal(
+    getFinancialReportErrorMessage(new Error(serverTimeout), 'fallback', 504),
+    `${serverTimeout} Use a shorter period or narrower filters, then try again.`,
+  );
+  assert.equal(
+    getFinancialReportErrorMessage(
+      new Error('Report exceeds 50000 rows. Narrow the report filters.'),
+      'fallback',
+    ),
+    'Report exceeds 50000 rows. Narrow the report filters. Use a shorter period or select fewer wallets, roles, or states.',
+  );
+});
+
+test('summary data is current only after the exact visible body reaches the debounce', () => {
+  const visibleBody: PostReportsSummaryData['body'] = {
+    paymentSourceId: 'source-1',
+    from: new Date('2026-07-25T12:00:00.000Z'),
+    to: new Date('2026-08-24T12:00:00.000Z'),
+  };
+
+  assert.equal(isCurrentFinancialReportBody(visibleBody, { ...visibleBody }), false);
+  assert.equal(isCurrentFinancialReportBody(visibleBody, visibleBody), true);
+  assert.equal(isCurrentFinancialReportBody(null, visibleBody), false);
+});
+
+test('an export error is hidden as soon as the visible report body changes', () => {
+  const attemptedBody: PostReportsSummaryData['body'] = {
+    paymentSourceId: 'source-1',
+    from: new Date('2026-07-25T12:00:00.000Z'),
+    to: new Date('2026-08-24T12:00:00.000Z'),
+  };
+  const error = new Error('Report exceeds the row limit.');
+
+  assert.equal(getCurrentFinancialReportExportError(error, attemptedBody, attemptedBody), error);
+  assert.equal(
+    getCurrentFinancialReportExportError(error, { ...attemptedBody }, attemptedBody),
+    null,
+  );
+});

--- a/frontend/src/components/dashboard/useFinancialReportModel.ts
+++ b/frontend/src/components/dashboard/useFinancialReportModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { hashKey, useMutation, useQuery } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import {
   getReportsFacets,
@@ -92,7 +92,14 @@ export function isCurrentFinancialReportBody(
   visibleBody: ReportBody | null,
   debouncedBody: ReportBody | null,
 ): boolean {
-  return visibleBody != null && visibleBody === debouncedBody;
+  // Compare content, not object identity. effectiveForm is memoized on
+  // facetsQuery.data?.managedWallets, so any facets refetch (a window refocus
+  // past the 60s stale time) rebuilds an identical body with a new identity.
+  // Read as a filter change, that blanked the metrics, charts and wallet table
+  // for a whole debounce window and reset table pagination to page 0.
+  // hashKey is the same stable hash the query key already uses, so freshness
+  // and cache identity cannot disagree.
+  return visibleBody != null && hashKey([visibleBody]) === hashKey([debouncedBody]);
 }
 
 export function getCurrentFinancialReportExportError(

--- a/frontend/src/components/dashboard/useFinancialReportModel.ts
+++ b/frontend/src/components/dashboard/useFinancialReportModel.ts
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import {
+  getReportsFacets,
+  postReportsSummary,
+  type GetReportsFacetsResponses,
+  type PostReportsSummaryData,
+  type PostReportsSummaryResponses,
+} from '@/lib/api/generated';
+import { extractApiErrorMessage } from '@/lib/api-error';
+import { useAppContext } from '@/lib/contexts/AppContext';
+import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
+import { TRANSACTION_REPORT_FACETS_QUERY_KEY } from '@/lib/queries/transaction-report-cache';
+import {
+  fetchTransactionReportExport,
+  saveTransactionReportExport,
+} from '@/lib/transaction-report/download';
+import {
+  buildTransactionReportBody,
+  createTransactionReportForm,
+  filterAccessibleReportWalletIds,
+  toggleReportFilterValue,
+  toggleReportWalletSelection,
+  type ReportOnChainState,
+  type ReportRole,
+  type TransactionReportFormState,
+  type TransactionReportViewDefaults,
+} from '@/components/transactions/download-details.helpers';
+
+type ReportFacets = GetReportsFacetsResponses[200]['data'];
+type ReportPaymentSource = ReportFacets['paymentSources'][number];
+type ReportSummary = PostReportsSummaryResponses[200]['data'];
+type ReportBody = PostReportsSummaryData['body'];
+
+type FinancialReportState = Readonly<{
+  form: TransactionReportFormState;
+  rangeAnchor: Date;
+  refreshVersion: number;
+}>;
+
+const DASHBOARD_REPORT_DEFAULTS = {
+  roles: ['Buyer', 'Seller'],
+  states: [],
+  hasUnmappedFilters: false,
+} as const satisfies TransactionReportViewDefaults;
+
+const LIMIT_GUIDANCE = 'Use a shorter period or select fewer wallets, roles, or states.';
+const TIMEOUT_GUIDANCE = 'Use a shorter period or narrower filters, then try again.';
+
+export function resolveFinancialReportSource(
+  sources: readonly ReportPaymentSource[],
+  network: ReportPaymentSource['network'],
+  formPaymentSourceId: string,
+  selectedPaymentSourceId: string | null,
+): Readonly<{
+  paymentSources: ReportPaymentSource[];
+  effectivePaymentSourceId: string;
+}> {
+  const paymentSources = sources
+    .filter((source) => source.network === network)
+    .sort((left, right) => {
+      if (left.deletedAt == null && right.deletedAt != null) return -1;
+      if (left.deletedAt != null && right.deletedAt == null) return 1;
+      return left.id.localeCompare(right.id);
+    });
+  const sourceIds = new Set(paymentSources.map((source) => source.id));
+  const effectivePaymentSourceId = sourceIds.has(formPaymentSourceId)
+    ? formPaymentSourceId
+    : selectedPaymentSourceId && sourceIds.has(selectedPaymentSourceId)
+      ? selectedPaymentSourceId
+      : (paymentSources[0]?.id ?? '');
+
+  return { paymentSources, effectivePaymentSourceId };
+}
+
+export function getFinancialReportErrorMessage(
+  error: unknown,
+  fallback: string,
+  status?: number,
+): string {
+  const message = extractApiErrorMessage(error, fallback);
+  const isLimit =
+    status === 413 || /(?:exceeds .*?(?:bytes|rows)|row limit|too large)/iu.test(message);
+  const isTimeout = status === 504 || /(?:timed out|timeout)/iu.test(message);
+  if (isLimit && !message.includes(LIMIT_GUIDANCE)) return `${message} ${LIMIT_GUIDANCE}`;
+  if (isTimeout && !message.includes(TIMEOUT_GUIDANCE)) return `${message} ${TIMEOUT_GUIDANCE}`;
+  return message;
+}
+
+export function isCurrentFinancialReportBody(
+  visibleBody: ReportBody | null,
+  debouncedBody: ReportBody | null,
+): boolean {
+  return visibleBody != null && visibleBody === debouncedBody;
+}
+
+export function getCurrentFinancialReportExportError(
+  error: unknown,
+  visibleBody: ReportBody | null,
+  attemptedBody: ReportBody | null,
+): unknown | null {
+  return error != null && isCurrentFinancialReportBody(visibleBody, attemptedBody) ? error : null;
+}
+
+function createState(paymentSourceId: string): FinancialReportState {
+  return {
+    form: createTransactionReportForm(paymentSourceId, DASHBOARD_REPORT_DEFAULTS),
+    rangeAnchor: new Date(),
+    refreshVersion: 0,
+  };
+}
+
+export function useFinancialReportModel() {
+  const { apiClient, network, selectedPaymentSourceId } = useAppContext();
+  const [reportState, setReportState] = useState<FinancialReportState>(() =>
+    createState(selectedPaymentSourceId ?? ''),
+  );
+  const previousSelectedPaymentSourceId = useRef(selectedPaymentSourceId);
+
+  useEffect(() => {
+    if (previousSelectedPaymentSourceId.current === selectedPaymentSourceId) return;
+    previousSelectedPaymentSourceId.current = selectedPaymentSourceId;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sidebar source changes reset the report scope and its moving period atomically.
+    setReportState(createState(selectedPaymentSourceId ?? ''));
+  }, [selectedPaymentSourceId]);
+
+  const facetsQuery = useQuery<ReportFacets>({
+    queryKey: TRANSACTION_REPORT_FACETS_QUERY_KEY,
+    queryFn: async ({ signal }) => {
+      const response = await getReportsFacets({ client: apiClient, signal });
+      if (response.error) {
+        throw new Error(
+          getFinancialReportErrorMessage(
+            response.error,
+            'Failed to load report filters',
+            response.response?.status,
+          ),
+        );
+      }
+      const facets = response.data?.data;
+      if (!facets) throw new Error('Report filters were missing from the server response.');
+      return facets;
+    },
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const { paymentSources, effectivePaymentSourceId } = useMemo(
+    () =>
+      resolveFinancialReportSource(
+        facetsQuery.data?.paymentSources ?? [],
+        network,
+        reportState.form.paymentSourceId,
+        selectedPaymentSourceId,
+      ),
+    [facetsQuery.data, network, reportState.form.paymentSourceId, selectedPaymentSourceId],
+  );
+
+  const effectiveForm = useMemo<TransactionReportFormState>(
+    () => ({
+      ...reportState.form,
+      paymentSourceId: effectivePaymentSourceId,
+      managedWalletIds:
+        reportState.form.paymentSourceId === effectivePaymentSourceId
+          ? filterAccessibleReportWalletIds(
+              reportState.form.managedWalletIds,
+              facetsQuery.data?.managedWallets ?? [],
+              effectivePaymentSourceId,
+            )
+          : [],
+    }),
+    [effectivePaymentSourceId, facetsQuery.data?.managedWallets, reportState.form],
+  );
+
+  const selectedPaymentSource = useMemo(
+    () => paymentSources.find((source) => source.id === effectivePaymentSourceId) ?? null,
+    [effectivePaymentSourceId, paymentSources],
+  );
+
+  const managedWallets = useMemo(
+    () =>
+      (facetsQuery.data?.managedWallets ?? [])
+        .filter((wallet) => wallet.paymentSourceId === effectivePaymentSourceId)
+        .sort(
+          (left, right) => left.type.localeCompare(right.type) || left.id.localeCompare(right.id),
+        ),
+    [effectivePaymentSourceId, facetsQuery.data],
+  );
+
+  const bodyResult = useMemo(
+    () => buildTransactionReportBody(effectiveForm, reportState.rangeAnchor),
+    [effectiveForm, reportState.rangeAnchor],
+  );
+  const body = bodyResult.body;
+  const debouncedBody = useDebouncedValue(body, 350);
+  const isBodyCurrent = isCurrentFinancialReportBody(body, debouncedBody);
+
+  const summaryQuery = useQuery<ReportSummary>({
+    queryKey: ['transaction-report-summary', debouncedBody, reportState.refreshVersion],
+    queryFn: async ({ signal }) => {
+      if (!debouncedBody) throw new Error('Report filters are incomplete.');
+      const response = await postReportsSummary({ client: apiClient, body: debouncedBody, signal });
+      if (response.error) {
+        throw new Error(
+          getFinancialReportErrorMessage(
+            response.error,
+            'Failed to load financial report',
+            response.response?.status,
+          ),
+        );
+      }
+      const summary = response.data?.data;
+      if (!summary) throw new Error('Report summary was missing from the server response.');
+      return summary;
+    },
+    enabled: isBodyCurrent,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const exportMutation = useMutation({
+    mutationFn: async (reportBody: ReportBody) => {
+      const file = await fetchTransactionReportExport({
+        client: apiClient,
+        body: reportBody,
+        kind: 'zip',
+      });
+      saveTransactionReportExport(file);
+    },
+    onSuccess: (_result, reportBody) => {
+      if (isCurrentFinancialReportBody(body, reportBody)) {
+        toast.success('Report ZIP download started');
+      }
+    },
+    onError: (error: unknown, reportBody) => {
+      if (isCurrentFinancialReportBody(body, reportBody)) {
+        toast.error(getFinancialReportErrorMessage(error, 'Failed to export transaction report'));
+      }
+    },
+  });
+
+  const exportZip = useCallback(() => {
+    if (body) exportMutation.mutate(body);
+  }, [body, exportMutation]);
+
+  const updateForm = useCallback((patch: Partial<TransactionReportFormState>) => {
+    setReportState((current) => ({
+      ...current,
+      form: { ...current.form, ...patch },
+    }));
+  }, []);
+
+  const setPaymentSource = useCallback((paymentSourceId: string) => {
+    setReportState((current) => ({
+      ...current,
+      form: { ...current.form, paymentSourceId, managedWalletIds: [] },
+      rangeAnchor: new Date(),
+    }));
+  }, []);
+
+  const toggleRole = useCallback((role: ReportRole) => {
+    setReportState((current) => ({
+      ...current,
+      form: { ...current.form, roles: toggleReportFilterValue(current.form.roles, role) },
+    }));
+  }, []);
+
+  const toggleState = useCallback((state: ReportOnChainState) => {
+    setReportState((current) => ({
+      ...current,
+      form: { ...current.form, states: toggleReportFilterValue(current.form.states, state) },
+    }));
+  }, []);
+
+  const toggleWallet = useCallback(
+    (walletId: string) => {
+      setReportState((current) => ({
+        ...current,
+        form: toggleReportWalletSelection(current.form, effectivePaymentSourceId, walletId),
+      }));
+    },
+    [effectivePaymentSourceId],
+  );
+
+  const reset = useCallback(() => {
+    setReportState((current) => ({
+      ...createState(effectivePaymentSourceId),
+      refreshVersion: current.refreshVersion + 1,
+    }));
+  }, [effectivePaymentSourceId]);
+
+  const refresh = useCallback(() => {
+    setReportState((current) => ({
+      ...current,
+      rangeAnchor: new Date(),
+      refreshVersion: current.refreshVersion + 1,
+    }));
+  }, []);
+
+  const summaryError =
+    isBodyCurrent && summaryQuery.error
+      ? extractApiErrorMessage(summaryQuery.error, 'Failed to load financial report')
+      : null;
+  const isLoadingSummary = body != null && (!isBodyCurrent || summaryQuery.isLoading);
+  const isRefetching =
+    body != null && !summaryQuery.isLoading && (!isBodyCurrent || summaryQuery.isFetching);
+  const currentExportError = getCurrentFinancialReportExportError(
+    exportMutation.error,
+    body,
+    exportMutation.variables ?? null,
+  );
+
+  return {
+    body,
+    bodyError: bodyResult.error,
+    effectivePaymentSourceId,
+    exportError: currentExportError
+      ? getFinancialReportErrorMessage(currentExportError, 'Failed to export transaction report')
+      : null,
+    exportZip,
+    facetsError: facetsQuery.error
+      ? extractApiErrorMessage(facetsQuery.error, 'Failed to load report filters')
+      : null,
+    form: effectiveForm,
+    isExporting: exportMutation.isPending,
+    isLoadingFacets: facetsQuery.isLoading,
+    isLoadingSummary,
+    isRefetching,
+    managedWallets,
+    paymentSources,
+    refresh,
+    reset,
+    selectedPaymentSource,
+    setPaymentSource,
+    summary: isBodyCurrent ? (summaryQuery.data ?? null) : null,
+    summaryError,
+    toggleRole,
+    toggleState,
+    toggleWallet,
+    updateForm,
+  };
+}

--- a/frontend/src/lib/transaction-report/report-rendering.test.ts
+++ b/frontend/src/lib/transaction-report/report-rendering.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  decimateReportChartPoints,
+  paginateReportRows,
+  REPORT_CHART_POINT_LIMIT,
+  REPORT_TABLE_PAGE_SIZE,
+  resetReportTablePageState,
+} from './report-rendering';
+
+test('chart decimation bounds SVG nodes while preserving endpoints and local extremes', () => {
+  const points = Array.from({ length: REPORT_CHART_POINT_LIMIT * 4 }, (_, index) => ({
+    x: index,
+    y: index === 400 ? -1_000 : index === 401 ? 1_000 : 0,
+  }));
+
+  const visible = decimateReportChartPoints(points);
+
+  assert.ok(visible.length <= REPORT_CHART_POINT_LIMIT);
+  assert.equal(visible[0], points[0]);
+  assert.equal(visible.at(-1), points.at(-1));
+  assert.ok(visible.includes(points[400]));
+  assert.ok(visible.includes(points[401]));
+});
+
+test('chart decimation preserves an unknown gap without exceeding the marker limit', () => {
+  const points = Array.from({ length: 1_000 }, (_, index) => ({
+    x: index,
+    y: 0,
+    isUnknown: index === 333,
+  }));
+
+  const visible = decimateReportChartPoints(points, 10);
+
+  assert.ok(visible.includes(points[333]));
+  assert.ok(visible.filter((point) => !point.isUnknown).length <= 10);
+});
+
+test('report table pagination clamps stale pages and exposes one bounded slice', () => {
+  const rows = Array.from({ length: REPORT_TABLE_PAGE_SIZE * 2 + 3 }, (_, index) => index);
+  const first = paginateReportRows(rows, 0);
+  const last = paginateReportRows(rows, 99);
+
+  assert.deepEqual(first.items, rows.slice(0, REPORT_TABLE_PAGE_SIZE));
+  assert.equal(first.page, 0);
+  assert.equal(first.pageCount, 3);
+  assert.equal(first.startIndex, 0);
+  assert.equal(first.endIndex, REPORT_TABLE_PAGE_SIZE);
+  assert.deepEqual(last.items, rows.slice(REPORT_TABLE_PAGE_SIZE * 2));
+  assert.equal(last.page, 2);
+  assert.equal(last.startIndex, REPORT_TABLE_PAGE_SIZE * 2);
+  assert.equal(last.endIndex, rows.length);
+});
+
+test('report table pagination resets when a same-sized report dataset replaces the old one', () => {
+  const oldDataset = [{ id: 'old-1' }, { id: 'old-2' }];
+  const newDataset = [{ id: 'new-1' }, { id: 'new-2' }];
+  const previousState = { dataset: oldDataset, page: 3 };
+
+  assert.equal(resetReportTablePageState(previousState, oldDataset), previousState);
+  assert.deepEqual(resetReportTablePageState(previousState, newDataset), {
+    dataset: newDataset,
+    page: 0,
+  });
+});

--- a/frontend/src/lib/transaction-report/report-rendering.ts
+++ b/frontend/src/lib/transaction-report/report-rendering.ts
@@ -1,0 +1,111 @@
+export const REPORT_CHART_POINT_LIMIT = 240;
+export const REPORT_TABLE_PAGE_SIZE = 50;
+
+type ChartPoint = Readonly<{ y: number; isUnknown?: boolean }>;
+
+function decimateKnownChartPoints<T extends ChartPoint>(
+  points: readonly T[],
+  limit: number,
+): readonly T[] {
+  if (points.length <= limit) return points;
+  if (limit < 4) return [points[0], points.at(-1)!];
+
+  const result: T[] = [points[0]];
+  const interiorLength = points.length - 2;
+  const bucketCount = Math.floor((limit - 2) / 2);
+
+  for (let bucketIndex = 0; bucketIndex < bucketCount; bucketIndex += 1) {
+    const start = 1 + Math.floor((interiorLength * bucketIndex) / bucketCount);
+    const end = 1 + Math.floor((interiorLength * (bucketIndex + 1)) / bucketCount);
+    let minIndex = start;
+    let maxIndex = start;
+
+    for (let pointIndex = start + 1; pointIndex < end; pointIndex += 1) {
+      if (points[pointIndex].y < points[minIndex].y) minIndex = pointIndex;
+      if (points[pointIndex].y > points[maxIndex].y) maxIndex = pointIndex;
+    }
+
+    if (minIndex === maxIndex) {
+      result.push(points[minIndex]);
+    } else if (minIndex < maxIndex) {
+      result.push(points[minIndex], points[maxIndex]);
+    } else {
+      result.push(points[maxIndex], points[minIndex]);
+    }
+  }
+
+  result.push(points.at(-1)!);
+  return result;
+}
+
+export function decimateReportChartPoints<T extends ChartPoint>(
+  points: readonly T[],
+  requestedLimit = REPORT_CHART_POINT_LIMIT,
+): readonly T[] {
+  const limit = Math.max(2, Math.floor(requestedLimit));
+  if (points.length <= limit) return points;
+
+  const knownPoints = points.filter((point) => !point.isUnknown);
+  if (knownPoints.length === 0) return points.length === 0 ? [] : [points[0]];
+
+  const visibleKnownPoints = decimateKnownChartPoints(knownPoints, limit);
+  const sourceIndexes = new Map(points.map((point, index) => [point, index]));
+  const result: T[] = [];
+  let previousSourceIndex: number | undefined;
+
+  for (const point of visibleKnownPoints) {
+    const sourceIndex = sourceIndexes.get(point)!;
+    if (previousSourceIndex != null) {
+      const gap = points
+        .slice(previousSourceIndex + 1, sourceIndex)
+        .find((candidate) => candidate.isUnknown);
+      if (gap) result.push(gap);
+    }
+    result.push(point);
+    previousSourceIndex = sourceIndex;
+  }
+
+  return result;
+}
+
+export type ReportRowPage<T> = Readonly<{
+  items: readonly T[];
+  page: number;
+  pageCount: number;
+  startIndex: number;
+  endIndex: number;
+  totalCount: number;
+}>;
+
+export type ReportTablePageState = Readonly<{
+  dataset: object;
+  page: number;
+}>;
+
+export function resetReportTablePageState(
+  state: ReportTablePageState,
+  dataset: object,
+): ReportTablePageState {
+  return state.dataset === dataset ? state : { dataset, page: 0 };
+}
+
+export function paginateReportRows<T>(
+  rows: readonly T[],
+  requestedPage: number,
+  requestedPageSize = REPORT_TABLE_PAGE_SIZE,
+): ReportRowPage<T> {
+  const pageSize = Math.max(1, Math.floor(requestedPageSize));
+  const pageCount = Math.ceil(rows.length / pageSize);
+  const page =
+    pageCount === 0 ? 0 : Math.min(Math.max(0, Math.floor(requestedPage)), pageCount - 1);
+  const startIndex = page * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, rows.length);
+  return {
+    items: rows.slice(startIndex, endIndex),
+    page,
+    pageCount,
+    startIndex,
+    endIndex,
+    totalCount: rows.length,
+  };
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -50,6 +50,7 @@ import { MigrateAgentsDialog } from '@/components/ai-agents/MigrateAgentsDialog'
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { isV2PaymentSource } from '@/lib/payment-source-type';
 import { getPrimaryCardanoPricing } from '@/lib/registry-pricing';
+import { FinancialReportSection } from '@/components/dashboard/FinancialReportSection';
 
 type AIAgent = RegistryEntry;
 
@@ -315,6 +316,8 @@ export default function Overview() {
                 )}
               </div>
             </div>
+
+            <FinancialReportSection />
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <div className="border rounded-lg p-6 flex flex-col">


### PR DESCRIPTION
## change

- VERIFIED: Adds financial report cards, history charts, wallet summaries, and report filters to the admin dashboard.
- VERIFIED: Uses exact atomic amounts and marks unknown chart points as gaps.
- VERIFIED: Caps chart points and paginates report tables for large valid reports.

## checks

- VERIFIED: `pnpm -C frontend run test` passed 111 tests.
- VERIFIED: Frontend typecheck, lint, and format checks passed.

## stack

3 of 4. Base: #740. Next: #742.