### PR TITLE
fix(hydra): store the InitTx chain-replay anchor on HydraHead

### DIFF
--- a/docs/hydra-persistence-recovery-verification.md
+++ b/docs/hydra-persistence-recovery-verification.md
@@ -1,0 +1,128 @@
+# Hydra persistence loss: live fund-recovery verification and snapshot-storage design
+
+Date: 2026-08-25. Network: preprod, real hydra-node 2.3.0-ef833d8a (aarch64-darwin), Blockfrost chain backend, isolated seeded Postgres on :5433. Worktree: `verify/hydra-persistence-recovery` (based on origin/dev 9dbc17a7). All claims below are tagged VERIFIED (ran it, saw the output), REPORTED (a source said so), or INFERRED (reasoned from evidence).
+
+## Questions and answers
+
+**Q1. One head is open. The head node keys were exported via the API. The payment-node wallet is saved. The hydra-node persistence gets deleted. Can all funds still be withdrawn?**
+
+Yes, proven live, with one qualification.
+
+- One side wiped, peer intact (head 1, `863b05ef…`): full recovery at the latest snapshot. VERIFIED. The intact peer closed at snapshot n=4 and the fanout paid every party (buyer 40, seller 20, purchasing 105.78 + 250).
+- BOTH sides wiped (head 3, `9e137dd3…`): full recovery of all funds, and even full resumption of the head. VERIFIED end to end. Chain replay alone rebuilt the last increment's signed snapshot, normal L2 operation resumed, and close plus fanout paid everyone. Qualification: L2 transactions signed AFTER the last on-chain increment roll back. They survive only if both parties cooperate and re-sign them, which we did live.
+
+**Q2. What does the masumi node DB store? Is DB + ENCRYPTION_KEY enough to recover everything?**
+
+The DB stores every key: encrypted wallet mnemonics, the hydra signing key, the node cardano key, remote party verification keys, and head identity fields. VERIFIED by decrypting and re-deriving addresses (`96-derive-db-wallets.mts`). It stores NO snapshot bodies, NO multisignatures, and NO in-head UTxO set (`latestSnapshotNumber` is a bare counter). So DB + ENCRYPTION_KEY recovers keys and wallets, and (given the chain) everything up to the last increment. It does not recover post-increment L2 state, and it does not record the chain anchor needed for `--start-chain-from`. The snapshot-storage feature below closes both gaps.
+
+**Q3. Should we store snapshots in the payment DB after each L1 hash and head change?**
+
+Yes. The live results narrow WHY: chain replay recovers more than expected (the last increment's certificate, with signatures), so the stored snapshot matters for exactly three things: (1) the L2 tail after the last increment, which is the part a counterparty who benefits from the rollback will refuse to re-sign; (2) a future unilateral close path at the true latest state (needs an external close builder, because sideload is rejected upstream); (3) the replay anchor and fanout proof material. Design in the second half of this document.
+
+## Method
+
+- Fresh worktree on origin/dev, isolated `.env` (test DB on :5433, own ENCRYPTION_KEY, Blockfrost preprod key from the main clone `.env`).
+- Real two-party hydra-node pair (purchasing = node1 :4001, selling = node2 :4002), contestation 220s, dedicated persistence dirs, Blockfrost backend. No local cardano-node.
+- Harness scripts in `hydra-l2-flow/`: `93-deposit.mts` (single deposit, node-side confirmation), `94-l2-spend.mts` (L2 spend from an explicitly named UTxO), `95-capture-head-state.sh` (snapshot/UTxO/head captures), `96-derive-db-wallets.mts` (DB + key → addresses), `97-restart-node.sh` (restart one node, optional `--wipe`, optional `--from SLOT.HASH`), `98-verify-l1.sh` (Blockfrost balances), `99-ws-command.mts` (raw WS client input).
+- "Wipe" = `mv` of the whole persistence dir (SQLite event store + etcd raft state). Archives kept as escape hatches; none were needed.
+
+## Verified findings
+
+### A. One-side wipe (head 1, version 2, snapshot n=4)
+
+1. VERIFIED. A wiped node cannot boot next to an intact peer by default: etcd fails with `member 15b56a3725607023 has already been bootstrapped`. Remedy: `ETCD_INITIAL_CLUSTER_STATE=existing`.
+2. VERIFIED. A wiped node without `--start-chain-from` is blind: `Idle`, empty `/snapshot`. An open head holding 415.78 ADA was invisible to it.
+3. VERIFIED. With `--start-chain-from <pre-init point>` the node replays to `Open` at the correct on-chain version.
+4. VERIFIED. The intact peer alone recovers everything: it closed at n=4 and fanout `daa81085…` paid buyer 40, seller 20, purchasing 105.781012 + 250 (the acknowledged pending deposit was absorbed into the close). The wiped node followed the close on chain to `Idle` without contesting.
+
+### B. Both-sides wipe (head 3, version 2, masumi shape: empty open + 2 deposits)
+
+Setup: head opened with empty commits, deposits 105.781012 and 250 absorbed (version 2), one L2 payment (buyer 30) signed as ConfirmedSnapshot n=3 v2 and captured to disk. Then BOTH persistence dirs were wiped and both nodes restarted with `--start-chain-from 132000805.c62243db…` (the captured pre-init anchor).
+
+5. VERIFIED. Replay reconstructs the last increment's certificate from chain data alone. Both nodes reached `Open` version 2 with `confirmedSnapshot = ConfirmedSnapshot n=2 v=1`, `utxo = {74a03dce…#0 = 105.781012}`, `utxoToCommit = {776d57c7…#0 = 250}`, and BOTH multisignatures present (recovered from the IncrementTx redeemer). `localUTxO` on both nodes held both UTxOs. Only the post-increment L2 tx (n=3) rolled back.
+6. VERIFIED (decisive). Normal L2 operation resumes. A NewTx spending the replayed UTxO was accepted; both nodes signed a fresh `ConfirmedSnapshot n=3 v=2` (buyer 30, change 75.781012, the alpha-250 absorbed; 2 signatures). The head was fully live with zero persistence carried over.
+7. VERIFIED. Close and fanout work from the recovered state. Close landed at snapshot n=3, neither node contested (both agreed), fanout `25498000…` finalized the head. L1 final: buyer 70 total (40 from head 1 + 30 from the re-signed post-recovery payment), seller 20, purchasing 873.043147. Zero funds lost.
+8. VERIFIED. Sideload of the STORED newer snapshot (n=3 v2, captured pre-wipe) into the replayed node is rejected: `{"lastSeenSv":1,"requestedSv":2,"tag":"SideLoadSvNumberInvalid"}`. Same guard rejected it on head 1 with `lastSeenSv:0`. Root cause (code, tag 2.3.0): `onOpenClientSideLoadSnapshot` compares the requested snapshot version against the CONFIRMED snapshot's version, which after replay is the reconstructed older one. Upstream gap: stock hydra-node gives no way to inject a stored newer signed snapshot.
+9. INFERRED (code-anchored, both live close paths consistent with it). Without any post-replay cooperation, a both-wiped pair can still close unilaterally at the reconstructed n=2 certificate via the CloseUsed path (snapshot version = open version − 1 with alpha), fanning out utxo ∪ utxoToCommit = all 355.78. We chose the richer test (resume, then close at n=3) instead of burning the head on this variant.
+
+### C. Deposit lifecycle hazards (head 2, `b1de342f…`, sacrificed)
+
+10. VERIFIED (code). Deposit deadline = now + 3 × depositPeriod (`HTTPServer.hs:299`). The protocol activation window is `[created + period, deadline − period]` in CHAIN-observation time (`HeadLogic.hs:874`). With Blockfrost the follower lags minutes, so a 300s period can miss the window entirely: the deposit lands on L1 but never activates. Use 600s or more for Blockfrost-backed nodes; masumi's production deposit period should be reviewed against worst-case provider lag.
+11. VERIFIED. Expired deposits are fully recoverable: `DELETE /commits/<txid>`, retried until the follower tip passes the deadline slot, returned 250 and 105.78 in full. A recover posted ~60s before the deadline slot fails with a PostTxError and must be retried.
+12. VERIFIED (live + code). Recovering a deposit that a signed snapshot already ACKNOWLEDGED wedges an empty head permanently. The confirmed snapshot keeps the recovered deposit in `utxoToCommit`; `selectNextDeposit` (`HeadLogic.hs:1604`) admits a new deposit only when that field is empty; clearing it needs a NewTx snapshot, which an empty head cannot produce. Head 2 was abandoned in this state. Worse, closing such a head with the poisoned snapshot commits to an alpha that no longer exists on L1, which makes fanout unsatisfiable. Upstream issue material. Operational rule for masumi: never recover a deposit that a snapshot has acknowledged unless a later snapshot has already cleared it, or the head still has L2 funds to force that snapshot.
+13. VERIFIED. `GET /commits` (chain-level pending deposits) is the authoritative deposit-observation signal and survives restarts from persistence. Blockfrost tx-query endpoints lag several minutes behind submission; a resubmission that fails with `BadInputsUTxO` of your own input means the tx already landed.
+14. VERIFIED. A node rejects `Init` sent right after boot (`RejectedInputBecauseUnsynced`, drift 0) until the follower observes its first block.
+
+## What the DB stores today (origin/dev schema)
+
+- Encrypted with ENCRYPTION_KEY: `WalletSecret.encryptedMnemonic` (fund wallets), `HydraSecretKey` (hydra SK + node cardano SK), HydraHost tokens.
+- Plain: `headIdentifier`, `contestationPeriod`, remote party vkeys (`HydraVerificationKey`), advertise fields, `latestSnapshotNumber` (bare counter), reconciliation cursors.
+- Absent: signed snapshot bodies, multisignatures, in-head UTxO sets, the event log, and any chain anchor for `--start-chain-from`.
+
+## Feature design: snapshot storage in the payment DB
+
+### What to store
+
+One append-only table, one row per confirmed snapshot, plus one anchor row per head.
+
+```prisma
+model HydraStoredSnapshot {
+  id              String   @id @default(cuid())
+  createdAt       DateTime @default(now())
+  hydraHeadId     String   // FK -> HydraHead
+  headIdentifier  String   // on-chain headId hex, denormalized for recovery without joins
+  snapshotNumber  Int
+  snapshotVersion Int
+  snapshotJson    Json     // full /snapshot response: snapshot body incl. utxo,
+                           // utxoToCommit, utxoToDecommit, AND signatures.multiSignature
+  utxoHash        String   // canonical hash for integrity checking on read-back
+  kind            HydraSnapshotKind // CONFIRMED | INCREMENT_ACK | DECREMENT_ACK
+  @@unique([hydraHeadId, snapshotNumber, snapshotVersion])
+  @@index([hydraHeadId, snapshotNumber(sort: Desc)])
+}
+
+// On HydraHead (new columns):
+//   initTxChainSlot  BigInt?  // slot of the block BEFORE the observed InitTx
+//   initTxChainHash  String?  // its block hash -> the --start-chain-from anchor
+```
+
+Write triggers, in the existing L2 sync path (the service already receives and verifies every `SnapshotConfirmed`; `VerifiedHydraSnapshot` already carries canonical TxOut bytes):
+
+1. After every verified `SnapshotConfirmed`: upsert the row. This covers the user's "after each head change".
+2. After every observed L1 head transition (increment, decrement, close, contest): re-assert that the latest stored row is the one the transition references, and mark `kind`. This covers "after each L1 hash".
+3. On head creation: store the pre-init chain point (slot + hash of the tip just before posting InitTx) on the head row. Without this anchor, replay-based recovery cannot start.
+
+Retention: keep at least the latest CONFIRMED row, the latest INCREMENT_ACK row per version, and every row not yet superseded by an on-chain transition. Older rows can be pruned; append-only until a pruning job exists is fine at masumi volumes.
+
+### Recovery runbooks the stored data enables
+
+R1. Peer intact (today's common case). Nothing needed from the store: the peer closes at the latest snapshot. VERIFIED live (head 1).
+
+R2. Both sides wiped, counterparty cooperative. Restart both nodes with `--wipe`-equivalent fresh dirs and `--start-chain-from` = stored anchor. Replay rebuilds the last increment certificate (VERIFIED, finding 5). Re-submit the rolled-back L2 tail: the stored `snapshotJson` rows tell you exactly which txs are missing (diff stored latest utxo vs reconstructed utxo). After re-signing, close and fan out normally (VERIFIED, findings 6 and 7).
+
+R3. Both sides wiped, counterparty gone or hostile. Stock node closes at the reconstructed last-increment state (INFERRED, finding 9), which already recovers ALL funds at their positions as of the last increment. To close at the true latest state instead, build the close tx externally from the stored snapshot: the row holds the snapshot body and both multisignatures; the accumulator commitment is recomputable from the stored canonical TxOut bytes (the service already has the KZG code); the head validator is a published reference script. This is the only path that needs new tx-building code, and it is needed only when the rolled-back tail materially favors the counterparty.
+
+R4. Mid-fanout crash (multi-step fanout). Partial fanout (hydra 2.2+) drains a closed head over several `PartialFanoutTx` steps plus a `FinalPartialFanoutTx`. Driver liveness is open: any party can resume the drain, and the proofs are membership proofs against the closed commitment. The stored snapshot's full UTxO contents are exactly the proof material needed to resume from any intermediate state, even with zero node persistence. Not triggered live here (3 outputs → single fanout); code-verified. The store must therefore keep the FULL utxo map, not a hash.
+
+R5. Pending-deposit cleanup after recovery. The stored row's `utxoToCommit` plus `GET /commits` decide, per deposit: absorbed on chain (nothing to do), acknowledged but not incremented (do NOT recover it while it sits in the latest snapshot's alpha; see finding 12), or unacknowledged/expired (recover via `DELETE /commits/<txid>` after the deadline; VERIFIED, finding 11).
+
+### Upstream issues worth filing
+
+1. Sideload guard: `POST /snapshot` cannot inject a stored newer signed snapshot into a replayed node (`SideLoadSvNumberInvalid`, findings 4/8). If upstream relaxed the guard to accept a strictly newer snapshot valid at the current open version, R3 would need no external builder.
+2. Recover-after-acknowledge wedge and unfanoutable close (finding 12).
+3. Deposit activation window vs slow chain followers (finding 10): the node could refuse to draft a deposit whose window its own follower lag will miss.
+
+## Operational notes for masumi
+
+- Set the hydra-node deposit period to at least 600s wherever Blockfrost (or any remote provider) backs the node.
+- Record the pre-init chain point at head creation time. It is a two-column change with outsized recovery value.
+- Treat `GET /commits` as the deposit source of truth in reconcilers; never key resubmission decisions off Blockfrost tx-query visibility.
+- Never auto-recover an acknowledged deposit (finding 12 guard).
+
+## Least confident decisions
+
+1. Finding 9 (unilateral CloseUsed at the reconstructed n=2 certificate) is INFERRED from the validator rules plus the reconstructed state's shape; we closed at n=3 instead of spending a head to prove it. Cheap to prove later with a throwaway head.
+2. The claim that increment redeemers always carry recoverable multisignatures is generalized from one hydra version (2.3.0). A hydra upgrade could change what replay reconstructs; the storage design intentionally does not depend on it.
+3. Multi-step fanout resumability (R4) is code-verified only. A live partial-fanout drill (a head with enough UTxOs to force chunking, killed mid-drain) would close the gap.
+4. The Prisma sketch stores full snapshot JSON per row. If heads ever hold hundreds of UTxOs, row size and write amplification may need the pruning job sooner than assumed.
+5. The 600s deposit-period floor is calibrated to the lag observed in this session (roughly 2 to 8 minutes). Worse provider conditions may need more, or the drafting-side guard from upstream issue 3.

--- a/hydra-l2-flow/.bin
+++ b/hydra-l2-flow/.bin
@@ -1,0 +1,1 @@
+/Users/sandro/GitHub/masumi-payment-service/hydra-l2-flow/.bin

--- a/hydra-l2-flow/93-deposit.mts
+++ b/hydra-l2-flow/93-deposit.mts
@@ -1,0 +1,87 @@
+/**
+ * Standalone deposit: commit ONE named purchasing-wallet UTxO into the open
+ * head via POST /commit → sign → POST /cardano-transaction, then confirm the
+ * deposit tx lands on L1 (Blockfrost), resubmitting the SAME signed tx if the
+ * submit was silently dropped.
+ *
+ * Run: pnpm exec tsx hydra-l2-flow/93-deposit.mts <txHash#index> <lovelace>
+ */
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const [utxoKey, lovelaceStr] = process.argv.slice(2);
+if (!lovelaceStr) {
+	console.error('usage: 93-deposit.mts <txHash#index> <lovelace>');
+	process.exit(2);
+}
+const PREPROD_DIR = join(process.cwd(), 'hydra-l2-flow', 'preprod');
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
+const BLOCKFROST_KEY = readFileSync(join(PREPROD_DIR, 'blockfrost.txt'), 'utf-8').trim();
+
+function log(m: string) {
+	console.log(`[deposit] ${new Date().toISOString().slice(11, 19)} ${m}`);
+}
+
+function fundsAddr(): string {
+	return execFileSync(
+		'docker',
+		['run', '--rm', '-v', `${PREPROD_DIR}:/keys`, '--entrypoint', 'cardano-cli', CARDANO_NODE_IMAGE,
+			'address', 'build', '--payment-verification-key-file', '/keys/purchasing-cardano.vk', '--testnet-magic', '1'],
+		{ encoding: 'utf-8' },
+	).trim();
+}
+
+async function httpPost(url: string, body: unknown): Promise<unknown> {
+	const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+	const t = await res.text();
+	try { return JSON.parse(t); } catch { return t; }
+}
+
+async function main() {
+	const addr = fundsAddr();
+	const commitBody = {
+		[utxoKey]: {
+			address: addr, datum: null, datumhash: null, inlineDatum: null,
+			inlineDatumRaw: null, referenceScript: null, value: { lovelace: Number(lovelaceStr) },
+		},
+	};
+	const draft = (await httpPost('http://127.0.0.1:4001/commit', commitBody)) as { cborHex?: string };
+	if (!draft.cborHex) throw new Error(`draft failed: ${JSON.stringify(draft).slice(0, 300)}`);
+	log(`draft ok; signing…`);
+	const envelope = JSON.stringify({ type: 'Tx ConwayEra', description: '', cborHex: draft.cborHex });
+	const signedJson = execFileSync(
+		'docker',
+		['run', '--rm', '-i', '-v', `${PREPROD_DIR}:/keys`, '--entrypoint', 'sh', CARDANO_NODE_IMAGE, '-c',
+			'cat > /tmp/c.tx && cardano-cli conway transaction sign --tx-file /tmp/c.tx --signing-key-file /keys/purchasing-cardano.sk --testnet-magic 1 --out-file /tmp/c.signed && cardano-cli conway transaction txid --tx-file /tmp/c.signed >&2 && cat /tmp/c.signed'],
+		{ input: envelope, encoding: 'utf-8' },
+	);
+	const signed = JSON.parse(signedJson) as { cborHex: string };
+	const submit = await httpPost('http://127.0.0.1:4001/cardano-transaction', { type: 'Tx ConwayEra', description: '', cborHex: signed.cborHex });
+	log(`submit: ${JSON.stringify(submit).slice(0, 100)}`);
+	const txId = execFileSync(
+		'docker',
+		['run', '--rm', '-i', '--entrypoint', 'sh', CARDANO_NODE_IMAGE, '-c',
+			'cat > /tmp/c.signed && cardano-cli conway transaction txid --tx-file /tmp/c.signed'],
+		{ input: signedJson, encoding: 'utf-8' },
+	).trim();
+	log(`deposit txid ${txId} — waiting for the NODE to observe it (GET /commits)…`);
+	for (let i = 0; i < 100; i++) {
+		await new Promise((r) => setTimeout(r, 15000));
+		const cm = (await (await fetch('http://127.0.0.1:4001/commits')).json()) as string[];
+		if (cm.includes(txId)) { log('DEPOSIT OBSERVED BY NODE'); return; }
+		if (i % 8 === 7) {
+			const rs = await fetch('https://cardano-preprod.blockfrost.io/api/v0/tx/submit', {
+				method: 'POST', headers: { project_id: BLOCKFROST_KEY, 'Content-Type': 'application/cbor' },
+				body: Buffer.from(signed.cborHex, 'hex'),
+			});
+			const body = await rs.text();
+			// A BadInputsUTxO rejection of our OWN input means the tx already landed;
+			// keep waiting for the node's follower to reach it.
+			log(`resubmit status ${rs.status}: ${body.slice(0, 120)}`);
+		}
+	}
+	throw new Error('deposit never observed by node');
+}
+
+main().catch((e) => { console.error('[deposit] FATAL', e); process.exit(1); });

--- a/hydra-l2-flow/94-l2-spend.mts
+++ b/hydra-l2-flow/94-l2-spend.mts
@@ -1,0 +1,101 @@
+/**
+ * L2-resume probe — build and submit an in-head transfer from an EXPLICITLY
+ * NAMED UTxO (no /snapshot/utxo fetch). Used after a persistence wipe + chain
+ * replay, where the confirmed-snapshot view is empty but localUTxO may still
+ * hold the replayed deposit outputs. The node's accept/reject answer is the
+ * measurement.
+ *
+ * Run: pnpm exec tsx hydra-l2-flow/94-l2-spend.mts \
+ *        <txHash> <index> <lovelace> <ownerAddr> <skPathInContainer> <destAddr> <sendLovelace> [nodePort]
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MeshTxBuilder } from '@meshsdk/core';
+import { HydraNode } from '@/lib/hydra/hydra/node';
+import { HydraProvider } from '@/lib/hydra/hydra/provider';
+
+const [txHash, indexStr, lovelace, ownerAddr, skPath, destAddr, sendLovelace, nodePort] = process.argv.slice(2);
+if (!sendLovelace) {
+	console.error(
+		'usage: 94-l2-spend.mts <txHash> <index> <lovelace> <ownerAddr> <skPathInContainer> <destAddr> <sendLovelace> [nodePort]',
+	);
+	process.exit(2);
+}
+const PORT = nodePort ?? '4001';
+const CARDANO_NODE_IMAGE = 'ghcr.io/intersectmbo/cardano-node:10.6.2';
+
+function log(m: string) {
+	console.log(`[l2-spend] ${new Date().toISOString().slice(11, 19)} ${m}`);
+}
+
+function signWithCardanoCli(cborHex: string): string {
+	const tmpIn = join(tmpdir(), `l2s-draft-${Date.now()}.tx`);
+	writeFileSync(tmpIn, JSON.stringify({ type: 'Tx ConwayEra', description: '', cborHex }));
+	try {
+		const preprodDir = join(process.cwd(), 'hydra-l2-flow', 'preprod');
+		const signedJson = execFileSync(
+			'docker',
+			[
+				'run',
+				'--rm',
+				'-i',
+				'-v',
+				`${preprodDir}:/keys`,
+				'--entrypoint',
+				'sh',
+				CARDANO_NODE_IMAGE,
+				'-c',
+				`cat > /tmp/d.tx && cardano-cli conway transaction sign --tx-file /tmp/d.tx --signing-key-file ${skPath} --testnet-magic 1 --out-file /tmp/s.tx && cat /tmp/s.tx`,
+			],
+			{ input: readFileSync(tmpIn, 'utf-8'), encoding: 'utf-8' },
+		);
+		return (JSON.parse(signedJson) as { cborHex: string }).cborHex;
+	} finally {
+		try {
+			unlinkSync(tmpIn);
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
+async function main() {
+	const node = new HydraNode({ httpUrl: `http://127.0.0.1:${PORT}` });
+	node.connect();
+	await new Promise((r) => setTimeout(r, 1500));
+	const provider = new HydraProvider({ node });
+	await new Promise((r) => setTimeout(r, 600));
+
+	const amountList = [{ unit: 'lovelace', quantity: lovelace }];
+	const tx = new MeshTxBuilder({ fetcher: provider, submitter: provider, isHydra: true });
+	await tx
+		.txIn(txHash, Number(indexStr), amountList, ownerAddr)
+		.txOut(destAddr, [{ unit: 'lovelace', quantity: sendLovelace }])
+		.setFee('0')
+		.changeAddress(ownerAddr)
+		.complete();
+	log(`draft built from ${txHash.slice(0, 12)}…#${indexStr}`);
+
+	const signed = signWithCardanoCli(tx.txHex);
+	log('signed; submitting to node…');
+	try {
+		const submittedHash = await provider.submitTx(signed);
+		log(`SUBMITTED OK: ${submittedHash}`);
+		const confirmed = await Promise.race([
+			node.awaitTx(submittedHash, 500).then(() => true),
+			new Promise<boolean>((r) => setTimeout(() => r(false), 20000)),
+		]);
+		log(`confirmed in snapshot: ${confirmed}`);
+		process.exit(confirmed ? 0 : 3);
+	} catch (e) {
+		log(`SUBMIT REJECTED: ${e instanceof Error ? e.message : String(e)}`);
+		process.exit(4);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/hydra-l2-flow/95-capture-head-state.sh
+++ b/hydra-l2-flow/95-capture-head-state.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Capture everything an external store would need to recover a Hydra head:
+# the full ConfirmedSnapshot (with multisignature) from each node, the in-head
+# UTxO map, and the last-seen snapshot marker. This simulates "the payment
+# service stored the latest signed snapshot in its DB".
+#
+# Usage: ./95-capture-head-state.sh <label>
+set -euo pipefail
+LABEL="${1:?usage: 95-capture-head-state.sh <label>}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/preprod/captures/$LABEL"
+mkdir -p "$DIR"
+for port in 4001 4002; do
+  for ep in snapshot snapshot/utxo snapshot/last-seen head; do
+    out="$DIR/node${port#400}-${ep//\//-}.json"
+    if curl -sf "http://127.0.0.1:$port/$ep" -o "$out"; then
+      echo "captured :$port /$ep -> $(wc -c < "$out") bytes"
+    else
+      echo "MISS :$port /$ep (endpoint absent or node down)"
+      rm -f "$out"
+    fi
+  done
+done
+date -u +"%Y-%m-%dT%H:%M:%SZ" > "$DIR/captured-at.txt"
+echo "capture -> $DIR"

--- a/hydra-l2-flow/96-derive-db-wallets.mts
+++ b/hydra-l2-flow/96-derive-db-wallets.mts
@@ -1,0 +1,32 @@
+/**
+ * Recover the V2 preprod fund wallets from the payment-service DB alone:
+ * read WalletSecret.encryptedMnemonic, decrypt with ENCRYPTION_KEY, derive
+ * the L1 addresses. This is the "DB + encryption key" recovery demonstration:
+ * no wallet file, no hydra-node, no persistence involved.
+ *
+ * Run: DATABASE_URL=<test-db> pnpm exec tsx hydra-l2-flow/96-derive-db-wallets.mts
+ */
+import { prisma } from '@masumi/payment-core/db';
+import { decrypt } from '@/utils/security/encryption';
+import { generateOfflineWallet } from '@/utils/generator/wallet-generator';
+import { HotWalletType, Network, PaymentSourceType } from '@/generated/prisma/client';
+
+async function main() {
+	const source = await prisma.paymentSource.findFirstOrThrow({
+		where: { network: Network.Preprod, paymentSourceType: PaymentSourceType.Web3CardanoV2, deletedAt: null },
+		include: { HotWallets: { where: { deletedAt: null }, include: { Secret: true } } },
+	});
+	const out: Record<string, { address: string; walletVkey: string }> = {};
+	for (const type of [HotWalletType.Purchasing, HotWalletType.Selling]) {
+		const wallet = source.HotWallets.find((w) => w.type === type);
+		if (!wallet) throw new Error(`no ${type} hot wallet`);
+		const mnemonic = decrypt(wallet.Secret.encryptedMnemonic).split(' ');
+		const mw = generateOfflineWallet(source.network, mnemonic);
+		const address = (await mw.getUnusedAddresses())[0] ?? mw.getUsedAddress().toBech32();
+		out[type.toLowerCase()] = { address, walletVkey: wallet.walletVkey };
+	}
+	console.log(JSON.stringify(out, null, 2));
+	await prisma.$disconnect();
+	process.exit(0);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/hydra-l2-flow/97-restart-node.sh
+++ b/hydra-l2-flow/97-restart-node.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Restart ONE preprod hydra-node (1=purchasing, 2=selling) with optional
+# persistence wipe and optional chain replay. Mirrors start_node_preprod in
+# hydra-native.sh exactly (same ports, keys, periods).
+#
+# Usage: 97-restart-node.sh <1|2> [--wipe] [--from SLOT.HASH]
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREPROD_DIR="$REPO/hydra-l2-flow/preprod"
+STATE="$REPO/hydra-l2-flow/.native-state"
+BIN="$REPO/hydra-l2-flow/.bin/hydra-node"
+export DYLD_FALLBACK_LIBRARY_PATH="${DYLD_FALLBACK_LIBRARY_PATH:-/usr/lib}"
+
+IDX="${1:?node index 1 or 2}"; shift
+WIPE=0; FROM=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --wipe) WIPE=1; shift ;;
+    --from) FROM="$2"; shift 2 ;;
+    *) echo "unknown arg $1"; exit 1 ;;
+  esac
+done
+
+if [ "$IDX" = 1 ]; then party=purchasing; other_vk=selling-hydra.vk; other_cvk=selling-cardano.vk; else party=selling; other_vk=purchasing-hydra.vk; other_cvk=purchasing-cardano.vk; fi
+api=$((4000 + IDX)); p2p=$((5000 + IDX)); mon=$((6000 + IDX)); other=$(( IDX == 1 ? 2 : 1 ))
+persist="$PREPROD_DIR/persistence/$party"
+
+# Stop the node if running.
+if [ -f "$STATE/node$IDX.pid" ] && kill -0 "$(cat "$STATE/node$IDX.pid")" 2>/dev/null; then
+  kill "$(cat "$STATE/node$IDX.pid")"; sleep 2
+  kill -9 "$(cat "$STATE/node$IDX.pid")" 2>/dev/null || true
+  echo "[restart-node$IDX] stopped previous pid"
+fi
+
+if [ "$WIPE" = 1 ]; then
+  stamp="$(date +%H%M%S)"
+  mv "$persist" "$persist.wiped-$stamp" 2>/dev/null && echo "[restart-node$IDX] persistence moved to $party.wiped-$stamp" || echo "[restart-node$IDX] no persistence to wipe"
+fi
+mkdir -p "$persist"
+rm -f "$persist/bin/etcd"
+
+( "$BIN" \
+    --node-id "$IDX" \
+    --api-host 127.0.0.1 --api-port "$api" \
+    --listen "127.0.0.1:$p2p" --monitoring-port "$mon" \
+    --peer "127.0.0.1:$((5000 + other))" \
+    --network preprod \
+    --hydra-signing-key "$PREPROD_DIR/$party-hydra.sk" \
+    --hydra-verification-key "$PREPROD_DIR/$other_vk" \
+    --cardano-signing-key "$PREPROD_DIR/$party-cardano.sk" \
+    --cardano-verification-key "$PREPROD_DIR/$other_cvk" \
+    --ledger-protocol-parameters "$PREPROD_DIR/protocol-parameters.json" \
+    --blockfrost "$PREPROD_DIR/blockfrost.txt" \
+    --blockfrost-query-timeout 10 \
+    --persistence-dir "$persist" \
+    --contestation-period 220s \
+    --deposit-period "${DEPOSIT_PERIOD:-300s}" \
+    --unsynced-period 1800s \
+    ${FROM:+--start-chain-from "$FROM"} \
+    >>"$STATE/node$IDX.log" 2>&1 ) &
+echo $! > "$STATE/node$IDX.pid"
+echo "[restart-node$IDX] started pid $(cat "$STATE/node$IDX.pid")${FROM:+ replaying from $FROM}${WIPE:+ (wiped)}"
+for _ in $(seq 1 60); do
+  curl -sf "http://127.0.0.1:$api/protocol-parameters" >/dev/null 2>&1 && { echo "[restart-node$IDX] API up"; exit 0; }
+  sleep 2
+done
+echo "[restart-node$IDX] API did not come up — see $STATE/node$IDX.log"; exit 1

