### PR TITLE
docs(x402): record key-scoped spend caps in ADR 0016

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,12 +132,13 @@ registry entries may advertise x402 options.
 
 The standard EVM x402 rail implemented by `@masumi/payment-source-x402`.
 It is separate from Cardano `PaymentSourceType` and stores its own
-networks, managed EVM wallets, budgets, attempts, and settlements.
+networks, managed EVM wallets, attempts, and settlements.
 
 The rail has two sides. The buy side signs a payment for a 402 the
-caller forwards, charges a managed wallet budget, and returns the
-`X-PAYMENT` header for the caller's agent to send with its own request;
-the service never fetches the resource itself. The sell side is an x402
+caller forwards, debits the calling key's usage credits when the key is
+usage limited, and returns the `X-PAYMENT` header for the caller's agent
+to send with its own request; the service never fetches the resource
+itself. The sell side is an x402
 facilitator that verifies and settles inbound payments for a registered
 resource, with settlement replay bound to that source.
 
@@ -159,9 +160,14 @@ transactions; it is not the standard EVM x402 HTTP payment protocol.
 An encrypted private-key wallet stored in `X402EvmWallet` and used by the
 standard x402 rail. Managed EVM wallets are separate from Cardano
 `HotWallet` / `WalletSecret` rows. API keys with `canAdmin` can manage