--- a/hydra-l2-flow/98-verify-l1.sh
+++ b/hydra-l2-flow/98-verify-l1.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Report L1 balances of the three fund destinations after fanout.
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEY="$(cat "$REPO/hydra-l2-flow/preprod/blockfrost.txt")"
+declare -a PAIRS=(
+  "buyer-db-wallet addr_test1qqhpyjqcq4u49rlp6gag57xq0xkvsu36q9n0z7j7vd5re38yhrczecm8dtse0rzhqcmnfu9zkymtjvtjp4fn365d3dyq8p9het"
+  "seller-db-wallet addr_test1qpukmaupwm9e5wccytz4l53hgh5qdvvz4cxmqm62a6h75wka08uf8taezqr6tjd0s2y8swqex57zjq0y7w3dkkh9exvs62g255"
+  "purchasing-file addr_test1vr0k7n76m2s9gsnha2n47umajyuwhe3rqsr7pnh2cgfc7yg60l8fh"
+)
+for pair in "${PAIRS[@]}"; do
+  name="${pair%% *}"; addr="${pair##* }"
+  total=$(curl -s "https://cardano-preprod.blockfrost.io/api/v0/addresses/$addr" -H "project_id: $KEY" | jq -r 'if .amount then ([.amount[] | select(.unit=="lovelace") | .quantity] | first // "0") else "0" end')
+  printf "%-18s %s  %.6f ADA\n" "$name" "${addr:0:24}…" "$(echo "$total / 1000000" | bc -l)"
+done

--- a/hydra-l2-flow/99-ws-command.mts
+++ b/hydra-l2-flow/99-ws-command.mts
@@ -1,0 +1,35 @@
+/**
+ * Send one raw client input to a hydra-node WS API and print every frame seen
+ * for a bounded window. Diagnostic driver for the persistence-recovery
+ * experiments: Close attempts, snapshot sideload observation, NewTx, etc.
+ *
+ * Run: pnpm exec tsx hydra-l2-flow/99-ws-command.mts <ws-url> <seconds> [json-command]
+ *   e.g. ...  ws://127.0.0.1:4001 15 '{"tag":"Close"}'
+ *   omit json-command to just observe (Greetings etc.).
+ */
+import WebSocket from 'ws';
+
+const url = process.argv[2] ?? 'ws://127.0.0.1:4001';
+const seconds = Number(process.argv[3] ?? '10');
+const command = process.argv[4];
+
+const socket = new WebSocket(`${url}?history=no`);
+socket.on('open', () => {
+	console.log(`[ws] connected ${url}`);
+	if (command) {
+		socket.send(command);
+		console.log(`[ws] sent ${command}`);
+	}
+});
+socket.on('message', (raw: Buffer) => {
+	const text = raw.toString('utf8');
+	try {
+		const parsed = JSON.parse(text) as Record<string, unknown>;
+		const compact = JSON.stringify(parsed);
+		console.log(`[frame] ${compact.length > 1200 ? compact.slice(0, 1200) + '…(' + compact.length + 'b)' : compact}`);
+	} catch {
+		console.log(`[frame-raw] ${text.slice(0, 300)}`);
+	}
+});
+socket.on('error', (e: Error) => console.log(`[ws-error] ${e.message}`));
+setTimeout(() => { socket.close(); process.exit(0); }, seconds * 1000);