-wallets, network configuration, and budgets; API keys with `canPay` can
-spend through a managed wallet only when their CAIP-2 chain limit and
-wallet budget allow it.
+wallets and network configuration; API keys with `canPay` can spend
+through a managed wallet only when their CAIP-2 chain limit and wallet
+scope allow it, capped by their usage credits when the key is usage
+limited. Spend caps live on the API key (the Cardano model), never on
+the wallet.
+
+Avoid: budget, wallet budget (removed concepts — a cap is Usage
+Credits on the key; wallet access is the key's wallet scope).
 
 ### Hydra Head
 

--- a/docs/adr/0008-standard-evm-x402-payment-rail.md
+++ b/docs/adr/0008-standard-evm-x402-payment-rail.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted.
+Accepted. Decision 2 (per-wallet budgets) is amended by
+[ADR 0016](0016-x402-key-scoped-spend-caps.md): spend caps are per-API-key
+usage credits; `X402WalletBudget` and `/x402/budgets` no longer exist.
 
 ## Context
 

--- a/docs/adr/0016-x402-key-scoped-spend-caps.md
+++ b/docs/adr/0016-x402-key-scoped-spend-caps.md
@@ -1,0 +1,43 @@
+# 0016: x402 spend caps live on the API key, not on the wallet
+
+## Status
+
+Accepted. Amends ADR 0008 decision 2: the rail-specific "wallet budgets"
+table is removed.
+
+## Context
+
+ADR 0008 gave the x402 rail a per-`(API key, wallet, asset)` budget table
+(`X402WalletBudget`). In practice one row carried two unrelated meanings
+at once: a spend cap, and an implicit delegation that let a non-owner key
+spend from a foreign wallet. The Cardano rail has neither concept on the
+wallet: a key's cap is its global usage-credit ledger
+(`ApiKey.usageLimited` + `UnitValue` rows), and wallet access is the
+key's wallet scope. Running both models side by side produced three caps
+on one payment (budget, credits, on-chain balance) and integration bugs
+in clients that had to reason about which cap binds when.
+
+## Decision
+
+Mirror Cardano exactly. The key-global usage-credit ledger (units
+`eip155:<chainId>:<asset>`) is the only x402 spend cap; a non-admin key
+reaches a wallet only through ownership (`createdById`) or its
+`ApiKeyX402WalletScope` list, while an admin key (`canAdmin`) stays
+unrestricted. `X402WalletBudget` and
+`GET/POST /x402/budgets` are removed outright, with no compatibility
+shim. The migration converts each enabled budget into a wallet-scope
+assignment (access survives) and deliberately does NOT convert budget
+remainders into credits: `usageLimited` is shared with the Cardano rail,
+and flipping it on budget-holding keys would start failing their Cardano
+purchases. A key that was capped only by a wallet budget is uncapped
+after the migration until an operator grants it usage credits.
+
+## Consequences
+
+- A per-wallet cap can no longer be expressed. The cap dimension is
+  per-key per-`(chain, asset)`.
+- Clients that read `/x402/budgets` (the dashboard's Budgets tab,
+  Sokosumi's buy-side readiness sync) must move to `api-key-status`
+  usage credits plus wallet scopes.
+- The rail-readiness `x402.budget` check is removed; the check list ends
+  at `x402.purchasing_wallet`, matching the Cardano rail's list.

--- a/docs/migrations/x402-key-scoped-spend-caps.md
+++ b/docs/migrations/x402-key-scoped-spend-caps.md
@@ -1,0 +1,61 @@
+# Upgrade note — x402 spend caps move to the API key
+
+`prisma/migrations/20260826010000_x402_key_scoped_spend_caps/migration.sql` drops
+the `X402WalletBudget` table. Read this before you deploy the release that
+contains it. See [ADR 0016](../adr/0016-x402-key-scoped-spend-caps.md) for the
+reasoning.
+
+## What changes
+
+| Before                                                                    | After                                                                                      |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| A budget row capped what one API key could spend from one managed wallet. | The API key's usage credits are the only node-side cap.                                    |
+| A budget row also granted that key access to a wallet it did not create.  | `ApiKeyX402WalletScope` is the only wallet-access grant.                                   |
+| `GET /x402/budgets`, `POST /x402/budgets`                                 | Removed. The endpoints return 404.                                                         |
+| Rail readiness reported `x402.budget`.                                    | That check is gone. The x402 list ends at the purchasing wallet, as the Cardano list does. |
+
+## What the migration does to your data
+
+1. **Access is preserved.** Each enabled budget becomes a wallet-scope row when
+   the key runs scoped (`x402WalletScopeEnabled`), is not an admin key, and both
+   the key and the wallet are live. An unscoped key already reaches every wallet,
+   so it gets no row.
+2. **Caps are dropped on purpose.** Budget remainders are NOT converted into
+   usage credits, and `usageLimited` is NOT switched on. That flag is shared with
+   the Cardano rail: switching it on would start failing the same key's Cardano
+   purchases until Cardano credits were granted.
+
+**Consequence:** a key that was capped only by a wallet budget spends uncapped
+after the upgrade, bounded only by the wallet's on-chain balance. The node logs
+nothing at upgrade time. Restore the cap yourself with step 2 below.
+
+## After you deploy
+
+1. List the keys that had a budget before the upgrade. Take this from your
+   pre-deploy snapshot, since the table is gone afterwards:
+   ```sql
+   SELECT "apiKeyId", "evmWalletId", "caip2Network", "asset", "remainingAmount"
+   FROM "X402WalletBudget" WHERE "enabled" = true;
+   ```
+2. Grant each key the equivalent usage credits and cap it:
+   ```http
+   PATCH /api/v1/api-key
+   { "id": "<apiKeyId>",
+     "usageLimited": true,
+     "UsageCredits": [{ "unit": "eip155:8453:0x<token address>", "amount": "<atomic amount>" }] }
+   ```
+   The unit is `eip155:<chainId>:<asset address, lowercased>`. The amount is in
+   the token's smallest unit.
+3. Check the wallet grants that the migration wrote:
+   ```sql
+   SELECT "apiKeyId", "evmWalletId" FROM "ApiKeyX402WalletScope" WHERE "id" LIKE 'mig_%';
+   ```
+
+A usage-limited key with no `eip155:` credit row at all stays uncapped and logs a
+warning on each payment. This is deliberate: it keeps Cardano-only keys working.
+
+## Rollback
+
+The migration drops a table, so it is not reversible. Roll back by restoring the
+pre-deploy dump. Wallet-scope rows written by the migration carry a `mig_` id
+prefix and can be deleted individually if you only need to undo the grants.

--- a/docs/x402.md
+++ b/docs/x402.md
@@ -12,13 +12,13 @@ dashboard, the HTTP API, and a first-run setup walkthrough.
 
 ## Concepts
 
-| Term                             | Meaning                                                                                                                                                                                                                                     |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Managed EVM wallet**           | An EVM keypair created (or imported) through the service. The private key is encrypted at rest; a generated key is returned once for backup, while an imported key is never echoed. It signs outbound payments and settles inbound ones.    |
-| **Chain / network**              | An EVM chain identified by its CAIP-2 id (`eip155:8453` = Base mainnet). Base mainnet and Base Sepolia are seeded. A chain needs either an owned facilitator wallet or a remote facilitator endpoint before it can settle inbound payments. |
-| **Facilitator**                  | The owned Selling wallet or remote HTTPS service that verifies and settles inbound x402 payments. An owned wallet pays gas locally; a remote facilitator manages its own signer. This is the **sell side**.                                 |
-| **Budget**                       | A per-`(API key, wallet, chain, token)` spendable cap. The buy side debits it atomically when it signs a payment. This is the **buy side**.                                                                                                 |
-| **Payment attempt / settlement** | Audit records of every verify / settle / sign, and the on-chain settlement result.                                                                                                                                                          |
+| Term                             | Meaning                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Managed EVM wallet**           | An EVM keypair created (or imported) through the service. The private key is encrypted at rest; a generated key is returned once for backup, while an imported key is never echoed. It signs outbound payments and settles inbound ones.                                                                                                                                          |
+| **Chain / network**              | An EVM chain identified by its CAIP-2 id (`eip155:8453` = Base mainnet). Base mainnet and Base Sepolia are seeded. A chain needs either an owned facilitator wallet or a remote facilitator endpoint before it can settle inbound payments.                                                                                                                                       |
+| **Facilitator**                  | The owned Selling wallet or remote HTTPS service that verifies and settles inbound x402 payments. An owned wallet pays gas locally; a remote facilitator manages its own signer. This is the **sell side**.                                                                                                                                                                       |
+| **Usage credits**                | The per-API-key spend cap, shared with the Cardano rail (`ADR 0016`). EVM credits use `eip155:<chainId>:<asset>` units. When the key is usage limited, the buy side debits them atomically at signing. A usage-limited key with no `eip155:` credit row at all is not capped: the node logs a warning and signs, which keeps Cardano-only keys working. This is the **buy side**. |
+| **Payment attempt / settlement** | Audit records of every verify / settle / sign, and the on-chain settlement result.                                                                                                                                                                                                                                                                                                |
 
 ### Two sides
 
@@ -27,9 +27,10 @@ dashboard, the HTTP API, and a first-run setup walkthrough.
   chain's configured facilitator. Requires either an owned Selling wallet or a
   remote facilitator endpoint.
 - **Buy side (pay others):** your agent receives a `402 Payment Required` from
-  another resource, forwards it to `/x402/pay`; the service signs it against a
-  managed wallet **budget** and returns an `X-PAYMENT` header your agent replays
-  with its own request. The service never fetches the resource itself.
+  another resource, forwards it to `/x402/pay`; the service signs it with a
+  managed wallet — debiting the key's **usage credits** when the key is usage
+  limited — and returns an `X-PAYMENT` header your agent replays with its own
+  request. The service never fetches the resource itself.
 
 ## Admin dashboard
 
@@ -42,11 +43,17 @@ Open **x402** in the admin sidebar (`/x402`). When the rail is not yet usable, a
   preconfigured.
 - **Wallets** — create a managed wallet (generate a fresh key or import a
   `0x`-prefixed 32-byte hex key), copy its address to fund it, or retire it.
-  Retiring disables its budgets and detaches it from any chain it facilitates.
-- **Budgets** — grant an API key a spend cap on a `(wallet, chain, token)`. The
-  asset prefills from the chain's default token.
+  Retiring detaches it from any chain it facilitates.
+- **Alerts** — low-balance rules for managed wallets.
 - **Payments** — the audit trail of payment attempts and settlements, filterable
   by status, direction, and chain.
+
+Per-API-key spend caps (usage credits in `eip155:<chainId>:<asset>` units) are
+managed through the API key endpoints (`PATCH /api/v1/api-key`); EVM wallet
+scoping is set on the **API keys** page. Upgrading a node that still has
+per-wallet budgets? Read
+[docs/migrations/x402-key-scoped-spend-caps.md](./migrations/x402-key-scoped-spend-caps.md)
+first: the migration keeps wallet access and drops the caps.
 
 To **advertise** an x402 price on one of your agents, use the EVM x402 options in
 the agent **Register / Edit** dialog (V2 registry entries only). That writes an
@@ -60,20 +67,19 @@ header (see [API Authentication](../CLAUDE.md)).
 
 ### Payment operations — `ReadAndPay` (`canPay`)
 
-| Method & path                                                                                                  | Purpose                                                                                                                                      |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /x402/verify`                                                                                            | Verify a buyer's signed payment payload against a registered supported payment source. Does not move funds.                                  |
-| `POST /x402/settle`                                                                                            | Settle a verified payment on-chain through the chain's facilitator. Idempotent per payment payload (replays return the recorded settlement). |
-| `POST /x402/pay`                                                                                               | Sign an outbound payment for a forwarded `402`. Debits a managed-wallet budget and returns the `X-PAYMENT` header.                           |
-| `GET /x402/networks/available`                                                                                 | List the permitted safe network projection, including the opaque `id` required to create a wallet.                                           |
-| `GET/POST /x402/wallets`, `GET /x402/wallets/detail`, `POST /x402/wallets/update`, `POST /x402/wallets/delete` | Manage wallets owned by the API key on its permitted networks.                                                                               |
+| Method & path                                                                                                  | Purpose                                                                                                                                                   |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /x402/verify`                                                                                            | Verify a buyer's signed payment payload against a registered supported payment source. Does not move funds.                                               |
+| `POST /x402/settle`                                                                                            | Settle a verified payment on-chain through the chain's facilitator. Idempotent per payment payload (replays return the recorded settlement).              |
+| `POST /x402/pay`                                                                                               | Sign an outbound payment for a forwarded `402`. Debits the calling key's usage credits when the key is usage limited, and returns the `X-PAYMENT` header. |
+| `GET /x402/networks/available`                                                                                 | List the permitted safe network projection, including the opaque `id` required to create a wallet.                                                        |
+| `GET/POST /x402/wallets`, `GET /x402/wallets/detail`, `POST /x402/wallets/update`, `POST /x402/wallets/delete` | Manage wallets owned by the API key on its permitted networks.                                                                                            |
 
 ### Rail management — `Admin` (`canAdmin`)
 
 | Method & path                                 | Purpose                                                                                              |
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `GET/POST /x402/networks`                     | List the full operator projection and upsert chains (including RPC, facilitator, and default asset). |
-| `GET/POST /x402/budgets`                      | List and set per-API-key spend budgets.                                                              |
 | `GET /x402/payments`, `GET /x402/settlements` | Paginated audit records.                                                                             |
 
 > Amounts are unsigned-integer **strings** in the token's base units (e.g. USDC
@@ -97,9 +103,12 @@ token: <pay-capable api key>
 ```
 
 The response includes `xPaymentHeader` — replay it as the `X-PAYMENT` header on
-your agent's retried request to the resource. The budget is debited at signing
-time (a signature is a spendable authorization); it is **not** refunded if your
-agent abandons the request.
+your agent's retried request to the resource. For a usage-limited key, the usage
+credits are debited at signing time (a signature is a spendable authorization);
+they are **not** refunded if your agent abandons the request.
+A usage-limited key that holds no `eip155:` credit row is uncapped: the node
+logs a warning and signs anyway. Grant EVM credits to that key to activate the
+cap.
 
 ### Example — sell side (`/x402/verify` then `/x402/settle`)
 
@@ -116,7 +125,7 @@ token: <pay-capable api key>
 
 `settle` returns `{ replay, settleResponse: { success, transaction, ... } }`.
 For fixed pricing, `paymentRequirements` may be omitted because the registry is
-authoritative — and a *supplied* `paymentRequirements` is ignored for fixed
+authoritative — and a _supplied_ `paymentRequirements` is ignored for fixed
 sources (the registry values are used; no mismatch error is raised). The signed
 buyer payload is still checked field-by-field against the registry values.
 For dynamic pricing it is required and must be supplied by the
@@ -143,13 +152,15 @@ The dashboard setup guide automates this; the order matters either way.
    intend to spend.
 3. **Assign a facilitator** (sell side): `Chains` tab → edit Base → choose an
    owned Selling wallet or a remote HTTPS facilitator, then keep _Enabled_ on.
-4. **Set a budget** (buy side): `Budgets` tab → _Set budget_ → pick the API key,
-   wallet, chain, token, and amount (base units).
+4. **Cap spending** (optional, buy side): grant the paying API key usage
+   credits in `eip155:<chainId>:<asset>` units and mark it usage limited
+   (`PATCH /api/v1/api-key`). An unlimited key spends up to the wallet's
+   on-chain balance.
 5. **Advertise a price** (sell side): add an EVM x402 option when registering /
    editing a V2 agent so buyers know how to pay it.
 
-You only need the steps for the side(s) you use — facilitator for receiving,
-budget for paying. Once a wallet plus at least one side exists, the setup guide
+You only need the steps for the side(s) you use — facilitator for receiving, a
+Purchasing wallet for paying. Once at least one side exists, the setup guide
 hides itself.
 
 ## Operational notes
@@ -159,6 +170,5 @@ hides itself.
   losing it makes the wallets unrecoverable.
 - **RPC URLs** are validated against private/loopback/link-local hosts and
   checked to actually serve the declared chain id before any signing/settling.
-- **Retiring a wallet** is a soft-delete: it disables the wallet's budgets and
-  detaches it from any chain it facilitates, so a compromised key can no longer
-  sign or settle.
+- **Retiring a wallet** is a soft-delete: it detaches the wallet from any chain
+  it facilitates, so a compromised key can no longer sign or settle.


### PR DESCRIPTION
# Pull Request Template

## **Purpose of this Pull Request**

[x] Documentation update

## **Overview of Changes**

Records the key-scoped spend-cap decision from the base PR of this stack:

- Adds ADR 0016 (amends ADR 0008 decision 2) and points ADR 0008's status line at it.
- Updates `docs/x402.md`: the concepts table, endpoint tables, and setup walkthrough now describe usage credits (`PATCH /api/v1/api-key`, `eip155:<chainId>:<asset>` units) instead of wallet budgets.
- Refreshes the `CONTEXT.md` glossary: budget and wallet budget are marked as removed concepts.
- Adds `docs/migrations/x402-key-scoped-spend-caps.md`, the operator upgrade note: the migration keeps wallet access and drops the caps, so an operator who relied on wallet budgets has to re-grant usage credits. `docs/x402.md` links it.

## **Issue Addressed**

None.

## **Checklist**

- [x] I have used `lint` and `format` to follow the code formatting
- [x] I have tested my changes locally and all of them pass
- [x] I have updated documentation (if applicable).

## **Focus for Reviewers**

ADR 0016's consequences section: it names the open follow-ups (EVM credit inputs in the API key dialogs; the Sokosumi readiness-sync rework).