--- a/prisma/migrations/20260826000000_hydra_init_chain_anchor/migration.sql
+++ b/prisma/migrations/20260826000000_hydra_init_chain_anchor/migration.sql
@@ -1,0 +1,9 @@
+-- Chain-replay anchor for hydra-node persistence-loss recovery: the block
+-- point immediately BEFORE the block carrying the head's InitTx. A wiped
+-- hydra-node restarted with `--start-chain-from <slot>.<hash>` re-observes the
+-- whole head from L1 (verified live on preprod; see
+-- docs/hydra-persistence-recovery-verification.md). Written alongside
+-- initTxHash by on-chain verification; the init backfill service heals rows
+-- that were verified before these columns existed.
+ALTER TABLE "HydraHead" ADD COLUMN "initChainSlot" BIGINT,
+ADD COLUMN "initChainHash" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1801,6 +1801,15 @@ model HydraHead {
   closeTxHash  String?
   fanoutTxHash String?
 
+  /// Chain-replay anchor for hydra-node persistence-loss recovery: the block
+  /// point immediately BEFORE the block that carries the InitTx. A wiped node
+  /// restarted with `--start-chain-from <initChainSlot>.<initChainHash>`
+  /// re-observes the whole head from L1 (verified live on preprod; see
+  /// docs/hydra-persistence-recovery-verification.md). Both fields are null or
+  /// both set; written alongside initTxHash during on-chain verification.
+  initChainSlot BigInt?
+  initChainHash String?
+
   /// Monotonic ownership fence (fencing token): incremented once per
   /// head-session acquisition. Lifecycle writes carry it, so a stale session's
   /// late write misses its guarded UPDATE and self-demotes instead of

--- a/src/lib/hydra/hydra/head-init-validation.spec.ts
+++ b/src/lib/hydra/hydra/head-init-validation.spec.ts
@@ -270,4 +270,22 @@ describe('resolveHydraInitChainAnchor', () => {
 	it('rejects a non-canonical InitTx hash', async () => {
 		await expect(resolveHydraInitChainAnchor(anchorObserver(), 'zz')).rejects.toThrow('not canonical hexadecimal');
 	});
+
+	it('returns null instead of throwing when the observer fails transiently', async () => {
+		const observer = {
+			txs: jest.fn(async (_hash: string): Promise<{ block: string | null }> => {
+				throw new Error('Blockfrost 429');
+			}),
+			blocks: jest.fn(async (_hashOrNumber: string) => ({ hash: PARENT_BLOCK, slot: 499, previous_block: null })),
+		};
+		await expect(resolveHydraInitChainAnchor(observer, INIT_TX_HASH)).resolves.toBeNull();
+	});
+
+	it('returns null when the observer pass exceeds its timeout', async () => {
+		const observer = {
+			txs: jest.fn((_hash: string) => new Promise<{ block: string | null }>(() => undefined)),
+			blocks: jest.fn(async (_hashOrNumber: string) => ({ hash: PARENT_BLOCK, slot: 499, previous_block: null })),
+		};
+		await expect(resolveHydraInitChainAnchor(observer, INIT_TX_HASH, 50)).resolves.toBeNull();
+	});
 });

--- a/src/lib/hydra/hydra/head-init-validation.spec.ts
+++ b/src/lib/hydra/hydra/head-init-validation.spec.ts
@@ -15,6 +15,7 @@ import {
 	DEFAULT_HYDRA_HEAD_SCRIPT_HASH,
 	HYDRA_HEAD_V2_ASSET_NAME_HEX,
 	HydraHeadInitObservationError,
+	resolveHydraInitChainAnchor,
 	verifyHydraHeadInitOnChain,
 	type HydraHeadChainObserver,
 } from './head-init-validation';
@@ -211,5 +212,62 @@ describe('verifyHydraHeadInitOnChain', () => {
 				contestationPeriodSeconds: CONTESTATION_SECONDS,
 			}),
 		).rejects.toThrow('participant tokens');
+	});
+});
+
+describe('resolveHydraInitChainAnchor', () => {
+	const INIT_BLOCK = 'aa'.repeat(32);
+	const PARENT_BLOCK = 'bb'.repeat(32);
+
+	function anchorObserver(overrides?: {
+		block?: string | null;
+		previousBlock?: string | null;
+		parentSlot?: number | null;
+	}) {
+		return {
+			txs: jest.fn(async (_hash: string) => ({ block: overrides?.block === undefined ? INIT_BLOCK : overrides.block })),
+			blocks: jest.fn(async (hashOrNumber: string) =>
+				hashOrNumber === INIT_BLOCK
+					? {
+							hash: INIT_BLOCK,
+							slot: 500,
+							previous_block: overrides?.previousBlock === undefined ? PARENT_BLOCK : overrides.previousBlock,
+						}
+					: {
+							hash: PARENT_BLOCK,
+							slot: overrides?.parentSlot === undefined ? 499 : overrides.parentSlot,
+							previous_block: 'cc'.repeat(32),
+						},
+			),
+		};
+	}
+
+	it('returns the parent block point of the InitTx block', async () => {
+		const observer = anchorObserver();
+		await expect(resolveHydraInitChainAnchor(observer, INIT_TX_HASH)).resolves.toEqual({
+			slot: 499n,
+			hash: PARENT_BLOCK,
+		});
+		expect(observer.txs).toHaveBeenCalledWith(INIT_TX_HASH);
+		expect(observer.blocks).toHaveBeenNthCalledWith(1, INIT_BLOCK);
+		expect(observer.blocks).toHaveBeenNthCalledWith(2, PARENT_BLOCK);
+	});
+
+	it('returns null when the InitTx has no block yet', async () => {
+		await expect(resolveHydraInitChainAnchor(anchorObserver({ block: null }), INIT_TX_HASH)).resolves.toBeNull();
+	});
+
+	it('returns null when the InitTx block has no previous block', async () => {
+		await expect(
+			resolveHydraInitChainAnchor(anchorObserver({ previousBlock: null }), INIT_TX_HASH),
+		).resolves.toBeNull();
+	});
+
+	it('returns null when the parent block has no slot', async () => {
+		await expect(resolveHydraInitChainAnchor(anchorObserver({ parentSlot: null }), INIT_TX_HASH)).resolves.toBeNull();
+	});
+
+	it('rejects a non-canonical InitTx hash', async () => {
+		await expect(resolveHydraInitChainAnchor(anchorObserver(), 'zz')).rejects.toThrow('not canonical hexadecimal');
 	});
 });

--- a/src/lib/hydra/hydra/head-init-validation.ts
+++ b/src/lib/hydra/hydra/head-init-validation.ts
@@ -171,6 +171,38 @@ export async function verifyHydraHeadInitOnChain(options: {
 	return { initTxHash };
 }
 
+/** Minimal L1 surface needed to resolve the chain-replay anchor of an InitTx. */
+export type HydraInitAnchorObserver = {
+	txs: (hash: string) => Promise<{ block: string | null }>;
+	blocks: (hashOrNumber: string) => Promise<{ hash: string; slot: number | null; previous_block?: string | null }>;
+};
+
+/**
+ * Resolve the `--start-chain-from` anchor for a verified InitTx: the chain
+ * point of the block immediately BEFORE the block that carries the InitTx.
+ * hydra-node begins observation strictly AFTER the given point, so the parent
+ * block is the newest anchor that still re-observes the InitTx during a
+ * persistence-loss chain replay.
+ *
+ * Returns null when the parent point cannot be expressed (no previous block,
+ * or a slot-less block): the head verification itself is unaffected then.
+ */
+export async function resolveHydraInitChainAnchor(
+	observer: HydraInitAnchorObserver,
+	initTxHash: string,
+): Promise<{ slot: bigint; hash: string } | null> {
+	const transaction = await observer.txs(normalizeHex(initTxHash, 64, 'Hydra InitTx hash'));
+	if (!transaction.block) return null;
+	const initBlock = await observer.blocks(transaction.block);
+	const parentHash = initBlock.previous_block;
+	if (!parentHash) return null;
+	const parent = await observer.blocks(parentHash);
+	if (parent.slot === null || parent.slot === undefined || !Number.isSafeInteger(parent.slot) || parent.slot < 0) {
+		return null;
+	}
+	return { slot: BigInt(parent.slot), hash: normalizeHex(parent.hash, 64, 'Hydra init anchor block hash') };
+}
+
 function validateHeadTokens(
 	output: HydraHeadChainOutput,
 	headId: string,

--- a/src/lib/hydra/hydra/head-init-validation.ts
+++ b/src/lib/hydra/hydra/head-init-validation.ts
@@ -184,23 +184,43 @@ export type HydraInitAnchorObserver = {
  * block is the newest anchor that still re-observes the InitTx during a
  * persistence-loss chain replay.
  *
- * Returns null when the parent point cannot be expressed (no previous block,
- * or a slot-less block): the head verification itself is unaffected then.
+ * Best-effort by design: returns null when the parent point cannot be
+ * expressed (no previous block, a slot-less block, a non-canonical response)
+ * AND on any observer transport failure or timeout. The anchor must never
+ * fail a verification that already proved the InitTx — the init backfill
+ * retries null anchors on its next cycle. Only a malformed initTxHash throws,
+ * because that is a caller bug, not an observation condition.
  */
 export async function resolveHydraInitChainAnchor(
 	observer: HydraInitAnchorObserver,
 	initTxHash: string,
+	observerTimeoutMs: number = DEFAULT_HEAD_INIT_OBSERVER_TIMEOUT_MS,
 ): Promise<{ slot: bigint; hash: string } | null> {
-	const transaction = await observer.txs(normalizeHex(initTxHash, 64, 'Hydra InitTx hash'));
-	if (!transaction.block) return null;
-	const initBlock = await observer.blocks(transaction.block);
-	const parentHash = initBlock.previous_block;
-	if (!parentHash) return null;
-	const parent = await observer.blocks(parentHash);
-	if (parent.slot === null || parent.slot === undefined || !Number.isSafeInteger(parent.slot) || parent.slot < 0) {
+	const canonicalTxHash = normalizeHex(initTxHash, 64, 'Hydra InitTx hash');
+	try {
+		return await withObserverTimeout(
+			(async () => {
+				const transaction = await observer.txs(canonicalTxHash);
+				if (!transaction.block) return null;
+				const initBlock = await observer.blocks(transaction.block);
+				const parentHash = initBlock.previous_block;
+				if (!parentHash) return null;
+				const parent = await observer.blocks(parentHash);
+				if (
+					parent.slot === null ||
+					parent.slot === undefined ||
+					!Number.isSafeInteger(parent.slot) ||
+					parent.slot < 0
+				) {
+					return null;
+				}
+				return { slot: BigInt(parent.slot), hash: normalizeHex(parent.hash, 64, 'Hydra init anchor block hash') };
+			})(),
+			observerTimeoutMs,
+		);
+	} catch {
 		return null;
 	}
-	return { slot: BigInt(parent.slot), hash: normalizeHex(parent.hash, 64, 'Hydra init anchor block hash') };
 }
 
 function validateHeadTokens(

--- a/src/routes/api/hydra/head/close-head.spec.ts
+++ b/src/routes/api/hydra/head/close-head.spec.ts
@@ -254,7 +254,9 @@ describe('Hydra head state convergence', () => {
 		await expect(updateHydraHeadEnabledState('head-1', false)).resolves.toBe(disabledHead);
 
 		expect(mockUpdateHead).toHaveBeenCalledWith(
-			expect.objectContaining({ data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null } }),
+			expect.objectContaining({
+				data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
+			}),
 		);
 		expect(mockReleaseClose).not.toHaveBeenCalled();
 		expect(mockReconcileEnabledState).toHaveBeenCalledTimes(1);

--- a/src/routes/api/hydra/head/close-head.spec.ts
+++ b/src/routes/api/hydra/head/close-head.spec.ts
@@ -254,7 +254,7 @@ describe('Hydra head state convergence', () => {
 		await expect(updateHydraHeadEnabledState('head-1', false)).resolves.toBe(disabledHead);
 
 		expect(mockUpdateHead).toHaveBeenCalledWith(
-			expect.objectContaining({ data: { isEnabled: false, initTxHash: null } }),
+			expect.objectContaining({ data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null } }),
 		);
 		expect(mockReleaseClose).not.toHaveBeenCalled();
 		expect(mockReconcileEnabledState).toHaveBeenCalledTimes(1);
@@ -288,7 +288,7 @@ describe('Hydra head state convergence', () => {
 		expect(mockUpdateHead).toHaveBeenCalledWith(
 			expect.objectContaining({
 				where: { id: 'head-1' },
-				data: { isEnabled: false, initTxHash: null },
+				data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 			}),
 		);
 		expect(verify).toHaveBeenCalledWith('head-1');

--- a/src/routes/api/hydra/head/index.ts
+++ b/src/routes/api/hydra/head/index.ts
@@ -30,6 +30,7 @@ import {
 	deriveHydraVerificationKeyCborHex,
 	HydraHeadInitObservationError,
 	normalizeHydraVerificationKeyCborHex,
+	resolveHydraInitChainAnchor,
 	verifyHydraHeadInitOnChain,
 } from '@/lib/hydra';
 import { toPrismaJsonValue } from '@/utils/json-value';
@@ -361,8 +362,9 @@ export async function verifyPersistedHydraHeadOnChain(
 		}
 	}
 
+	const observer = getBlockfrostInstance(head.HydraRelation.network, rpcProviderApiKey);
 	const verified = await verifyHydraHeadInitOnChain({
-		observer: getBlockfrostInstance(head.HydraRelation.network, rpcProviderApiKey),
+		observer,
 		headId: head.headIdentifier,
 		expectedVerificationKeys: [localVerificationKey, remoteVerificationKey],
 		// On-chain participant tokens are minted for each node's OWN Cardano key,
@@ -374,6 +376,10 @@ export async function verifyPersistedHydraHeadOnChain(
 	if (options.persist === false) {
 		return { headIdentifier: head.headIdentifier, initTxHash: verified.initTxHash };
 	}
+	// The anchor rides the same L1 evidence pass as initTxHash: a failure here
+	// throws like any other observation error and the caller (backfill,
+	// lifecycle) retries the whole verification on its next cycle.
+	const anchor = await resolveHydraInitChainAnchor(observer, verified.initTxHash);
 	const persisted = await prisma.hydraHead.updateMany({
 		where: {
 			id: head.id,
@@ -381,7 +387,10 @@ export async function verifyPersistedHydraHeadOnChain(
 			headIdentifier: head.headIdentifier,
 			contestationPeriod: head.contestationPeriod,
 		},
-		data: { initTxHash: verified.initTxHash },
+		data: {
+			initTxHash: verified.initTxHash,
+			...(anchor ? { initChainSlot: anchor.slot, initChainHash: anchor.hash } : {}),
+		},
 	});
 	if (persisted.count !== 1) throw createHttpError(409, 'Hydra head changed during on-chain verification');
 	return { headIdentifier: head.headIdentifier, initTxHash: verified.initTxHash };

--- a/src/routes/api/hydra/head/index.ts
+++ b/src/routes/api/hydra/head/index.ts
@@ -264,6 +264,7 @@ const hydraHeadOnChainVerificationSelect = {
 	isEnabled: true,
 	headIdentifier: true,
 	contestationPeriod: true,
+	initChainSlot: true,
 	LocalParticipant: {
 		select: {
 			walletId: true,
@@ -376,10 +377,13 @@ export async function verifyPersistedHydraHeadOnChain(
 	if (options.persist === false) {
 		return { headIdentifier: head.headIdentifier, initTxHash: verified.initTxHash };
 	}
-	// The anchor rides the same L1 evidence pass as initTxHash: a failure here
-	// throws like any other observation error and the caller (backfill,
-	// lifecycle) retries the whole verification on its next cycle.
-	const anchor = await resolveHydraInitChainAnchor(observer, verified.initTxHash);
+	// Anchor resolution is best-effort and immutable once stored: the parent
+	// point of an L1-confirmed InitTx block never changes, so skip the three
+	// Blockfrost round-trips on every later verification (top-up, decommit,
+	// commit all pass through here). A transient failure yields null instead of
+	// throwing — the anchor must never take down a verification that already
+	// proved the InitTx — and the init backfill retries null anchors.
+	const anchor = head.initChainSlot === null ? await resolveHydraInitChainAnchor(observer, verified.initTxHash) : null;
 	const persisted = await prisma.hydraHead.updateMany({
 		where: {
 			id: head.id,
@@ -574,8 +578,12 @@ export async function updateHydraHeadEnabledState(
 	const quarantined = await prisma.hydraHead.update({
 		where: { id },
 		// A disabled head's prior InitTx binding is no longer an admission token.
-		// Re-enable always proves the current head/participants/configuration again.
-		data: { isEnabled: false, initTxHash: null },
+		// Re-enable always proves the current head/participants/configuration
+		// again. The chain-replay anchor is derived from that binding, so it is
+		// cleared with it: a deep rollback can move the InitTx to a different
+		// block, and a stale anchor would silently defeat --start-chain-from
+		// recovery. The init backfill re-resolves it after re-enable.
+		data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 		include: headInclude,
 	});
 	await manager.reconcileEnabledState(id);

--- a/src/services/hydra-connection-manager/head-session-ops.ts
+++ b/src/services/hydra-connection-manager/head-session-ops.ts
@@ -83,6 +83,8 @@ export async function persistRegressiveHeadStatus(
 						data: {
 							isEnabled: false,
 							initTxHash: null,
+							initChainSlot: null,
+							initChainHash: null,
 							reconciliationCompletedAt: null,
 						},
 					});
@@ -91,7 +93,7 @@ export async function persistRegressiveHeadStatus(
 					}
 					await tx.hydraHead.updateMany({
 						where: { hydraRelationId, id: { not: hydraHeadId } },
-						data: { isEnabled: false, initTxHash: null },
+						data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 					});
 					return 'quarantined-confirmed-finality-conflict';
 				}
@@ -147,6 +149,8 @@ export async function persistRegressiveHeadStatus(
 					updateData.openedAt = null;
 					updateData.isEnabled = false;
 					updateData.initTxHash = null;
+					updateData.initChainSlot = null;
+					updateData.initChainHash = null;
 					updateData.lastReconciledSnapshotSequence = null;
 					updateData.lastReconciledSnapshotTransactionIndex = null;
 					updateData.latestSnapshotNumber = 0n;
@@ -170,6 +174,8 @@ export async function persistRegressiveHeadStatus(
 							status: current.status,
 							isEnabled: false,
 							initTxHash: null,
+							initChainSlot: null,
+							initChainHash: null,
 						},
 					});
 					if (invalidated.count !== 1) {
@@ -177,7 +183,7 @@ export async function persistRegressiveHeadStatus(
 					}
 					await tx.hydraHead.updateMany({
 						where: { hydraRelationId, id: { not: hydraHeadId } },
-						data: { isEnabled: false, initTxHash: null },
+						data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 					});
 					return 'quarantined-relation-conflict';
 				}

--- a/src/services/hydra-connection-manager/head-status-persistence.spec.ts
+++ b/src/services/hydra-connection-manager/head-status-persistence.spec.ts
@@ -129,7 +129,13 @@ describe('failClosedAfterStatusPersistenceFailure under the ownership fence', ()
 
 		expect(mockUpdateMany).toHaveBeenCalledWith({
 			where: { id: 'head-1', ownerEpoch: 3n },
-			data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null, reconciliationCompletedAt: null },
+			data: {
+				isEnabled: false,
+				initTxHash: null,
+				initChainSlot: null,
+				initChainHash: null,
+				reconciliationCompletedAt: null,
+			},
 		});
 	});
 

--- a/src/services/hydra-connection-manager/head-status-persistence.spec.ts
+++ b/src/services/hydra-connection-manager/head-status-persistence.spec.ts
@@ -129,7 +129,7 @@ describe('failClosedAfterStatusPersistenceFailure under the ownership fence', ()
 
 		expect(mockUpdateMany).toHaveBeenCalledWith({
 			where: { id: 'head-1', ownerEpoch: 3n },
-			data: { isEnabled: false, initTxHash: null, reconciliationCompletedAt: null },
+			data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null, reconciliationCompletedAt: null },
 		});
 	});
 

--- a/src/services/hydra-connection-manager/head-status-persistence.ts
+++ b/src/services/hydra-connection-manager/head-status-persistence.ts
@@ -240,6 +240,8 @@ export async function failClosedAfterStatusPersistenceFailure(
 					data: {
 						isEnabled: false,
 						initTxHash: null,
+						initChainSlot: null,
+						initChainHash: null,
 						reconciliationCompletedAt: null,
 					},
 				}),

--- a/src/services/hydra-connection-manager/hydra-connection-manager.service.spec.ts
+++ b/src/services/hydra-connection-manager/hydra-connection-manager.service.spec.ts
@@ -820,6 +820,8 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 			data: {
 				isEnabled: false,
 				initTxHash: null,
+				initChainSlot: null,
+				initChainHash: null,
 				reconciliationCompletedAt: null,
 			},
 		});
@@ -922,6 +924,8 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 			data: {
 				isEnabled: false,
 				initTxHash: null,
+				initChainSlot: null,
+				initChainHash: null,
 				reconciliationCompletedAt: null,
 			},
 		});
@@ -1125,6 +1129,8 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 			data: {
 				isEnabled: false,
 				initTxHash: null,
+				initChainSlot: null,
+				initChainHash: null,
 				reconciliationCompletedAt: null,
 			},
 		});
@@ -1179,12 +1185,14 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 			data: {
 				isEnabled: false,
 				initTxHash: null,
+				initChainSlot: null,
+				initChainHash: null,
 				reconciliationCompletedAt: null,
 			},
 		});
 		expect(mockHydraHeadUpdateMany).toHaveBeenNthCalledWith(2, {
 			where: { hydraRelationId: 'relation-1', id: { not: 'head-1' } },
-			data: { isEnabled: false, initTxHash: null },
+			data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 		});
 		expect(mockPaymentRequestUpdateMany).not.toHaveBeenCalled();
 		expect(mockPurchaseRequestUpdateMany).not.toHaveBeenCalled();
@@ -1307,7 +1315,7 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 		);
 		expect(mockHydraHeadUpdateMany).toHaveBeenNthCalledWith(2, {
 			where: { hydraRelationId: 'relation-1', id: { not: 'head-1' } },
-			data: { isEnabled: false, initTxHash: null },
+			data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 		});
 		const lockedHeadQuery = (
 			(mockQueryRaw.mock.calls[1]?.[0] as { strings?: readonly string[] } | undefined)?.strings ?? []
@@ -1367,7 +1375,7 @@ describe('HydraConnectionManager confirmed transaction output sync', () => {
 		expect(mockPrismaTransaction).toHaveBeenCalledTimes(2);
 		expect(mockHydraHeadUpdateMany).toHaveBeenLastCalledWith({
 			where: { hydraRelationId: 'relation-1', id: { not: 'head-1' } },
-			data: { isEnabled: false, initTxHash: null },
+			data: { isEnabled: false, initTxHash: null, initChainSlot: null, initChainHash: null },
 		});
 	});
 

--- a/src/services/hydra-init-backfill/index.ts
+++ b/src/services/hydra-init-backfill/index.ts
@@ -25,7 +25,9 @@ import { verifyPersistedHydraHeadOnChain } from '@/routes/api/hydra/head';
 const MAX_PER_CYCLE = 5;
 
 /**
- * One pass over heads that are live but have no recorded opening transaction.
+ * One pass over heads that are live but have no recorded opening transaction,
+ * or no chain-replay anchor yet (initChainSlot/initChainHash; heads verified
+ * before the anchor columns existed). Verification persists both.
  *
  * Only heads past Initializing are considered: before that there may genuinely
  * be no InitTx on chain yet, and asking would fail every cycle.
@@ -34,7 +36,7 @@ export async function backfillHydraInitTxHashes(): Promise<number> {
 	const heads = await prisma.hydraHead.findMany({
 		where: {
 			isEnabled: true,
-			initTxHash: null,
+			OR: [{ initTxHash: null }, { initChainSlot: null }],
 			headIdentifier: { not: null },
 			status: { in: [HydraHeadStatus.Open, HydraHeadStatus.Closed, HydraHeadStatus.FanoutPossible] },
 		},


### PR DESCRIPTION
## What

Store the chain-replay anchor for each Hydra head: `initChainSlot` + `initChainHash` on `HydraHead`, the block point immediately BEFORE the block that carries the InitTx.

A hydra-node that loses its persistence can only re-observe its head from L1 when restarted with `--start-chain-from` set to a point before the InitTx block. The DB stored `initTxHash` but no such point, so persistence-loss recovery depended on operators reconstructing the anchor by hand.

## How

- The anchor rides the existing independent L1 evidence pass: `verifyPersistedHydraHeadOnChain` resolves the InitTx block's parent point via the same Blockfrost observer and persists it together with `initTxHash` in the same guarded update.
- The anchor pass is best-effort: it runs under the shared 15s observer timeout, and any transient failure yields null instead of failing a verification that already proved the InitTx. The init backfill service retries null anchors on its next cycle, and now also heals heads verified before the columns existed.
- The anchor of an L1-confirmed InitTx block is immutable, so verification skips the lookups once `initChainSlot` is stored (top-up, decommit, and commit all pass through this verification).
- Every rollback, quarantine, and disable path that clears `initTxHash` clears the anchor with it: a deep L1 rollback can move the InitTx to a different block, and a stale anchor would silently point recovery at the wrong branch.

## Why (verified live)

Live preprod verification with hydra-node 2.3.0 over Blockfrost (full report: `docs/hydra-persistence-recovery-verification.md`, VERIFIED/INFERRED tags per claim):

- A BOTH-SIDES persistence wipe replayed from this anchor reconstructed the last increment's signed snapshot (multisignatures recovered from the IncrementTx redeemer), resumed normal L2 operation with a fresh signed snapshot, and closed plus fanned out with zero funds lost (fanout `25498000830d00…`, preprod).
- Without the anchor, a wiped node stays `Idle` and cannot see its own open head.

## Testing

- `head-init-validation.spec.ts`: 7 new tests for `resolveHydraInitChainAnchor` (parent-point resolution, null previous-block/slot edges, malformed-hash rejection, transient-failure → null, timeout → null); suite `17 passed`.
- Connection-manager, close-head, and status-persistence suites updated for the anchor-clearing payloads: `122 passed` + `22 passed`.
- `tsc --noEmit` 0 errors, ESLint clean.
- Migration `20260826000000_hydra_init_chain_anchor` (two nullable columns) applied against a seeded Postgres.

Review: ultrareview ran on this branch (base `dev`); all three findings are addressed in the third commit.
