### PR TITLE
feat(reports): add the report domain model and aggregation

### DIFF
--- a/src/services/transaction-report/access.spec.ts
+++ b/src/services/transaction-report/access.spec.ts
@@ -1,0 +1,246 @@
+import { jest } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { HotWalletType, Network, PaymentSourceType } from '@/generated/prisma/client';
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+const mockPaymentSourceFindFirst = jest.fn() as AnyMock;
+const mockPaymentSourceFindMany = jest.fn() as AnyMock;
+const mockHotWalletFindMany = jest.fn() as AnyMock;
+
+jest.unstable_mockModule('@masumi/payment-core/db', () => ({
+	prisma: {
+		paymentSource: {
+			findFirst: mockPaymentSourceFindFirst,
+			findMany: mockPaymentSourceFindMany,
+		},
+		hotWallet: {
+			findMany: mockHotWalletFindMany,
+		},
+	},
+}));
+
+const {
+	listAccessibleReportFacets,
+	MAX_REPORT_FACET_ROWS,
+	resolveAccessibleReportSource,
+	resolveAuthorizedManagedWalletIds,
+} = await import('./access');
+
+function authContext(overrides: Partial<AuthContext> = {}): AuthContext {
+	return {
+		id: 'api-key-1',
+		canRead: true,
+		canPay: false,
+		canAdmin: false,
+		networkLimit: [Network.Preprod],
+		caip2NetworkLimit: ['cardano:preprod'],
+		usageLimited: false,
+		walletScopeIds: null,
+		x402WalletScopeIds: null,
+		...overrides,
+	};
+}
+
+function source(deletedAt: Date | null = null) {
+	return {
+		id: 'source-1',
+		createdAt: new Date('2026-01-01T00:00:00.000Z'),
+		network: Network.Preprod,
+		paymentSourceType: PaymentSourceType.Web3CardanoV1,
+		smartContractAddress: 'addr_test1contract',
+		feeRatePermille: 50,
+		deletedAt,
+	};
+}
+
+describe('resolveAccessibleReportSource', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it.each([
+		['active', null],
+		['archived', new Date('2026-02-01T00:00:00.000Z')],
+	] as const)('returns an accessible %s source', async (_label, deletedAt) => {
+		mockPaymentSourceFindFirst.mockResolvedValue(source(deletedAt));
+
+		await expect(resolveAccessibleReportSource(authContext(), 'source-1')).resolves.toEqual(source(deletedAt));
+		const query = mockPaymentSourceFindFirst.mock.calls[0][0] as { where: Record<string, unknown> };
+		expect(query.where).toEqual({ id: 'source-1', network: { in: [Network.Preprod] } });
+		expect(query.where).not.toHaveProperty('deletedAt');
+	});
+
+	it('uses one generic 404 for an absent or wrong-network source', async () => {
+		mockPaymentSourceFindFirst.mockResolvedValue(null);
+
+		await expect(resolveAccessibleReportSource(authContext(), 'missing-source')).rejects.toMatchObject({
+			statusCode: 404,
+			message: 'Not found',
+		});
+		await expect(
+			resolveAccessibleReportSource(authContext({ networkLimit: [Network.Mainnet] }), 'source-1'),
+		).rejects.toMatchObject({ statusCode: 404, message: 'Not found' });
+	});
+});
+
+describe('resolveAuthorizedManagedWalletIds', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockPaymentSourceFindFirst.mockResolvedValue(source());
+	});
+
+	it('keeps an unrestricted source unrestricted when no wallet filter is requested', async () => {
+		await expect(resolveAuthorizedManagedWalletIds(authContext(), 'source-1')).resolves.toBeNull();
+		expect(mockHotWalletFindMany).not.toHaveBeenCalled();
+	});
+
+	it('returns scoped wallets that belong to the source, including deleted wallets', async () => {
+		mockHotWalletFindMany.mockResolvedValue([{ id: 'wallet-active' }, { id: 'wallet-deleted' }]);
+
+		await expect(
+			resolveAuthorizedManagedWalletIds(
+				authContext({ walletScopeIds: ['wallet-active', 'wallet-deleted', 'other-source-wallet'] }),
+				'source-1',
+			),
+		).resolves.toEqual(['wallet-active', 'wallet-deleted']);
+
+		const query = mockHotWalletFindMany.mock.calls[0][0] as { where: Record<string, unknown> };
+		expect(query.where).toEqual({
+			paymentSourceId: 'source-1',
+			id: { in: ['wallet-active', 'wallet-deleted', 'other-source-wallet'] },
+			type: { in: [HotWalletType.Selling, HotWalletType.Purchasing] },
+		});
+		expect(query.where).not.toHaveProperty('deletedAt');
+	});
+
+	it('accepts an explicitly requested deleted wallet in scope', async () => {
+		mockPaymentSourceFindFirst.mockResolvedValue(source(new Date('2026-02-01T00:00:00.000Z')));
+		mockHotWalletFindMany.mockResolvedValue([{ id: 'wallet-deleted' }]);
+
+		await expect(
+			resolveAuthorizedManagedWalletIds(authContext({ walletScopeIds: ['wallet-deleted'] }), 'source-1', [
+				'wallet-deleted',
+			]),
+		).resolves.toEqual(['wallet-deleted']);
+	});
+
+	it('rejects a Funding wallet because fund transfers are outside transaction reports', async () => {
+		mockHotWalletFindMany.mockResolvedValue([]);
+
+		await expect(
+			resolveAuthorizedManagedWalletIds(authContext(), 'source-1', ['funding-wallet']),
+		).rejects.toMatchObject({ statusCode: 404, message: 'Not found' });
+		expect(mockHotWalletFindMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					type: { in: [HotWalletType.Selling, HotWalletType.Purchasing] },
+				}),
+			}),
+		);
+	});
+
+	it('uses the generic 404 when an explicit wallet is outside the key scope', async () => {
+		await expect(
+			resolveAuthorizedManagedWalletIds(authContext({ walletScopeIds: ['wallet-allowed'] }), 'source-1', [
+				'wallet-denied',
+			]),
+		).rejects.toMatchObject({ statusCode: 404, message: 'Not found' });
+		expect(mockHotWalletFindMany).not.toHaveBeenCalled();
+	});
+
+	it('uses the generic 404 when an explicit wallet belongs to another source', async () => {
+		mockHotWalletFindMany.mockResolvedValue([]);
+
+		await expect(
+			resolveAuthorizedManagedWalletIds(authContext(), 'source-1', ['other-source-wallet']),
+		).rejects.toMatchObject({ statusCode: 404, message: 'Not found' });
+	});
+
+	it('does not query wallets when the source is outside the allowed network', async () => {
+		mockPaymentSourceFindFirst.mockResolvedValue(null);
+
+		await expect(
+			resolveAuthorizedManagedWalletIds(
+				authContext({ networkLimit: [Network.Mainnet], walletScopeIds: ['wallet-deleted'] }),
+				'source-1',
+				['wallet-deleted'],
+			),
+		).rejects.toMatchObject({ statusCode: 404, message: 'Not found' });
+		expect(mockHotWalletFindMany).not.toHaveBeenCalled();
+	});
+});
+
+describe('listAccessibleReportFacets', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('lists active and archived sources plus active and deleted scoped wallets', async () => {
+		const archivedSource = { ...source(new Date('2026-02-01T00:00:00.000Z')), id: 'source-archived' };
+		const wallets = [
+			{
+				id: 'wallet-active',
+				createdAt: new Date('2026-01-02T00:00:00.000Z'),
+				paymentSourceId: 'source-1',
+				type: HotWalletType.Selling,
+				walletAddress: 'addr_test1active',
+				walletVkey: 'vkey-active',
+				collectionAddress: null,
+				note: null,
+				deletedAt: null,
+			},
+			{
+				id: 'wallet-deleted',
+				createdAt: new Date('2026-01-03T00:00:00.000Z'),
+				paymentSourceId: 'source-archived',
+				type: HotWalletType.Purchasing,
+				walletAddress: 'addr_test1deleted',
+				walletVkey: 'vkey-deleted',
+				collectionAddress: null,
+				note: 'old wallet',
+				deletedAt: new Date('2026-02-02T00:00:00.000Z'),
+			},
+		];
+		mockPaymentSourceFindMany.mockResolvedValue([source(), archivedSource]);
+		mockHotWalletFindMany.mockResolvedValue(wallets);
+
+		await expect(
+			listAccessibleReportFacets(authContext({ walletScopeIds: ['wallet-active', 'wallet-deleted'] })),
+		).resolves.toEqual({ paymentSources: [source(), archivedSource], managedWallets: wallets });
+
+		const sourceQuery = mockPaymentSourceFindMany.mock.calls[0][0] as {
+			where: Record<string, unknown>;
+			take: number;
+		};
+		expect(sourceQuery.where).toEqual({ network: { in: [Network.Preprod] } });
+		expect(sourceQuery.take).toBe(MAX_REPORT_FACET_ROWS + 1);
+		expect(sourceQuery.where).not.toHaveProperty('deletedAt');
+
+		const walletQuery = mockHotWalletFindMany.mock.calls[0][0] as {
+			where: Record<string, unknown>;
+			take: number;
+		};
+		expect(walletQuery.where).toEqual({
+			type: { in: [HotWalletType.Selling, HotWalletType.Purchasing] },
+			PaymentSource: { network: { in: [Network.Preprod] } },
+			id: { in: ['wallet-active', 'wallet-deleted'] },
+		});
+		expect(walletQuery.take).toBe(MAX_REPORT_FACET_ROWS + 1);
+		expect(walletQuery.where).not.toHaveProperty('deletedAt');
+	});
+
+	it.each([
+		['payment sources', mockPaymentSourceFindMany, mockHotWalletFindMany],
+		['managed wallets', mockHotWalletFindMany, mockPaymentSourceFindMany],
+	] as const)('rejects oversized %s facets before serialization', async (_label, oversizedQuery, otherQuery) => {
+		oversizedQuery.mockResolvedValue(Array.from({ length: MAX_REPORT_FACET_ROWS + 1 }, () => source()));
+		otherQuery.mockResolvedValue([]);
+
+		await expect(listAccessibleReportFacets(authContext())).rejects.toMatchObject({
+			statusCode: 413,
+			message: `Report facets exceed ${MAX_REPORT_FACET_ROWS} rows`,
+		});
+	});
+});

--- a/src/services/transaction-report/access.ts
+++ b/src/services/transaction-report/access.ts
@@ -1,0 +1,109 @@
+import createHttpError from 'http-errors';
+import { prisma } from '@masumi/payment-core/db';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { HotWalletType, type Prisma } from '@/generated/prisma/client';
+
+export type ReportAccessClient = Pick<Prisma.TransactionClient, 'paymentSource' | 'hotWallet'>;
+
+export const MAX_REPORT_FACET_ROWS = 10_000;
+
+const paymentSourceSelect = {
+	id: true,
+	createdAt: true,
+	network: true,
+	paymentSourceType: true,
+	smartContractAddress: true,
+	feeRatePermille: true,
+	deletedAt: true,
+} as const;
+
+const managedWalletSelect = {
+	id: true,
+	createdAt: true,
+	paymentSourceId: true,
+	type: true,
+	walletAddress: true,
+	walletVkey: true,
+	collectionAddress: true,
+	note: true,
+	deletedAt: true,
+} as const;
+
+function notFound(): never {
+	throw createHttpError(404, 'Not found');
+}
+
+export async function resolveAccessibleReportSource(
+	ctx: AuthContext,
+	paymentSourceId: string,
+	database: ReportAccessClient = prisma,
+) {
+	const paymentSource = await database.paymentSource.findFirst({
+		where: {
+			id: paymentSourceId,
+			network: { in: ctx.networkLimit },
+		},
+		select: paymentSourceSelect,
+	});
+
+	return paymentSource ?? notFound();
+}
+
+export async function resolveAuthorizedManagedWalletIds(
+	ctx: AuthContext,
+	paymentSourceId: string,
+	requestedIds?: readonly string[],
+	database: ReportAccessClient = prisma,
+): Promise<string[] | null> {
+	await resolveAccessibleReportSource(ctx, paymentSourceId, database);
+
+	const uniqueRequestedIds = requestedIds == null ? null : Array.from(new Set(requestedIds));
+	if (uniqueRequestedIds == null && ctx.walletScopeIds === null) return null;
+
+	const candidateIds = uniqueRequestedIds ?? ctx.walletScopeIds ?? [];
+	if (ctx.walletScopeIds !== null) {
+		const walletScope = new Set(ctx.walletScopeIds);
+		if (candidateIds.some((id) => !walletScope.has(id))) notFound();
+	}
+
+	if (candidateIds.length === 0) return [];
+	const wallets = await database.hotWallet.findMany({
+		where: {
+			paymentSourceId,
+			id: { in: candidateIds },
+			type: { in: [HotWalletType.Selling, HotWalletType.Purchasing] },
+		},
+		select: { id: true },
+	});
+	const foundIds = new Set(wallets.map((wallet) => wallet.id));
+	if (uniqueRequestedIds != null && uniqueRequestedIds.some((id) => !foundIds.has(id))) notFound();
+
+	return candidateIds.filter((id) => foundIds.has(id));
+}
+
+export async function listAccessibleReportFacets(ctx: AuthContext) {
+	const walletScopeFilter = ctx.walletScopeIds === null ? {} : { id: { in: ctx.walletScopeIds } };
+	const [paymentSources, managedWallets] = await Promise.all([
+		prisma.paymentSource.findMany({
+			where: { network: { in: ctx.networkLimit } },
+			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+			select: paymentSourceSelect,
+			take: MAX_REPORT_FACET_ROWS + 1,
+		}),
+		prisma.hotWallet.findMany({
+			where: {
+				type: { in: [HotWalletType.Selling, HotWalletType.Purchasing] },
+				PaymentSource: { network: { in: ctx.networkLimit } },
+				...walletScopeFilter,
+			},
+			orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+			select: managedWalletSelect,
+			take: MAX_REPORT_FACET_ROWS + 1,
+		}),
+	]);
+	if (paymentSources.length > MAX_REPORT_FACET_ROWS || managedWallets.length > MAX_REPORT_FACET_ROWS) {
+		throw createHttpError(413, `Report facets exceed ${MAX_REPORT_FACET_ROWS} rows`);
+	}
+
+	return { paymentSources, managedWallets };
+}

--- a/src/services/transaction-report/aggregate-amounts.ts
+++ b/src/services/transaction-report/aggregate-amounts.ts
@@ -1,0 +1,46 @@
+import {
+	accumulateAmounts,
+	createAmountAccumulator,
+	materializeAmounts,
+	type AmountAccumulator,
+	type AtomicAmount,
+} from './amounts';
+import type { ReportAggregate, ReportAggregateMetric, ReportMetricCompleteness } from './aggregate';
+
+const metricAmounts = new WeakMap<ReportAggregateMetric, AmountAccumulator>();
+
+function getMetricAccumulator(metric: ReportAggregateMetric): AmountAccumulator {
+	const existing = metricAmounts.get(metric);
+	if (existing != null) return existing;
+	const accumulator = createAmountAccumulator();
+	accumulateAmounts(accumulator, metric.amounts);
+	metricAmounts.set(metric, accumulator);
+	return accumulator;
+}
+
+export function createAggregateMetric(): ReportAggregateMetric {
+	const metric = { amounts: [], completeness: 'complete' } satisfies ReportAggregateMetric;
+	metricAmounts.set(metric, createAmountAccumulator());
+	return metric;
+}
+
+export function addAggregateMetric(
+	metric: ReportAggregateMetric,
+	amounts: readonly AtomicAmount[] | null,
+	completeness: ReportMetricCompleteness = 'complete',
+): void {
+	if (amounts != null) accumulateAmounts(getMetricAccumulator(metric), amounts);
+	if (amounts == null || completeness === 'partial') metric.completeness = 'partial';
+}
+
+export function readAggregateMetricAmounts(metric: ReportAggregateMetric): AtomicAmount[] {
+	return materializeAmounts(getMetricAccumulator(metric));
+}
+
+export function finalizeReportAggregate(aggregate: ReportAggregate): void {
+	for (const value of Object.values(aggregate)) {
+		if (typeof value === 'object' && value != null && metricAmounts.has(value)) {
+			value.amounts = readAggregateMetricAmounts(value);
+		}
+	}
+}

--- a/src/services/transaction-report/aggregate-counts.ts
+++ b/src/services/transaction-report/aggregate-counts.ts
@@ -1,0 +1,56 @@
+import type { ReportMetricWindow, ReportRow } from './records';
+
+type ReportDateBasis = ReportMetricWindow['dateBasis'];
+
+function isDateInRange(value: Date | null, from: Date, to: Date): boolean {
+	return value != null && value.getTime() >= from.getTime() && value.getTime() < to.getTime();
+}
+
+export function getKnownReportTransactionDates(row: ReportRow): Date[] {
+	return row.transactions.flatMap((transaction) => {
+		if (
+			transaction.status !== 'Confirmed' ||
+			transaction.txHash == null ||
+			transaction.blockTime == null ||
+			!Number.isSafeInteger(transaction.blockTime) ||
+			transaction.blockTime < 0
+		) {
+			return [];
+		}
+		const date = new Date(transaction.blockTime * 1000);
+		return Number.isNaN(date.getTime()) ? [] : [date];
+	});
+}
+
+function hasKnownDateMembership(row: ReportRow, dateBasis: ReportDateBasis, from: Date, to: Date): boolean {
+	if (dateBasis === 'CreatedAt') return isDateInRange(row.createdAt, from, to);
+	if (dateBasis === 'FundsLockedAt') return isDateInRange(row.timestamps.fundsLockedAt, from, to);
+	if (
+		[row.timestamps.sellerRevenueRecognizedAt, row.timestamps.buyerGrossSpendAt, row.timestamps.buyerReturnedAt].some(
+			(value) => isDateInRange(value, from, to),
+		)
+	) {
+		return true;
+	}
+	return getKnownReportTransactionDates(row).some((date) => isDateInRange(date, from, to));
+}
+
+export function getReportTransactionCount(
+	rows: readonly ReportRow[],
+	dateBasis: ReportDateBasis,
+	from: Date,
+	to: Date,
+) {
+	const membershipByPayment = new Map<string, boolean>();
+	for (const row of rows) {
+		membershipByPayment.set(
+			row.blockchainIdentifier,
+			(membershipByPayment.get(row.blockchainIdentifier) ?? false) || hasKnownDateMembership(row, dateBasis, from, to),
+		);
+	}
+	const memberships = Array.from(membershipByPayment.values());
+	return {
+		transactionCount: memberships.filter(Boolean).length,
+		transactionCountCompleteness: memberships.every(Boolean) ? ('complete' as const) : ('partial' as const),
+	};
+}

--- a/src/services/transaction-report/aggregate-fees.ts
+++ b/src/services/transaction-report/aggregate-fees.ts
@@ -1,0 +1,319 @@
+import type { ReportMetricWindow, ReportRow } from './records';
+import { groupReportRowsByPayment } from './row-groups';
+import { mergeReportTransactions } from './timestamps';
+import { NO_REPORT_CHECKPOINT, runReportCheckpoint, type ReportCheckpoint } from './checkpoint';
+
+type ReportDateBasis = ReportMetricWindow['dateBasis'];
+
+export type CoveredTransaction = {
+	fee: bigint;
+	blockTime: Date | null;
+	paymentKeys: readonly string[];
+};
+
+export type FeeComponent = {
+	paymentKeys: readonly string[];
+	transactions: CoveredTransaction[];
+	total: bigint;
+	admin: bigint | null;
+	isTotalComplete: boolean;
+	isAdminComplete: boolean;
+	buyerActorFees: bigint;
+	sellerActorFees: bigint;
+	actorFees: bigint;
+	isActorComplete: boolean;
+};
+
+export type FeeAnalysis = {
+	components: FeeComponent[];
+	actor: bigint;
+	total: bigint;
+	admin: bigint;
+	actorCompleteness: 'complete' | 'partial';
+	totalCompleteness: 'complete' | 'partial';
+	adminCompleteness: 'complete' | 'partial';
+};
+
+function dateFromBlockTime(blockTime: number | null): Date | null {
+	if (blockTime == null || !Number.isSafeInteger(blockTime) || blockTime < 0) return null;
+	const value = new Date(blockTime * 1000);
+	return Number.isNaN(value.getTime()) ? null : value;
+}
+
+function uniqueSorted(values: readonly string[] | null | undefined): string[] {
+	return values == null ? [] : Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+export function analyzeReportFees(
+	rows: readonly ReportRow[],
+	dateBasis: ReportDateBasis,
+	from: Date,
+	to: Date,
+	checkpoint: ReportCheckpoint = NO_REPORT_CHECKPOINT,
+): FeeAnalysis {
+	checkpoint();
+	const selectedPaymentKeys = new Set(rows.map((row) => row.blockchainIdentifier));
+	const parent = new Map(Array.from(selectedPaymentKeys, (key) => [key, key]));
+	const totalEvidence = new Map(Array.from(selectedPaymentKeys, (key) => [key, true]));
+	const hasKnownCohortMembership = new Map(
+		Array.from(selectedPaymentKeys, (key) => [key, dateBasis !== 'FundsLockedAt']),
+	);
+	if (dateBasis === 'FundsLockedAt') {
+		for (const [index, row] of rows.entries()) {
+			runReportCheckpoint(index, checkpoint);
+			if (
+				row.timestamps.fundsLockedAt != null &&
+				row.timestamps.fundsLockedAt.getTime() >= from.getTime() &&
+				row.timestamps.fundsLockedAt.getTime() < to.getTime()
+			) {
+				hasKnownCohortMembership.set(row.blockchainIdentifier, true);
+			}
+		}
+	}
+	const mergedTransactions = mergeReportTransactions(rows.flatMap((row) => row.transactions));
+	const confirmedPaymentKeys = new Set(
+		mergedTransactions
+			.filter((transaction) => transaction.status === 'Confirmed')
+			.flatMap((transaction) => uniqueSorted(transaction.relatedPaymentKeys))
+			.filter((key) => selectedPaymentKeys.has(key)),
+	);
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		if (row.onChainState != null && !confirmedPaymentKeys.has(row.blockchainIdentifier)) {
+			totalEvidence.set(row.blockchainIdentifier, false);
+		}
+		if (!hasKnownCohortMembership.get(row.blockchainIdentifier)) {
+			totalEvidence.set(row.blockchainIdentifier, false);
+		}
+	}
+	const find = (key: string): string => {
+		let root = key;
+		while (parent.get(root) !== root) root = parent.get(root)!;
+		parent.set(key, root);
+		return root;
+	};
+	const union = (keys: readonly string[]) => {
+		for (const key of keys.slice(1)) parent.set(find(key), find(keys[0]));
+	};
+	let hasUnknownTotalEvidence = false;
+	const covered: CoveredTransaction[] = [];
+	for (const [index, transaction] of mergedTransactions.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const blockTime = dateFromBlockTime(transaction.blockTime);
+		if (
+			dateBasis === 'RevenueRecognizedAt' &&
+			blockTime != null &&
+			(blockTime.getTime() < from.getTime() || blockTime.getTime() >= to.getTime())
+		) {
+			continue;
+		}
+		if (transaction.status !== 'Confirmed' && transaction.status != null) continue;
+		const paymentKeys = uniqueSorted(transaction.relatedPaymentKeys);
+		const selectedRelatedKeys = paymentKeys.filter((key) => selectedPaymentKeys.has(key));
+		const markIncomplete = (target: Map<string, boolean>) => {
+			if (selectedRelatedKeys.length === 0) {
+				hasUnknownTotalEvidence = true;
+			} else for (const key of selectedRelatedKeys) target.set(key, false);
+		};
+		const isCoreComplete =
+			transaction.status === 'Confirmed' &&
+			transaction.txHash != null &&
+			transaction.fees != null &&
+			transaction.fees >= 0n &&
+			(dateBasis !== 'RevenueRecognizedAt' || blockTime != null);
+		const isLogicalCoverageComplete =
+			transaction.relatedPaymentKeysComplete !== false &&
+			paymentKeys.length > 0 &&
+			paymentKeys.every((key) => selectedPaymentKeys.has(key));
+		if (!isCoreComplete) {
+			markIncomplete(totalEvidence);
+			continue;
+		}
+		if (transaction.fees === 0n) continue;
+		if (selectedRelatedKeys.some((key) => !hasKnownCohortMembership.get(key))) {
+			markIncomplete(totalEvidence);
+			continue;
+		}
+		if (!isLogicalCoverageComplete) {
+			markIncomplete(totalEvidence);
+			continue;
+		}
+		if (selectedRelatedKeys.length > 1) union(selectedRelatedKeys);
+		covered.push({ fee: transaction.fees, blockTime, paymentKeys });
+	}
+
+	const rowsByPayment = groupReportRowsByPayment(rows, checkpoint);
+	const paymentsByRoot = new Map<string, string[]>();
+	let paymentIndex = 0;
+	for (const key of selectedPaymentKeys) {
+		runReportCheckpoint(paymentIndex, checkpoint);
+		paymentIndex += 1;
+		const root = find(key);
+		const payments = paymentsByRoot.get(root);
+		if (payments == null) paymentsByRoot.set(root, [key]);
+		else payments.push(key);
+	}
+	const coveredByRoot = new Map<string, CoveredTransaction[]>();
+	for (const [index, transaction] of covered.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const root = find(transaction.paymentKeys[0]);
+		const transactions = coveredByRoot.get(root);
+		if (transactions == null) coveredByRoot.set(root, [transaction]);
+		else transactions.push(transaction);
+	}
+	const components = Array.from(paymentsByRoot, ([root, paymentKeys], index): FeeComponent => {
+		runReportCheckpoint(index, checkpoint);
+		const transactions = coveredByRoot.get(root) ?? [];
+		let buyerActorFees = 0n;
+		let sellerActorFees = 0n;
+		let isActorComplete = true;
+		for (const paymentKey of paymentKeys) {
+			const paymentRows = rowsByPayment.get(paymentKey) ?? [];
+			const ownerRows = paymentRows.filter((row) => row.isFeeReconciliationOwner);
+			const evidenceRows = ownerRows.length === 1 ? ownerRows : paymentRows;
+			for (const field of ['buyerCardanoFees', 'sellerCardanoFees'] as const) {
+				const values = new Set(evidenceRows.map((row) => row.cardanoFeeReconciliation[field].toString()));
+				if (values.size !== 1) isActorComplete = false;
+				else if (field === 'buyerCardanoFees') buyerActorFees += BigInt([...values][0]);
+				else sellerActorFees += BigInt([...values][0]);
+			}
+			if (evidenceRows.some((row) => row.actorCardanoFeeAllocation.completeness === 'partial')) {
+				isActorComplete = false;
+			}
+		}
+		const actorFees = buyerActorFees + sellerActorFees;
+		const total = transactions.reduce((sum, transaction) => sum + transaction.fee, 0n);
+		const isTotalComplete = paymentKeys.every((key) => totalEvidence.get(key));
+		const isAdminComplete = isTotalComplete && isActorComplete && total >= actorFees;
+		return {
+			paymentKeys,
+			transactions,
+			total,
+			admin: isAdminComplete ? total - actorFees : null,
+			isTotalComplete,
+			isAdminComplete,
+			buyerActorFees,
+			sellerActorFees,
+			actorFees,
+			isActorComplete,
+		};
+	});
+	const actor = components.reduce((sum, component) => sum + component.actorFees, 0n);
+	const total = covered.reduce((sum, transaction) => sum + transaction.fee, 0n);
+	const admin = components.reduce((sum, component) => sum + (component.admin ?? 0n), 0n);
+	return {
+		components,
+		actor,
+		total,
+		admin,
+		actorCompleteness: components.some((component) => !component.isActorComplete) ? 'partial' : 'complete',
+		totalCompleteness:
+			hasUnknownTotalEvidence || components.some((component) => !component.isTotalComplete) ? 'partial' : 'complete',
+		adminCompleteness:
+			hasUnknownTotalEvidence || components.some((component) => !component.isAdminComplete) ? 'partial' : 'complete',
+	};
+}
+
+function reportRowKey(row: ReportRow): string {
+	return `${row.requestType}:${row.id}`;
+}
+
+function componentRowReconciliation(component: FeeComponent, isOwner: boolean): ReportRow['cardanoFeeReconciliation'] {
+	if (!isOwner) {
+		if (!component.isTotalComplete || !component.isActorComplete) {
+			return {
+				buyerCardanoFees: 0n,
+				sellerCardanoFees: 0n,
+				adminCardanoFees: null,
+				totalCardanoFees: null,
+				completeness: 'partial',
+			};
+		}
+		return component.total < component.actorFees
+			? {
+					buyerCardanoFees: 0n,
+					sellerCardanoFees: 0n,
+					adminCardanoFees: null,
+					totalCardanoFees: 0n,
+					completeness: 'inconsistent',
+				}
+			: {
+					buyerCardanoFees: 0n,
+					sellerCardanoFees: 0n,
+					adminCardanoFees: 0n,
+					totalCardanoFees: 0n,
+					completeness: 'complete',
+				};
+	}
+	if (!component.isTotalComplete || !component.isActorComplete) {
+		return {
+			buyerCardanoFees: component.buyerActorFees,
+			sellerCardanoFees: component.sellerActorFees,
+			adminCardanoFees: null,
+			totalCardanoFees: component.total,
+			completeness: 'partial',
+		};
+	}
+	if (component.total < component.actorFees) {
+		return {
+			buyerCardanoFees: component.buyerActorFees,
+			sellerCardanoFees: component.sellerActorFees,
+			adminCardanoFees: null,
+			totalCardanoFees: component.total,
+			completeness: 'inconsistent',
+		};
+	}
+	return {
+		buyerCardanoFees: component.buyerActorFees,
+		sellerCardanoFees: component.sellerActorFees,
+		adminCardanoFees: component.admin!,
+		totalCardanoFees: component.total,
+		completeness: 'complete',
+	};
+}
+
+export function assignCompleteReportFeeReconciliation(
+	rows: readonly ReportRow[],
+	dateBasis: ReportDateBasis,
+	from: Date,
+	to: Date,
+	checkpoint: ReportCheckpoint = NO_REPORT_CHECKPOINT,
+): ReportRow[] {
+	const analysis = analyzeReportFees(rows, dateBasis, from, to, checkpoint);
+	const rowsByPayment = groupReportRowsByPayment(rows, checkpoint);
+	const allocations = new Map<
+		string,
+		Pick<
+			ReportRow,
+			'actorCardanoFeeAllocation' | 'cardanoFeeReconciliation' | 'feeComponentScope' | 'isFeeReconciliationOwner'
+		>
+	>();
+	for (const [index, component] of analysis.components.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const componentRows = component.paymentKeys
+			.flatMap((key) => rowsByPayment.get(key) ?? [])
+			.sort((left, right) => {
+				const paymentComparison = left.blockchainIdentifier.localeCompare(right.blockchainIdentifier);
+				if (paymentComparison !== 0) return paymentComparison;
+				if (left.isFeeReconciliationOwner !== right.isFeeReconciliationOwner) {
+					return left.isFeeReconciliationOwner ? -1 : 1;
+				}
+				return reportRowKey(left).localeCompare(reportRowKey(right));
+			});
+		const owner = componentRows[0];
+		const completeness = componentRowReconciliation(component, true).completeness;
+		for (const row of componentRows) {
+			const isOwner = row === owner;
+			allocations.set(reportRowKey(row), {
+				isFeeReconciliationOwner: isOwner,
+				feeComponentScope: completeness === 'complete' ? 'complete' : 'partial',
+				actorCardanoFeeAllocation: {
+					...row.actorCardanoFeeAllocation,
+					completeness: 'partial',
+				},
+				cardanoFeeReconciliation: componentRowReconciliation(component, isOwner),
+			});
+		}
+	}
+	return rows.map((row) => ({ ...row, ...allocations.get(reportRowKey(row)) }));
+}

--- a/src/services/transaction-report/aggregate-serialization.ts
+++ b/src/services/transaction-report/aggregate-serialization.ts
@@ -1,0 +1,43 @@
+import { serializeReportAmount } from '@/utils/asset-units';
+import type { ReportAggregate, ReportAggregateMetric, ReportAggregateResult } from './aggregate';
+
+function serializeAggregateMetric(metric: ReportAggregateMetric) {
+	return { amounts: metric.amounts.map(serializeReportAmount), completeness: metric.completeness };
+}
+
+function serializeAggregate(aggregate: ReportAggregate) {
+	return {
+		transactionCount: aggregate.transactionCount,
+		transactionCountCompleteness: aggregate.transactionCountCompleteness,
+		sellerGrossRevenue: serializeAggregateMetric(aggregate.sellerGrossRevenue),
+		protocolFees: serializeAggregateMetric(aggregate.protocolFees),
+		sellerCardanoFees: serializeAggregateMetric(aggregate.sellerCardanoFees),
+		actorCardanoFees: serializeAggregateMetric(aggregate.actorCardanoFees),
+		adminCardanoFees: serializeAggregateMetric(aggregate.adminCardanoFees),
+		totalCardanoFees: serializeAggregateMetric(aggregate.totalCardanoFees),
+		sellerNetRevenue: serializeAggregateMetric(aggregate.sellerNetRevenue),
+		buyerGrossSpend: serializeAggregateMetric(aggregate.buyerGrossSpend),
+		returnedFunds: serializeAggregateMetric(aggregate.returnedFunds),
+		buyerCardanoFees: serializeAggregateMetric(aggregate.buyerCardanoFees),
+		buyerNetSpend: serializeAggregateMetric(aggregate.buyerNetSpend),
+	};
+}
+
+export function serializeReportAggregateResult(result: ReportAggregateResult) {
+	return {
+		totals: serializeAggregate(result.totals),
+		wallets: result.wallets.map((wallet) => ({
+			managedWallet: wallet.managedWallet,
+			role: wallet.role,
+			metrics: serializeAggregate(wallet.metrics),
+		})),
+		history: result.history.map((entry) => ({
+			bucketStart: entry.bucketStart,
+			bucketEnd: entry.bucketEnd,
+			metrics: serializeAggregate(entry.metrics),
+		})),
+		bucket: result.bucket,
+		warnings: result.warnings,
+		historyFeeCompleteness: result.historyFeeCompleteness,
+	};
+}

--- a/src/services/transaction-report/aggregate.spec.ts
+++ b/src/services/transaction-report/aggregate.spec.ts
@@ -1,0 +1,1217 @@
+import { describe, expect, it } from '@jest/globals';
+import { getAtomicAmount } from './amounts';
+import {
+	aggregateReportRows,
+	chooseReportBucket,
+	serializeReportAggregateResult,
+	type ReportAggregate,
+	type ReportAggregateMetric,
+} from './aggregate';
+import { buildReportRow, type ReportRequestRecord, type ReportRow } from './records';
+import type { ReportOnChainState, RevenueMode } from './metrics';
+
+const AS_OF = new Date('2026-12-31T00:00:00.000Z');
+
+function blockTime(value: string): number {
+	return Math.floor(new Date(value).getTime() / 1000);
+}
+
+function transaction(
+	id: string,
+	state: ReportOnChainState,
+	time: string,
+	fees = 0n,
+	relatedRequestKeys?: readonly string[],
+	relatedPaymentKeys?: readonly string[],
+): ReportRequestRecord['transactions'][number] {
+	return {
+		id,
+		txHash: `hash-${id}`,
+		status: 'Confirmed',
+		newOnChainState: state,
+		blockTime: blockTime(time),
+		fees,
+		relatedRequestKeys,
+		relatedPaymentKeys,
+	};
+}
+
+function record(overrides: Partial<ReportRequestRecord> = {}): ReportRequestRecord {
+	const result: ReportRequestRecord = {
+		id: 'request-1',
+		role: 'Seller',
+		requestType: 'PaymentRequest',
+		createdAt: new Date('2026-01-01T12:00:00.000Z'),
+		blockchainIdentifier: 'chain-1',
+		agentIdentifier: 'agent-1',
+		agentName: 'Agent',
+		onChainState: 'Withdrawn',
+		metadata: null,
+		managedWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-wallet',
+			walletVkey: 'wallet-vkey',
+			collectionAddress: 'addr-collection',
+			deletedAt: null,
+		},
+		counterpartyAddress: 'addr-counterparty',
+		buyerReturnAddress: null,
+		sellerReturnAddress: null,
+		paymentSourceType: 'Web3CardanoV2',
+		configuredFeeRatePermille: 50,
+		unlockTime: BigInt(new Date('2026-01-02T00:00:00.000Z').getTime()),
+		collateralReturnLovelace: 2_000_000n,
+		requestedFunds: [{ unit: 'lovelace', amount: 100_000_000n }],
+		withdrawnForBuyer: [],
+		withdrawnForSeller: [],
+		buyerPayoutCompleteness: 'complete',
+		sellerPayoutCompleteness: 'complete',
+		buyerCardanoFees: 0n,
+		sellerCardanoFees: 0n,
+		transactions: [transaction('withdraw', 'Withdrawn', '2026-01-02T12:00:00.000Z')],
+		feeAllocationScope: 'single_request',
+		isFeeReconciliationOwner: true,
+		feeComponentScope: 'complete',
+		...overrides,
+	};
+	return {
+		...result,
+		transactions: result.transactions.map((value) => ({
+			...value,
+			relatedRequestKeys:
+				value.relatedRequestKeys === undefined ? [`${result.role}:${result.id}`] : value.relatedRequestKeys,
+			relatedPaymentKeys:
+				value.relatedPaymentKeys === undefined ? [result.blockchainIdentifier] : value.relatedPaymentKeys,
+		})),
+	};
+}
+
+function row(
+	overrides: Partial<ReportRequestRecord> = {},
+	revenueMode: RevenueMode = 'Billable',
+	dateBasis: 'CreatedAt' | 'FundsLockedAt' | 'RevenueRecognizedAt' = 'CreatedAt',
+	from = new Date('2026-01-01T00:00:00.000Z'),
+	to = new Date('2027-01-01T00:00:00.000Z'),
+): ReportRow {
+	return buildReportRow(record(overrides), revenueMode, AS_OF, { dateBasis, from, to });
+}
+
+function amount(metric: ReportAggregateMetric, unit = 'lovelace'): bigint {
+	return getAtomicAmount(metric.amounts, unit);
+}
+
+function historyAmount(
+	result: ReturnType<typeof aggregateReportRows>,
+	metricName: Exclude<keyof ReportAggregate, 'transactionCount' | 'transactionCountCompleteness'>,
+	unit = 'lovelace',
+): bigint {
+	return result.history.reduce((total, entry) => total + amount(entry.metrics[metricName], unit), 0n);
+}
+
+describe('chooseReportBucket', () => {
+	it('uses day through 30 days, week through 366 days, then month', () => {
+		const from = new Date('2026-01-01T00:00:00.000Z');
+		expect(chooseReportBucket(from, new Date('2026-01-31T00:00:00.000Z'), 'Auto')).toBe('Day');
+		expect(chooseReportBucket(from, new Date('2026-02-01T00:00:00.000Z'), 'Auto')).toBe('Week');
+		expect(chooseReportBucket(from, new Date('2027-01-03T00:00:00.000Z'), 'Auto')).toBe('Month');
+	});
+
+	it('rejects invalid and reversed ranges', () => {
+		expect(() => chooseReportBucket(new Date('invalid'), new Date(), 'Auto')).toThrow('must be valid');
+		expect(() =>
+			chooseReportBucket(new Date('2026-01-02T00:00:00.000Z'), new Date('2026-01-01T00:00:00.000Z'), 'Day'),
+		).toThrow('must be after');
+	});
+});
+
+describe('aggregateReportRows totals', () => {
+	it('marks an unknown FundsLocked date membership count partial', () => {
+		const uncertain = row(
+			{ role: 'Buyer', requestType: 'PurchaseRequest', onChainState: 'Withdrawn' },
+			'Billable',
+			'FundsLockedAt',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+		);
+		const result = aggregateReportRows(
+			[uncertain],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'FundsLockedAt',
+		);
+
+		expect(result.totals.transactionCount).toBe(0);
+		expect(result.totals.transactionCountCompleteness).toBe('partial');
+		expect(result.totals.buyerGrossSpend).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.wallets[0].metrics.transactionCountCompleteness).toBe('partial');
+		expect(result.wallets[0].metrics.transactionCount).toBe(0);
+		expect(result.history.every((entry) => entry.metrics.transactionCountCompleteness === 'partial')).toBe(true);
+		expect(result.warnings.map((warning) => warning.code)).toContain('TRANSACTION_COUNT_PARTIAL');
+	});
+
+	it('does not count a missing transaction hash as proven date membership', () => {
+		const missingHash = row(
+			{
+				transactions: [{ ...transaction('missing-hash', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n), txHash: null }],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			new Date('2026-01-02T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+		);
+		const result = aggregateReportRows(
+			[missingHash],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-02T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+			'RevenueRecognizedAt',
+		);
+
+		expect(result.totals.transactionCount).toBe(0);
+		expect(result.totals.transactionCountCompleteness).toBe('partial');
+		expect(result.history[0].metrics.transactionCount).toBe(0);
+	});
+
+	it('counts distinct logical payments inside each wallet group', () => {
+		const first = row({ id: 'duplicate-count-a', blockchainIdentifier: 'duplicate-count-chain' });
+		const second = row({ id: 'duplicate-count-b', blockchainIdentifier: 'duplicate-count-chain' });
+		const result = aggregateReportRows(
+			[first, second],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.transactionCount).toBe(1);
+		expect(result.wallets[0].metrics.transactionCount).toBe(1);
+		expect(result.totals.transactionCountCompleteness).toBe('complete');
+	});
+
+	it('keeps exact BigInt totals and reduces detailed completeness', () => {
+		const exactAdminRow = row({
+			id: 'v1',
+			paymentSourceType: 'Web3CardanoV1',
+			requestedFunds: [{ unit: 'lovelace', amount: 9_007_199_254_740_993n }],
+			sellerCardanoFees: 20n,
+			transactions: [transaction('v1-withdraw', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n)],
+		});
+		const sharedRow = row({
+			id: 'v2',
+			blockchainIdentifier: 'chain-2',
+			feeAllocationScope: 'shared_or_unknown',
+			transactions: [transaction('v2-withdraw', 'Withdrawn', '2026-01-03T12:00:00.000Z', 500n)],
+		});
+		const result = aggregateReportRows(
+			[exactAdminRow, sharedRow],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-05T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.transactionCount).toBe(2);
+		expect(amount(result.totals.sellerGrossRevenue)).toBe(9_007_199_354_740_993n);
+		expect(result.totals.protocolFees.completeness).toBe('partial');
+		expect(amount(result.totals.adminCardanoFees)).toBe(0n);
+		expect(amount(result.totals.totalCardanoFees)).toBe(600n);
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+		expect(result.totals.totalCardanoFees.completeness).toBe('complete');
+		expect(result.totals.sellerNetRevenue.completeness).toBe('partial');
+
+		const serialized = serializeReportAggregateResult(result);
+		expect(serialized.totals.sellerGrossRevenue.amounts[0]).toMatchObject({
+			rawAmount: '9007199354740993',
+			decimalAmount: '9007199354.740993',
+		});
+		expect(() => JSON.stringify(serialized)).not.toThrow();
+	});
+
+	it('keeps the same managed wallet in separate buyer and seller groups', () => {
+		const seller = row({ onChainState: null, transactions: [] }, 'RequestedGross');
+		const buyer = row({
+			id: 'request-2',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'chain-2',
+			onChainState: 'FundsLocked',
+			transactions: [transaction('lock', 'FundsLocked', '2026-01-02T08:00:00.000Z')],
+		});
+		const result = aggregateReportRows(
+			[seller, buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.wallets.map((wallet) => wallet.role)).toEqual(['Buyer', 'Seller']);
+		expect(amount(result.wallets[0].metrics.buyerGrossSpend)).toBe(100_000_000n);
+		expect(amount(result.wallets[1].metrics.sellerGrossRevenue)).toBe(100_000_000n);
+		expect(result.wallets.every((wallet) => wallet.metrics.transactionCount === 1)).toBe(true);
+	});
+
+	it('deduplicates paired global transactions and flags conflicting reconciliation', () => {
+		const sharedTransactions = [
+			transaction('pair-lock', 'FundsLocked', '2026-01-01T12:00:00.000Z'),
+			transaction('pair-withdraw', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n),
+		];
+		const seller = row({
+			id: 'seller-pair',
+			blockchainIdentifier: 'paired-chain',
+			buyerCardanoFees: 10n,
+			sellerCardanoFees: 20n,
+			transactions: sharedTransactions,
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const buyer = row({
+			id: 'buyer-pair',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'paired-chain',
+			buyerCardanoFees: 10n,
+			sellerCardanoFees: 20n,
+			transactions: sharedTransactions,
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const exact = aggregateReportRows(
+			[seller, buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(exact.totals.transactionCount).toBe(1);
+		expect(amount(exact.totals.adminCardanoFees)).toBe(0n);
+		expect(amount(exact.totals.totalCardanoFees)).toBe(100n);
+		expect(exact.totals.adminCardanoFees.completeness).toBe('partial');
+		expect(exact.wallets.map((wallet) => wallet.metrics.transactionCount)).toEqual([1, 1]);
+		expect(exact.wallets.reduce((total, wallet) => total + amount(wallet.metrics.totalCardanoFees), 0n)).toBe(100n);
+		expect(exact.wallets.filter((wallet) => amount(wallet.metrics.totalCardanoFees) > 0n)).toHaveLength(1);
+
+		const conflictingBuyer = row({
+			id: 'buyer-pair',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'paired-chain',
+			buyerCardanoFees: 11n,
+			sellerCardanoFees: 20n,
+			transactions: [
+				transaction('pair-lock', 'FundsLocked', '2026-01-01T12:00:00.000Z'),
+				transaction('pair-withdraw', 'Withdrawn', '2026-01-02T12:00:00.000Z', 110n),
+			],
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const conflict = aggregateReportRows(
+			[seller, conflictingBuyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(conflict.totals.transactionCount).toBe(1);
+		expect(amount(conflict.totals.totalCardanoFees)).toBe(0n);
+		expect(amount(conflict.totals.adminCardanoFees)).toBe(0n);
+		expect(conflict.totals.totalCardanoFees.completeness).toBe('partial');
+		expect(conflict.totals.adminCardanoFees.completeness).toBe('partial');
+	});
+
+	it('keeps paired role wallet fee metrics complete for an exact zero fee', () => {
+		const requestKeys = ['Seller:zero-pair-seller', 'Buyer:zero-pair-buyer'];
+		const shared = transaction('zero-pair', 'Withdrawn', '2026-01-02T12:00:00.000Z', 0n, requestKeys, [
+			'zero-pair-chain',
+		]);
+		const seller = row({
+			id: 'zero-pair-seller',
+			blockchainIdentifier: 'zero-pair-chain',
+			transactions: [shared],
+		});
+		const buyer = row({
+			id: 'zero-pair-buyer',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'zero-pair-chain',
+			transactions: [shared],
+		});
+		const result = aggregateReportRows(
+			[seller, buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.wallets).toHaveLength(2);
+		expect(result.wallets.every((wallet) => wallet.metrics.totalCardanoFees.completeness === 'complete')).toBe(true);
+		expect(result.wallets.every((wallet) => wallet.metrics.adminCardanoFees.completeness === 'partial')).toBe(true);
+	});
+
+	it('assigns paired wallet fees to the unique reconciliation owner', () => {
+		const requestKeys = ['Seller:owner-pair-seller', 'Buyer:owner-pair-buyer'];
+		const shared = transaction('owner-pair', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n, requestKeys, [
+			'owner-pair-chain',
+		]);
+		const seller = row({
+			id: 'owner-pair-seller',
+			blockchainIdentifier: 'owner-pair-chain',
+			managedWallet: {
+				id: 'aaa-seller-wallet',
+				walletAddress: 'addr-seller',
+				walletVkey: 'seller-vkey',
+				collectionAddress: 'addr-seller-collection',
+				deletedAt: null,
+			},
+			isFeeReconciliationOwner: false,
+			transactions: [shared],
+		});
+		const buyer = row({
+			id: 'owner-pair-buyer',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'owner-pair-chain',
+			managedWallet: {
+				id: 'zzz-buyer-wallet',
+				walletAddress: 'addr-buyer',
+				walletVkey: 'buyer-vkey',
+				collectionAddress: 'addr-buyer-collection',
+				deletedAt: null,
+			},
+			isFeeReconciliationOwner: true,
+			transactions: [shared],
+		});
+		const result = aggregateReportRows(
+			[seller, buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+		const sellerWallet = result.wallets.find((wallet) => wallet.managedWallet?.id === 'aaa-seller-wallet')!;
+		const buyerWallet = result.wallets.find((wallet) => wallet.managedWallet?.id === 'zzz-buyer-wallet')!;
+
+		expect(amount(sellerWallet.metrics.totalCardanoFees)).toBe(0n);
+		expect(amount(sellerWallet.metrics.adminCardanoFees)).toBe(0n);
+		expect(amount(buyerWallet.metrics.totalCardanoFees)).toBe(100n);
+		expect(amount(buyerWallet.metrics.adminCardanoFees)).toBe(0n);
+		expect(buyerWallet.metrics.totalCardanoFees.completeness).toBe('complete');
+		expect(buyerWallet.metrics.adminCardanoFees.completeness).toBe('partial');
+		expect(result.warnings.map((warning) => warning.code)).toContain('SHARED_CARDANO_FEE_COMPONENT_ALLOCATION');
+	});
+
+	it('counts a covered V2 batch fee once when every related request is selected', () => {
+		const relatedRequestKeys = ['Seller:seller-batch', 'Buyer:buyer-batch'];
+		const batchTransaction = transaction(
+			'batch-withdraw',
+			'Withdrawn',
+			'2026-01-02T12:00:00.000Z',
+			500n,
+			relatedRequestKeys,
+		);
+		const seller = row({
+			id: 'seller-batch',
+			blockchainIdentifier: 'seller-chain',
+			transactions: [batchTransaction],
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const buyer = row({
+			id: 'buyer-batch',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			blockchainIdentifier: 'buyer-chain',
+			onChainState: 'FundsLocked',
+			transactions: [batchTransaction],
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const result = aggregateReportRows(
+			[seller, buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 500n }],
+			completeness: 'complete',
+		});
+		expect(result.totals.adminCardanoFees).toEqual({
+			amounts: [],
+			completeness: 'partial',
+		});
+	});
+
+	it('keeps admin exact when a filtered counterpart is the same logical payment', () => {
+		const seller = row({
+			id: 'seller-filtered-batch',
+			transactions: [
+				transaction('filtered-batch', 'Withdrawn', '2026-01-02T12:00:00.000Z', 500n, [
+					'Seller:seller-filtered-batch',
+					'Buyer:filtered-out',
+				]),
+			],
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 500n }],
+			completeness: 'complete',
+		});
+		expect(result.totals.adminCardanoFees).toEqual({
+			amounts: [],
+			completeness: 'partial',
+		});
+		expect(result.warnings.map((warning) => warning.code)).toContain('CARDANO_FEE_COVERAGE_PARTIAL');
+	});
+
+	it('excludes a whole shared fee when a related logical payment is filtered out', () => {
+		const seller = row({
+			id: 'seller-logical-filter',
+			transactions: [
+				transaction(
+					'logical-filter',
+					'Withdrawn',
+					'2026-01-02T12:00:00.000Z',
+					500n,
+					['Seller:seller-logical-filter'],
+					['chain-1', 'filtered-chain'],
+				),
+			],
+		});
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.adminCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+	});
+
+	it('keeps records without a managed wallet in an Unassigned role group', () => {
+		const unassigned = row({ managedWallet: null });
+		const result = aggregateReportRows(
+			[unassigned],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.wallets).toHaveLength(1);
+		expect(result.wallets[0].managedWallet).toBeNull();
+		expect(result.wallets[0].role).toBe('Seller');
+		expect(amount(result.wallets[0].metrics.sellerGrossRevenue)).toBe(100_000_000n);
+	});
+
+	it('subtracts both known actor fees for a seller-only reconciliation', () => {
+		const seller = row({
+			buyerCardanoFees: 10n,
+			sellerCardanoFees: 20n,
+			transactions: [transaction('seller-only', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n)],
+		});
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(amount(result.totals.totalCardanoFees)).toBe(100n);
+		expect(result.totals.actorCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 30n }],
+			completeness: 'partial',
+		});
+		expect(result.totals.adminCardanoFees).toEqual({
+			amounts: [],
+			completeness: 'partial',
+		});
+		expect(amount(result.wallets[0].metrics.actorCardanoFees)).toBe(30n);
+		expect(historyAmount(result, 'actorCardanoFees')).toBe(30n);
+	});
+
+	it('requires a transaction hash for exact total coverage', () => {
+		const withoutHash = transaction('without-hash', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n);
+		const seller = row({ transactions: [{ ...withoutHash, txHash: null }] });
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+	});
+
+	it('excludes negative transaction fee evidence', () => {
+		const seller = row();
+		const withNegativeFee: ReportRow = {
+			...seller,
+			transactions: seller.transactions.map((value) => ({ ...value, fees: -1n })),
+		};
+		const result = aggregateReportRows(
+			[withNegativeFee],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+	});
+
+	it('marks a chain state without transaction evidence partial', () => {
+		const missingEvidence = row({ transactions: [] });
+		const result = aggregateReportRows(
+			[missingEvidence],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+	});
+
+	it('marks an on-chain state with only pending transaction evidence partial', () => {
+		const pending = transaction('pending-only', 'FundsLocked', '2026-01-02T12:00:00.000Z', 100n);
+		const pendingEvidence = row({ transactions: [{ ...pending, status: 'Pending' }] });
+		const result = aggregateReportRows(
+			[pendingEvidence],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+	});
+
+	it('retains an exact admin subtotal when another transaction has unknown logical coverage', () => {
+		const exact = row({
+			id: 'exact-subtotal',
+			blockchainIdentifier: 'exact-chain',
+			sellerCardanoFees: 20n,
+			transactions: [transaction('exact-subtotal-tx', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n)],
+		});
+		const unknown = row({
+			id: 'unknown-shared',
+			blockchainIdentifier: 'unknown-chain',
+			transactions: [
+				{
+					...transaction('unknown-shared-tx', 'Withdrawn', '2026-01-02T12:00:00.000Z', 500n),
+					relatedPaymentKeys: null,
+				},
+			],
+		});
+		const result = aggregateReportRows(
+			[exact, unknown],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 100n }],
+			completeness: 'partial',
+		});
+		expect(result.totals.adminCardanoFees).toEqual({
+			amounts: [],
+			completeness: 'partial',
+		});
+		expect(result.wallets).toHaveLength(1);
+		expect(result.wallets[0].metrics.totalCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 100n }],
+			completeness: 'partial',
+		});
+		expect(result.wallets[0].metrics.adminCardanoFees).toEqual({
+			amounts: [],
+			completeness: 'partial',
+		});
+	});
+
+	it('rejects conflicting same-role actor fee evidence for one logical payment', () => {
+		const requestKeys = ['Seller:duplicate-seller-a', 'Seller:duplicate-seller-b'];
+		const shared = transaction('duplicate-seller-tx', 'Withdrawn', '2026-01-02T12:00:00.000Z', 100n, requestKeys, [
+			'duplicate-chain',
+		]);
+		const first = row({
+			id: 'duplicate-seller-a',
+			blockchainIdentifier: 'duplicate-chain',
+			sellerCardanoFees: 20n,
+			transactions: [shared],
+		});
+		const second = row({
+			id: 'duplicate-seller-b',
+			blockchainIdentifier: 'duplicate-chain',
+			sellerCardanoFees: 25n,
+			transactions: [shared],
+		});
+		const result = aggregateReportRows(
+			[first, second],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-01-04T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees.completeness).toBe('complete');
+		expect(result.totals.adminCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+	});
+});
+
+describe('aggregateReportRows history', () => {
+	it('counts a logical payment in the bucket of an in-range fee-only event', () => {
+		const from = new Date('2026-03-02T00:00:00.000Z');
+		const to = new Date('2026-03-03T00:00:00.000Z');
+		const feeOnly = row(
+			{
+				transactions: [
+					transaction('fee-only-lock', 'FundsLocked', '2026-03-01T12:00:00.000Z'),
+					transaction('fee-only-refund-request', 'RefundRequested', '2026-03-02T12:00:00.000Z', 50n),
+					transaction('fee-only-withdraw', 'Withdrawn', '2026-03-04T12:00:00.000Z'),
+				],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			from,
+			to,
+		);
+		const result = aggregateReportRows([feeOnly], 'Day', 'Etc/UTC', from, to, 'RevenueRecognizedAt');
+
+		expect(result.totals.transactionCount).toBe(1);
+		expect(result.history[0].metrics.transactionCount).toBe(1);
+		expect(amount(result.history[0].metrics.totalCardanoFees)).toBe(50n);
+	});
+
+	it('marks unplaced buyer gross and actor-fee history partial', () => {
+		const from = new Date('2026-03-02T00:00:00.000Z');
+		const to = new Date('2026-03-03T00:00:00.000Z');
+		const buyer = row(
+			{
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				buyerCardanoFees: 10n,
+				transactions: [transaction('buyer-without-lock', 'Withdrawn', '2026-03-02T12:00:00.000Z', 50n)],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			from,
+			to,
+		);
+		const result = aggregateReportRows([buyer], 'Day', 'Etc/UTC', from, to, 'RevenueRecognizedAt');
+
+		expect(result.history[0].metrics.buyerGrossSpend.completeness).toBe('partial');
+		expect(result.history[0].metrics.buyerCardanoFees.completeness).toBe('partial');
+		expect(result.history[0].metrics.buyerNetSpend.completeness).toBe('partial');
+	});
+
+	it('marks unplaced seller actor-fee history partial without changing gross completeness', () => {
+		const from = new Date('2026-03-02T00:00:00.000Z');
+		const to = new Date('2026-03-03T00:00:00.000Z');
+		const seller = row(
+			{
+				onChainState: 'RefundRequested',
+				sellerCardanoFees: 10n,
+				transactions: [transaction('seller-refund-request', 'RefundRequested', '2026-03-02T12:00:00.000Z', 50n)],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			from,
+			to,
+		);
+		const result = aggregateReportRows([seller], 'Day', 'Etc/UTC', from, to, 'RevenueRecognizedAt');
+
+		expect(result.history[0].metrics.sellerGrossRevenue.completeness).toBe('complete');
+		expect(result.history[0].metrics.sellerCardanoFees.completeness).toBe('partial');
+		expect(result.history[0].metrics.sellerNetRevenue.completeness).toBe('partial');
+	});
+
+	it('places buyer gross spend and returned funds on their separate chain events', () => {
+		const buyer = row(
+			{
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+				transactions: [
+					transaction('lock', 'FundsLocked', '2026-03-01T12:00:00.000Z'),
+					transaction('refund', 'RefundWithdrawn', '2026-03-03T12:00:00.000Z'),
+				],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			new Date('2026-03-01T00:00:00.000Z'),
+			new Date('2026-03-04T00:00:00.000Z'),
+		);
+		const result = aggregateReportRows(
+			[buyer],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-03-01T00:00:00.000Z'),
+			new Date('2026-03-04T00:00:00.000Z'),
+			'RevenueRecognizedAt',
+		);
+
+		expect(amount(result.history[0].metrics.buyerGrossSpend, 'policyasset')).toBe(1_000n);
+		expect(amount(result.history[0].metrics.buyerNetSpend, 'policyasset')).toBe(1_000n);
+		expect(amount(result.history[1].metrics.buyerGrossSpend, 'policyasset')).toBe(0n);
+		expect(amount(result.history[2].metrics.returnedFunds, 'policyasset')).toBe(1_000n);
+		expect(amount(result.history[2].metrics.buyerNetSpend, 'policyasset')).toBe(-1_000n);
+		expect(result.history.map((entry) => entry.metrics.transactionCount)).toEqual([1, 0, 1]);
+		expect(result.totals.buyerNetSpend.amounts).toEqual([]);
+	});
+
+	it('keeps refund-only revenue totals equal to history deltas', () => {
+		const from = new Date('2026-03-03T00:00:00.000Z');
+		const to = new Date('2026-03-04T00:00:00.000Z');
+		const buyer = row(
+			{
+				id: 'refund-only',
+				blockchainIdentifier: 'refund-only-chain',
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+				buyerCardanoFees: 100n,
+				feeAllocationScope: 'shared_or_unknown',
+				feeComponentScope: 'partial',
+				transactions: [
+					transaction(
+						'refund-only-lock',
+						'FundsLocked',
+						'2026-03-01T12:00:00.000Z',
+						100n,
+						['Buyer:refund-only', 'Buyer:old-sibling'],
+						['refund-only-chain', 'old-sibling-chain'],
+					),
+					transaction('refund-only-return', 'RefundWithdrawn', '2026-03-03T12:00:00.000Z', 50n),
+				],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			from,
+			to,
+		);
+		const result = aggregateReportRows([buyer], 'Day', 'Etc/UTC', from, to, 'RevenueRecognizedAt');
+
+		expect(buyer.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: 0n,
+			adminCardanoFees: null,
+			totalCardanoFees: 50n,
+			completeness: 'partial',
+		});
+		expect(amount(result.totals.totalCardanoFees)).toBe(buyer.cardanoFeeReconciliation.totalCardanoFees);
+		expect(amount(result.totals.buyerGrossSpend, 'policyasset')).toBe(0n);
+		expect(amount(result.totals.returnedFunds, 'policyasset')).toBe(1_000n);
+		expect(amount(result.totals.buyerNetSpend, 'policyasset')).toBe(-1_000n);
+		expect(historyAmount(result, 'buyerGrossSpend', 'policyasset')).toBe(0n);
+		expect(historyAmount(result, 'returnedFunds', 'policyasset')).toBe(1_000n);
+		expect(historyAmount(result, 'buyerNetSpend', 'policyasset')).toBe(-1_000n);
+		expect(historyAmount(result, 'totalCardanoFees')).toBe(amount(result.totals.totalCardanoFees));
+	});
+
+	it.each(['CreatedAt', 'FundsLockedAt'] as const)(
+		'keeps %s cohort totals equal to one deterministic history bucket',
+		(dateBasis) => {
+			const from = new Date('2026-01-01T00:00:00.000Z');
+			const to = new Date('2026-01-04T00:00:00.000Z');
+			const buyer = row(
+				{
+					id: 'cohort-refund',
+					role: 'Buyer',
+					requestType: 'PurchaseRequest',
+					onChainState: 'RefundWithdrawn',
+					requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+					buyerCardanoFees: 100n,
+					transactions: [
+						transaction('cohort-lock', 'FundsLocked', '2026-01-01T12:00:00.000Z', 100n),
+						transaction('cohort-return', 'RefundWithdrawn', '2026-01-03T12:00:00.000Z', 50n),
+					],
+				},
+				'Billable',
+				dateBasis,
+				from,
+				to,
+			);
+			const result = aggregateReportRows([buyer], 'Day', 'Etc/UTC', from, to, dateBasis);
+
+			for (const [metricName, unit] of [
+				['buyerGrossSpend', 'policyasset'],
+				['returnedFunds', 'policyasset'],
+				['buyerCardanoFees', 'lovelace'],
+				['buyerNetSpend', 'lovelace'],
+				['adminCardanoFees', 'lovelace'],
+				['totalCardanoFees', 'lovelace'],
+			] as const) {
+				expect(historyAmount(result, metricName, unit)).toBe(amount(result.totals[metricName], unit));
+			}
+			expect(result.history.filter((entry) => entry.metrics.transactionCount > 0)).toHaveLength(1);
+		},
+	);
+
+	it('keeps two exact cohort reconciliations in their own January buckets', () => {
+		const from = new Date('2026-01-01T00:00:00.000Z');
+		const to = new Date('2026-02-01T00:00:00.000Z');
+		const first = row({
+			id: 'jan-first',
+			blockchainIdentifier: 'jan-chain-first',
+			createdAt: new Date('2026-01-05T12:00:00.000Z'),
+			sellerCardanoFees: 20n,
+			transactions: [transaction('jan-first-tx', 'Withdrawn', '2026-01-06T12:00:00.000Z', 100n)],
+		});
+		const second = row({
+			id: 'jan-second',
+			blockchainIdentifier: 'jan-chain-second',
+			createdAt: new Date('2026-01-20T12:00:00.000Z'),
+			sellerCardanoFees: 50n,
+			transactions: [transaction('jan-second-tx', 'Withdrawn', '2026-01-21T12:00:00.000Z', 200n)],
+		});
+		const result = aggregateReportRows([first, second], 'Day', 'Etc/UTC', from, to, 'CreatedAt');
+		const firstBucket = result.history.find((entry) => entry.bucketStart.toISOString() === '2026-01-05T00:00:00.000Z')!;
+		const secondBucket = result.history.find(
+			(entry) => entry.bucketStart.toISOString() === '2026-01-20T00:00:00.000Z',
+		)!;
+
+		expect(amount(firstBucket.metrics.totalCardanoFees)).toBe(100n);
+		expect(amount(firstBucket.metrics.adminCardanoFees)).toBe(0n);
+		expect(amount(secondBucket.metrics.totalCardanoFees)).toBe(200n);
+		expect(amount(secondBucket.metrics.adminCardanoFees)).toBe(0n);
+		expect(historyAmount(result, 'adminCardanoFees')).toBe(0n);
+		expect(result.historyFeeCompleteness).toBe('partial');
+	});
+
+	it.each([
+		{
+			name: 'same bucket and wallet group',
+			secondDate: '2026-01-05T18:00:00.000Z',
+			secondWallet: 'same',
+			expectedHistory: 500n,
+			expectedWallet: 500n,
+		},
+		{
+			name: 'different cohort buckets',
+			secondDate: '2026-01-20T12:00:00.000Z',
+			secondWallet: 'same',
+			expectedHistory: 500n,
+			expectedWallet: 500n,
+		},
+		{
+			name: 'different wallet groups',
+			secondDate: '2026-01-05T18:00:00.000Z',
+			secondWallet: 'different',
+			expectedHistory: 500n,
+			expectedWallet: 500n,
+		},
+	])(
+		'handles shared V2 logical payments in $name cohort buckets',
+		({ secondDate, secondWallet, expectedHistory, expectedWallet }) => {
+			const requestKeys = ['Seller:shared-first', 'Seller:shared-second'];
+			const paymentKeys = ['shared-chain-first', 'shared-chain-second'];
+			const shared = transaction('shared-v2', 'Withdrawn', '2026-01-10T12:00:00.000Z', 500n, requestKeys, paymentKeys);
+			const first = row({
+				id: 'shared-first',
+				blockchainIdentifier: 'shared-chain-first',
+				createdAt: new Date('2026-01-05T12:00:00.000Z'),
+				transactions: [shared],
+				feeAllocationScope: 'shared_or_unknown',
+			});
+			const second = row({
+				id: 'shared-second',
+				blockchainIdentifier: 'shared-chain-second',
+				createdAt: new Date(secondDate),
+				...(secondWallet === 'same'
+					? {}
+					: {
+							managedWallet: {
+								id: 'wallet-2',
+								walletAddress: 'addr-wallet-2',
+								walletVkey: 'wallet-vkey-2',
+								collectionAddress: 'addr-collection-2',
+								deletedAt: null,
+							},
+						}),
+				transactions: [shared],
+				feeAllocationScope: 'shared_or_unknown',
+			});
+			const result = aggregateReportRows(
+				[first, second],
+				'Day',
+				'Etc/UTC',
+				new Date('2026-01-01T00:00:00.000Z'),
+				new Date('2026-02-01T00:00:00.000Z'),
+				'CreatedAt',
+			);
+
+			expect(amount(result.totals.totalCardanoFees)).toBe(500n);
+			expect(result.totals.totalCardanoFees.completeness).toBe('complete');
+			expect(historyAmount(result, 'totalCardanoFees')).toBe(expectedHistory);
+			expect(result.wallets.reduce((sum, wallet) => sum + amount(wallet.metrics.totalCardanoFees), 0n)).toBe(
+				expectedWallet,
+			);
+			expect(result.historyFeeCompleteness).toBe('partial');
+			expect(result.warnings.map((warning) => warning.code)).toContain('SHARED_CARDANO_FEE_COMPONENT_ALLOCATION');
+		},
+	);
+
+	it('keeps exact zero shared fees complete across wallet and cohort boundaries', () => {
+		const requestKeys = ['Seller:zero-shared-first', 'Seller:zero-shared-second'];
+		const paymentKeys = ['zero-shared-chain-first', 'zero-shared-chain-second'];
+		const shared = transaction('zero-shared', 'Withdrawn', '2026-01-10T12:00:00.000Z', 0n, requestKeys, paymentKeys);
+		const first = row({
+			id: 'zero-shared-first',
+			blockchainIdentifier: 'zero-shared-chain-first',
+			createdAt: new Date('2026-01-05T12:00:00.000Z'),
+			transactions: [shared],
+		});
+		const second = row({
+			id: 'zero-shared-second',
+			blockchainIdentifier: 'zero-shared-chain-second',
+			createdAt: new Date('2026-01-20T12:00:00.000Z'),
+			managedWallet: {
+				id: 'wallet-2',
+				walletAddress: 'addr-wallet-2',
+				walletVkey: 'wallet-vkey-2',
+				collectionAddress: 'addr-collection-2',
+				deletedAt: null,
+			},
+			transactions: [shared],
+		});
+		const result = aggregateReportRows(
+			[first, second],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-02-01T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(result.totals.totalCardanoFees).toEqual({ amounts: [], completeness: 'complete' });
+		expect(result.totals.adminCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.wallets.every((wallet) => wallet.metrics.totalCardanoFees.completeness === 'complete')).toBe(true);
+		expect(result.wallets.every((wallet) => wallet.metrics.adminCardanoFees.completeness === 'partial')).toBe(true);
+		expect(result.history.every((entry) => entry.metrics.totalCardanoFees.completeness === 'complete')).toBe(true);
+		expect(result.history.every((entry) => entry.metrics.adminCardanoFees.completeness === 'partial')).toBe(true);
+		expect(result.historyFeeCompleteness).toBe('partial');
+	});
+
+	it('does not join positive fee components through a shared zero transaction', () => {
+		const sharedZero = transaction(
+			'mixed-shared-zero',
+			'Withdrawn',
+			'2026-01-10T12:00:00.000Z',
+			0n,
+			['Seller:mixed-first', 'Seller:mixed-second'],
+			['mixed-chain-first', 'mixed-chain-second'],
+		);
+		const first = row({
+			id: 'mixed-first',
+			blockchainIdentifier: 'mixed-chain-first',
+			createdAt: new Date('2026-01-05T12:00:00.000Z'),
+			transactions: [
+				transaction(
+					'mixed-first-fee',
+					'Withdrawn',
+					'2026-01-05T12:00:00.000Z',
+					100n,
+					['Seller:mixed-first'],
+					['mixed-chain-first'],
+				),
+				sharedZero,
+			],
+		});
+		const second = row({
+			id: 'mixed-second',
+			blockchainIdentifier: 'mixed-chain-second',
+			createdAt: new Date('2026-01-20T12:00:00.000Z'),
+			managedWallet: {
+				id: 'wallet-2',
+				walletAddress: 'addr-wallet-2',
+				walletVkey: 'wallet-vkey-2',
+				collectionAddress: 'addr-collection-2',
+				deletedAt: null,
+			},
+			transactions: [
+				transaction(
+					'mixed-second-fee',
+					'Withdrawn',
+					'2026-01-20T12:00:00.000Z',
+					200n,
+					['Seller:mixed-second'],
+					['mixed-chain-second'],
+				),
+				sharedZero,
+			],
+		});
+		const result = aggregateReportRows(
+			[first, second],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-01T00:00:00.000Z'),
+			new Date('2026-02-01T00:00:00.000Z'),
+			'CreatedAt',
+		);
+
+		expect(amount(result.totals.totalCardanoFees)).toBe(300n);
+		expect(amount(result.totals.adminCardanoFees)).toBe(0n);
+		expect(result.totals.adminCardanoFees.completeness).toBe('partial');
+		expect(result.wallets.map((wallet) => amount(wallet.metrics.totalCardanoFees))).toEqual([100n, 200n]);
+		expect(result.wallets.map((wallet) => amount(wallet.metrics.adminCardanoFees))).toEqual([0n, 0n]);
+		expect(historyAmount(result, 'totalCardanoFees')).toBe(300n);
+		expect(historyAmount(result, 'adminCardanoFees')).toBe(0n);
+		expect(result.historyFeeCompleteness).toBe('partial');
+	});
+
+	it('uses local calendar boundaries across a 23-hour DST day', () => {
+		const seller = row(
+			{
+				onChainState: null,
+				transactions: [],
+				createdAt: new Date('2026-03-08T06:00:00.000Z'),
+			},
+			'RequestedGross',
+		);
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'America/New_York',
+			new Date('2026-03-08T05:00:00.000Z'),
+			new Date('2026-03-10T04:00:00.000Z'),
+			'RevenueRecognizedAt',
+		);
+
+		expect(result.history.map((entry) => [entry.bucketStart.toISOString(), entry.bucketEnd.toISOString()])).toEqual([
+			['2026-03-08T05:00:00.000Z', '2026-03-09T04:00:00.000Z'],
+			['2026-03-09T04:00:00.000Z', '2026-03-10T04:00:00.000Z'],
+		]);
+		expect(result.history[0].bucketEnd.getTime() - result.history[0].bucketStart.getTime()).toBe(23 * 60 * 60 * 1000);
+		expect(result.history[0].metrics.sellerGrossRevenue.amounts).toEqual([{ unit: 'lovelace', amount: 100_000_000n }]);
+	});
+
+	it.each([
+		{
+			bucket: 'Week' as const,
+			from: '2026-01-07T00:00:00.000Z',
+			to: '2026-01-13T00:00:00.000Z',
+			expected: [
+				['2026-01-05T00:00:00.000Z', '2026-01-12T00:00:00.000Z'],
+				['2026-01-12T00:00:00.000Z', '2026-01-19T00:00:00.000Z'],
+			],
+		},
+		{
+			bucket: 'Month' as const,
+			from: '2026-01-15T00:00:00.000Z',
+			to: '2026-03-02T00:00:00.000Z',
+			expected: [
+				['2026-01-01T00:00:00.000Z', '2026-02-01T00:00:00.000Z'],
+				['2026-02-01T00:00:00.000Z', '2026-03-01T00:00:00.000Z'],
+				['2026-03-01T00:00:00.000Z', '2026-04-01T00:00:00.000Z'],
+			],
+		},
+	])('builds $bucket calendar buckets', ({ bucket, from, to, expected }) => {
+		const result = aggregateReportRows([], bucket, 'Etc/UTC', new Date(from), new Date(to), 'CreatedAt');
+		expect(result.history.map((entry) => [entry.bucketStart.toISOString(), entry.bucketEnd.toISOString()])).toEqual(
+			expected,
+		);
+	});
+
+	it('places accounting-allocated actor fees in a deterministic revenue bucket', () => {
+		const seller = row(
+			{
+				sellerCardanoFees: 200n,
+				transactions: [transaction('withdraw-fee', 'Withdrawn', '2026-01-02T12:00:00.000Z', 300n)],
+			},
+			'Billable',
+			'RevenueRecognizedAt',
+			new Date('2026-01-02T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+		);
+		const result = aggregateReportRows(
+			[seller],
+			'Day',
+			'Etc/UTC',
+			new Date('2026-01-02T00:00:00.000Z'),
+			new Date('2026-01-03T00:00:00.000Z'),
+			'RevenueRecognizedAt',
+		);
+
+		expect(amount(result.totals.sellerCardanoFees)).toBe(200n);
+		expect(result.totals.sellerCardanoFees.completeness).toBe('partial');
+		expect(result.history[0].metrics.sellerCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 200n }],
+			completeness: 'partial',
+		});
+		expect(result.history[0].metrics.sellerNetRevenue.completeness).toBe('partial');
+		expect(result.history[0].metrics.adminCardanoFees.completeness).toBe('partial');
+		expect(amount(result.history[0].metrics.totalCardanoFees)).toBe(300n);
+		expect(result.historyFeeCompleteness).toBe('partial');
+		expect(result.warnings.map((warning) => warning.code)).toContain('HISTORY_ACTOR_CARDANO_FEE_ALLOCATION_PARTIAL');
+	});
+
+	it('runs a cancellation checkpoint during large synchronous aggregation', () => {
+		const rows = Array.from({ length: 600 }, (_value, index) =>
+			row({
+				id: `checkpoint-${index}`,
+				blockchainIdentifier: `checkpoint-chain-${index}`,
+				transactions: [],
+			}),
+		);
+		const stopped = new Error('stopped');
+		let checks = 0;
+
+		expect(() =>
+			aggregateReportRows(
+				rows,
+				'Day',
+				'Etc/UTC',
+				new Date('2026-01-01T00:00:00.000Z'),
+				new Date('2026-02-01T00:00:00.000Z'),
+				'CreatedAt',
+				() => {
+					checks += 1;
+					if (checks === 3) throw stopped;
+				},
+			),
+		).toThrow(stopped);
+		expect(checks).toBe(3);
+	});
+});

--- a/src/services/transaction-report/aggregate.ts
+++ b/src/services/transaction-report/aggregate.ts
@@ -1,0 +1,747 @@
+import { addAmounts, getAtomicAmount, subtractAmounts, type AtomicAmount } from './amounts';
+import {
+	addAggregateMetric as addMetric,
+	createAggregateMetric as createMetric,
+	finalizeReportAggregate as finalizeAggregate,
+	readAggregateMetricAmounts as readMetricAmounts,
+} from './aggregate-amounts';
+import { getKnownReportTransactionDates, getReportTransactionCount } from './aggregate-counts';
+import { analyzeReportFees, assignCompleteReportFeeReconciliation, type FeeAnalysis } from './aggregate-fees';
+import type { ReportMetricWindow, ReportRow, ReportWarning } from './records';
+import { groupReportRowsByPayment } from './row-groups';
+import { NO_REPORT_CHECKPOINT, runReportCheckpoint, type ReportCheckpoint } from './checkpoint';
+
+export { serializeReportAggregateResult } from './aggregate-serialization';
+
+export type ReportBucket = 'Day' | 'Week' | 'Month';
+export type RequestedReportBucket = 'Auto' | ReportBucket;
+export type ReportMetricCompleteness = 'complete' | 'partial';
+
+export type ReportAggregateMetric = {
+	amounts: AtomicAmount[];
+	completeness: ReportMetricCompleteness;
+};
+
+export type ReportAggregate = {
+	transactionCount: number;
+	transactionCountCompleteness: ReportMetricCompleteness;
+	sellerGrossRevenue: ReportAggregateMetric;
+	protocolFees: ReportAggregateMetric;
+	sellerCardanoFees: ReportAggregateMetric;
+	actorCardanoFees: ReportAggregateMetric;
+	adminCardanoFees: ReportAggregateMetric;
+	totalCardanoFees: ReportAggregateMetric;
+	sellerNetRevenue: ReportAggregateMetric;
+	buyerGrossSpend: ReportAggregateMetric;
+	returnedFunds: ReportAggregateMetric;
+	buyerCardanoFees: ReportAggregateMetric;
+	buyerNetSpend: ReportAggregateMetric;
+};
+
+export type ReportWalletAggregate = {
+	managedWallet: ReportRow['managedWallet'];
+	role: ReportRow['role'];
+	metrics: ReportAggregate;
+};
+
+export type ReportHistoryAggregate = {
+	bucketStart: Date;
+	bucketEnd: Date;
+	metrics: ReportAggregate;
+};
+
+export type ReportAggregateResult = {
+	totals: ReportAggregate;
+	wallets: ReportWalletAggregate[];
+	history: ReportHistoryAggregate[];
+	bucket: ReportBucket;
+	warnings: ReportWarning[];
+	historyFeeCompleteness: ReportMetricCompleteness;
+};
+
+type AggregateMetricName = Exclude<keyof ReportAggregate, 'transactionCount' | 'transactionCountCompleteness'>;
+type ReportDateBasis = ReportMetricWindow['dateBasis'];
+type LocalDate = Readonly<{ year: number; month: number; day: number }>;
+type MutableHistoryAggregate = ReportHistoryAggregate & { transactionKeys: Set<string> };
+
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
+const MAX_HISTORY_BUCKETS = 10_000;
+const DATE_BOUNDARY_SEARCH_HOURS = 36;
+
+function createAggregate(): ReportAggregate {
+	return {
+		transactionCount: 0,
+		transactionCountCompleteness: 'complete',
+		sellerGrossRevenue: createMetric(),
+		protocolFees: createMetric(),
+		sellerCardanoFees: createMetric(),
+		actorCardanoFees: createMetric(),
+		adminCardanoFees: createMetric(),
+		totalCardanoFees: createMetric(),
+		sellerNetRevenue: createMetric(),
+		buyerGrossSpend: createMetric(),
+		returnedFunds: createMetric(),
+		buyerCardanoFees: createMetric(),
+		buyerNetSpend: createMetric(),
+	};
+}
+
+function hasAmounts(amounts: readonly AtomicAmount[] | null): boolean {
+	return amounts != null && amounts.length > 0;
+}
+
+function isProtocolMetricComplete(row: ReportRow): boolean {
+	return row.seller?.protocolFee.completeness === 'exact' || row.seller?.protocolFee.completeness === 'not_applicable';
+}
+
+function combineCompleteness(...values: ReportMetricCompleteness[]): ReportMetricCompleteness {
+	return values.every((value) => value === 'complete') ? 'complete' : 'partial';
+}
+
+function addRoleMetrics(aggregate: ReportAggregate, row: ReportRow): void {
+	if (row.seller != null) {
+		const protocolCompleteness = isProtocolMetricComplete(row) ? 'complete' : 'partial';
+		const actorFeeCompleteness = row.actorCardanoFeeAllocation.completeness;
+		addMetric(aggregate.sellerGrossRevenue, row.seller.grossRevenue);
+		addMetric(aggregate.protocolFees, row.seller.protocolFee.amounts ?? [], protocolCompleteness);
+		addMetric(aggregate.sellerCardanoFees, row.seller.cardanoFees, actorFeeCompleteness);
+		addMetric(
+			aggregate.sellerNetRevenue,
+			row.seller.netRevenue,
+			combineCompleteness(protocolCompleteness, actorFeeCompleteness),
+		);
+	}
+	if (row.buyer != null) {
+		const actorFeeCompleteness = row.actorCardanoFeeAllocation.completeness;
+		addMetric(aggregate.buyerGrossSpend, row.buyer.grossSpend);
+		addMetric(aggregate.returnedFunds, row.buyer.returnedFunds);
+		addMetric(aggregate.buyerCardanoFees, row.buyer.cardanoFees, actorFeeCompleteness);
+		addMetric(aggregate.buyerNetSpend, row.buyer.netSpend, actorFeeCompleteness);
+	}
+}
+
+function setFeeReconciliation(aggregate: ReportAggregate, analysis: FeeAnalysis): void {
+	addMetric(
+		aggregate.actorCardanoFees,
+		analysis.actor === 0n ? [] : [{ unit: 'lovelace', amount: analysis.actor }],
+		analysis.actorCompleteness,
+	);
+	addMetric(
+		aggregate.totalCardanoFees,
+		analysis.total === 0n ? [] : [{ unit: 'lovelace', amount: analysis.total }],
+		analysis.totalCompleteness,
+	);
+	addMetric(
+		aggregate.adminCardanoFees,
+		analysis.admin === 0n ? [] : [{ unit: 'lovelace', amount: analysis.admin }],
+		analysis.adminCompleteness,
+	);
+}
+
+function aggregateGlobalRows(
+	rows: readonly ReportRow[],
+	dateBasis: ReportDateBasis,
+	from: Date,
+	to: Date,
+	checkpoint: ReportCheckpoint,
+): { metrics: ReportAggregate; fees: FeeAnalysis } {
+	const aggregate = createAggregate();
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		addRoleMetrics(aggregate, row);
+	}
+	Object.assign(aggregate, getReportTransactionCount(rows, dateBasis, from, to));
+	const fees = analyzeReportFees(rows, dateBasis, from, to, checkpoint);
+	setFeeReconciliation(aggregate, fees);
+	return { metrics: aggregate, fees };
+}
+
+function assertValidRange(from: Date, to: Date): void {
+	if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+		throw new RangeError('Report dates must be valid');
+	}
+	if (to.getTime() <= from.getTime()) throw new RangeError('Report to date must be after from date');
+}
+
+export function chooseReportBucket(from: Date, to: Date, requested: RequestedReportBucket = 'Auto'): ReportBucket {
+	assertValidRange(from, to);
+	if (requested !== 'Auto') return requested;
+	const rangeMilliseconds = to.getTime() - from.getTime();
+	if (rangeMilliseconds <= 30 * DAY_MILLISECONDS) return 'Day';
+	if (rangeMilliseconds <= 366 * DAY_MILLISECONDS) return 'Week';
+	return 'Month';
+}
+
+function localDateOrdinal(date: LocalDate): number {
+	const value = new Date(0);
+	value.setUTCFullYear(date.year, date.month - 1, date.day);
+	value.setUTCHours(0, 0, 0, 0);
+	return value.getTime();
+}
+
+function localDateFromOrdinal(ordinal: number): LocalDate {
+	const value = new Date(ordinal);
+	return { year: value.getUTCFullYear(), month: value.getUTCMonth() + 1, day: value.getUTCDate() };
+}
+
+function createLocalDateReader(timeZone: string): (date: Date) => LocalDate {
+	const formatter = new Intl.DateTimeFormat('en-CA', {
+		timeZone,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	});
+	return (date) => {
+		const fields = new Map(
+			formatter
+				.formatToParts(date)
+				.filter((part) => part.type !== 'literal')
+				.map((part) => [part.type, Number(part.value)]),
+		);
+		const year = fields.get('year');
+		const month = fields.get('month');
+		const day = fields.get('day');
+		if (year == null || month == null || day == null) throw new RangeError('Unable to read local report date');
+		return { year, month, day };
+	};
+}
+
+function getBucketLocalStart(localDate: LocalDate, bucket: ReportBucket): LocalDate {
+	if (bucket === 'Day') return localDate;
+	if (bucket === 'Month') return { ...localDate, day: 1 };
+	const ordinal = localDateOrdinal(localDate);
+	const dayOfWeek = new Date(ordinal).getUTCDay();
+	const daysSinceMonday = (dayOfWeek + 6) % 7;
+	return localDateFromOrdinal(ordinal - daysSinceMonday * DAY_MILLISECONDS);
+}
+
+function getNextBucketLocalStart(localDate: LocalDate, bucket: ReportBucket): LocalDate {
+	if (bucket === 'Month') {
+		return localDate.month === 12
+			? { year: localDate.year + 1, month: 1, day: 1 }
+			: { year: localDate.year, month: localDate.month + 1, day: 1 };
+	}
+	const dayCount = bucket === 'Day' ? 1 : 7;
+	return localDateFromOrdinal(localDateOrdinal(localDate) + dayCount * DAY_MILLISECONDS);
+}
+
+function findLocalDateStart(localDate: LocalDate, readLocalDate: (date: Date) => LocalDate): Date {
+	const targetOrdinal = localDateOrdinal(localDate);
+	let low = targetOrdinal - DATE_BOUNDARY_SEARCH_HOURS * 60 * 60 * 1000;
+	let high = targetOrdinal + DATE_BOUNDARY_SEARCH_HOURS * 60 * 60 * 1000;
+	while (localDateOrdinal(readLocalDate(new Date(low))) >= targetOrdinal) low -= DAY_MILLISECONDS;
+	while (localDateOrdinal(readLocalDate(new Date(high))) < targetOrdinal) high += DAY_MILLISECONDS;
+
+	while (high - low > 1) {
+		const middle = low + Math.floor((high - low) / 2);
+		if (localDateOrdinal(readLocalDate(new Date(middle))) >= targetOrdinal) high = middle;
+		else low = middle;
+	}
+	return new Date(high);
+}
+
+function createHistoryBuckets(
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	checkpoint: ReportCheckpoint,
+): MutableHistoryAggregate[] {
+	const history: MutableHistoryAggregate[] = [];
+	let localStart = getBucketLocalStart(readLocalDate(from), bucket);
+	for (let index = 0; index < MAX_HISTORY_BUCKETS; index += 1) {
+		runReportCheckpoint(index, checkpoint);
+		const nextLocalStart = getNextBucketLocalStart(localStart, bucket);
+		const bucketStart = findLocalDateStart(localStart, readLocalDate);
+		const bucketEnd = findLocalDateStart(nextLocalStart, readLocalDate);
+		if (bucketStart.getTime() >= to.getTime()) return history;
+		if (bucketEnd.getTime() > from.getTime() && bucketEnd.getTime() > bucketStart.getTime()) {
+			history.push({ bucketStart, bucketEnd, metrics: createAggregate(), transactionKeys: new Set() });
+		}
+		localStart = nextLocalStart;
+	}
+	throw new RangeError(`Report history exceeds ${MAX_HISTORY_BUCKETS} buckets`);
+}
+
+function getEventBucket(
+	date: Date | null,
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	historyByStart: ReadonlyMap<number, MutableHistoryAggregate>,
+): MutableHistoryAggregate | null {
+	if (date == null || date.getTime() < from.getTime() || date.getTime() >= to.getTime()) return null;
+	const localStart = getBucketLocalStart(readLocalDate(date), bucket);
+	return historyByStart.get(findLocalDateStart(localStart, readLocalDate).getTime()) ?? null;
+}
+
+function recordHistoryRow(bucket: MutableHistoryAggregate, row: ReportRow): void {
+	if (bucket.transactionKeys.has(row.blockchainIdentifier)) return;
+	bucket.transactionKeys.add(row.blockchainIdentifier);
+	bucket.metrics.transactionCount += 1;
+}
+
+function markMetricPartial(history: readonly MutableHistoryAggregate[], metricName: AggregateMetricName): void {
+	for (const entry of history) entry.metrics[metricName].completeness = 'partial';
+}
+
+function getCohortDate(row: ReportRow, dateBasis: Exclude<ReportDateBasis, 'RevenueRecognizedAt'>): Date | null {
+	return dateBasis === 'CreatedAt' ? row.createdAt : row.timestamps.fundsLockedAt;
+}
+
+function addCohortHistory(
+	row: ReportRow,
+	dateBasis: Exclude<ReportDateBasis, 'RevenueRecognizedAt'>,
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	historyByStart: ReadonlyMap<number, MutableHistoryAggregate>,
+	missingTimestampMetrics: Set<AggregateMetricName>,
+): void {
+	const entry = getEventBucket(getCohortDate(row, dateBasis), from, to, bucket, readLocalDate, historyByStart);
+	if (entry == null) {
+		const metricNames: AggregateMetricName[] =
+			row.role === 'Seller'
+				? ['sellerGrossRevenue', 'protocolFees', 'sellerCardanoFees', 'sellerNetRevenue']
+				: ['buyerGrossSpend', 'returnedFunds', 'buyerCardanoFees', 'buyerNetSpend'];
+		for (const metricName of metricNames) missingTimestampMetrics.add(metricName);
+		return;
+	}
+	recordHistoryRow(entry, row);
+	addRoleMetrics(entry.metrics, row);
+}
+
+function addSellerRevenueHistory(
+	row: ReportRow,
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	historyByStart: ReadonlyMap<number, MutableHistoryAggregate>,
+	missingTimestampMetrics: Set<AggregateMetricName>,
+): void {
+	if (row.seller == null) return;
+	const date = row.timestamps.sellerRevenueRecognizedAt;
+	if (date == null) {
+		if (row.seller.grossRevenue == null || hasAmounts(row.seller.grossRevenue)) {
+			missingTimestampMetrics.add('sellerGrossRevenue');
+			missingTimestampMetrics.add('sellerNetRevenue');
+		}
+		if (hasAmounts(row.seller.protocolFee.amounts) || row.seller.protocolFee.completeness === 'insufficient_data') {
+			missingTimestampMetrics.add('protocolFees');
+			missingTimestampMetrics.add('sellerNetRevenue');
+		}
+	}
+	const entry = getEventBucket(date, from, to, bucket, readLocalDate, historyByStart);
+	if (entry == null) {
+		if (row.actorCardanoFeeAllocation.completeness === 'partial') {
+			missingTimestampMetrics.add('sellerCardanoFees');
+			missingTimestampMetrics.add('sellerNetRevenue');
+		}
+		return;
+	}
+	recordHistoryRow(entry, row);
+	const protocolCompleteness = isProtocolMetricComplete(row) ? 'complete' : 'partial';
+	const actorFeeCompleteness = row.actorCardanoFeeAllocation.completeness;
+	addMetric(entry.metrics.sellerGrossRevenue, row.seller.grossRevenue);
+	addMetric(entry.metrics.protocolFees, row.seller.protocolFee.amounts ?? [], protocolCompleteness);
+	addMetric(entry.metrics.sellerCardanoFees, row.seller.cardanoFees, actorFeeCompleteness);
+	addMetric(
+		entry.metrics.sellerNetRevenue,
+		row.seller.netRevenue,
+		combineCompleteness(protocolCompleteness, actorFeeCompleteness),
+	);
+}
+
+function addBuyerRevenueHistory(
+	row: ReportRow,
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	historyByStart: ReadonlyMap<number, MutableHistoryAggregate>,
+	missingTimestampMetrics: Set<AggregateMetricName>,
+): void {
+	if (row.buyer == null) return;
+	const grossEntry = getEventBucket(row.timestamps.buyerGrossSpendAt, from, to, bucket, readLocalDate, historyByStart);
+	if (row.timestamps.buyerGrossSpendAt == null && (row.buyer.grossSpend == null || hasAmounts(row.buyer.grossSpend))) {
+		missingTimestampMetrics.add('buyerGrossSpend');
+		missingTimestampMetrics.add('buyerNetSpend');
+	}
+	if (grossEntry == null && row.actorCardanoFeeAllocation.completeness === 'partial') {
+		missingTimestampMetrics.add('buyerCardanoFees');
+		missingTimestampMetrics.add('buyerNetSpend');
+	} else if (grossEntry != null) {
+		recordHistoryRow(grossEntry, row);
+		addMetric(grossEntry.metrics.buyerGrossSpend, row.buyer.grossSpend);
+		addMetric(grossEntry.metrics.buyerCardanoFees, row.buyer.cardanoFees, row.actorCardanoFeeAllocation.completeness);
+		addMetric(
+			grossEntry.metrics.buyerNetSpend,
+			row.buyer.grossSpend == null ? null : addAmounts(row.buyer.grossSpend, row.buyer.cardanoFees),
+			row.actorCardanoFeeAllocation.completeness,
+		);
+	}
+
+	const hasReturnedValue = hasAmounts(row.buyer.returnedFunds) || row.buyer.returnedFunds == null;
+	const returnEntry = getEventBucket(row.timestamps.buyerReturnedAt, from, to, bucket, readLocalDate, historyByStart);
+	if (row.timestamps.buyerReturnedAt == null && hasReturnedValue) {
+		missingTimestampMetrics.add('returnedFunds');
+		missingTimestampMetrics.add('buyerNetSpend');
+	} else if (returnEntry != null) {
+		recordHistoryRow(returnEntry, row);
+		addMetric(returnEntry.metrics.returnedFunds, row.buyer.returnedFunds);
+		addMetric(
+			returnEntry.metrics.buyerNetSpend,
+			row.buyer.returnedFunds == null ? null : subtractAmounts([], row.buyer.returnedFunds),
+			row.actorCardanoFeeAllocation.completeness,
+		);
+	}
+}
+
+function walletGroupKey(row: ReportRow): string {
+	return `${row.managedWallet == null ? 'unassigned' : `wallet:${row.managedWallet.id}`}:${row.role}`;
+}
+
+function buildWalletAggregates(
+	rows: readonly ReportRow[],
+	fees: FeeAnalysis,
+	dateBasis: ReportDateBasis,
+	from: Date,
+	to: Date,
+	checkpoint: ReportCheckpoint,
+): ReportWalletAggregate[] {
+	const groupedRows = new Map<string, { managedWallet: ReportRow['managedWallet']; rows: ReportRow[] }>();
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const key = walletGroupKey(row);
+		const group = groupedRows.get(key) ?? { managedWallet: row.managedWallet, rows: [] };
+		group.rows.push(row);
+		groupedRows.set(key, group);
+	}
+	const metricsByGroup = new Map<string, ReportAggregate>();
+	let groupIndex = 0;
+	for (const [key, group] of groupedRows) {
+		runReportCheckpoint(groupIndex, checkpoint);
+		groupIndex += 1;
+		const metrics = createAggregate();
+		for (const [index, row] of group.rows.entries()) {
+			runReportCheckpoint(index, checkpoint);
+			addRoleMetrics(metrics, row);
+		}
+		Object.assign(metrics, getReportTransactionCount(group.rows, dateBasis, from, to));
+		metricsByGroup.set(key, metrics);
+	}
+	const rowsByPayment = groupReportRowsByPayment(rows, checkpoint);
+	const groupsByPayment = new Map<string, string[]>();
+	let paymentIndex = 0;
+	for (const [paymentKey, paymentRows] of rowsByPayment) {
+		runReportCheckpoint(paymentIndex, checkpoint);
+		paymentIndex += 1;
+		const groups = Array.from(new Set(paymentRows.map(walletGroupKey))).sort((left, right) =>
+			left.localeCompare(right),
+		);
+		groupsByPayment.set(paymentKey, groups);
+	}
+	for (const [index, component] of fees.components.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const componentGroups = Array.from(new Set(component.paymentKeys.flatMap((key) => groupsByPayment.get(key)!)));
+		const ownerGroups = Array.from(
+			new Set(
+				component.paymentKeys.flatMap((key) =>
+					(rowsByPayment.get(key) ?? []).filter((row) => row.isFeeReconciliationOwner).map(walletGroupKey),
+				),
+			),
+		);
+		if (ownerGroups.length !== 1) {
+			for (const group of componentGroups) {
+				metricsByGroup.get(group)!.actorCardanoFees.completeness = 'partial';
+				metricsByGroup.get(group)!.adminCardanoFees.completeness = 'partial';
+				metricsByGroup.get(group)!.totalCardanoFees.completeness = 'partial';
+			}
+			continue;
+		}
+		const metrics = metricsByGroup.get(ownerGroups[0])!;
+		addMetric(
+			metrics.actorCardanoFees,
+			component.actorFees === 0n ? [] : [{ unit: 'lovelace', amount: component.actorFees }],
+			component.isActorComplete ? 'complete' : 'partial',
+		);
+		addMetric(
+			metrics.adminCardanoFees,
+			component.admin == null ? null : [{ unit: 'lovelace', amount: component.admin }],
+			component.isAdminComplete ? 'complete' : 'partial',
+		);
+		addMetric(
+			metrics.totalCardanoFees,
+			component.total === 0n ? [] : [{ unit: 'lovelace', amount: component.total }],
+			component.isTotalComplete ? 'complete' : 'partial',
+		);
+	}
+	if (fees.actorCompleteness === 'partial') {
+		for (const metrics of metricsByGroup.values()) metrics.actorCardanoFees.completeness = 'partial';
+	}
+	if (fees.totalCompleteness === 'partial') {
+		for (const metrics of metricsByGroup.values()) metrics.totalCardanoFees.completeness = 'partial';
+	}
+	if (fees.adminCompleteness === 'partial') {
+		for (const metrics of metricsByGroup.values()) metrics.adminCardanoFees.completeness = 'partial';
+	}
+	return Array.from(groupedRows)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([key, group], index) => {
+			runReportCheckpoint(index, checkpoint);
+			return {
+				managedWallet: group.managedWallet,
+				role: group.rows[0].role,
+				metrics: metricsByGroup.get(key)!,
+			};
+		});
+}
+
+function addFeeHistory(
+	rows: readonly ReportRow[],
+	dateBasis: ReportDateBasis,
+	fees: FeeAnalysis,
+	from: Date,
+	to: Date,
+	bucket: ReportBucket,
+	readLocalDate: (date: Date) => LocalDate,
+	historyByStart: ReadonlyMap<number, MutableHistoryAggregate>,
+	mutableHistory: readonly MutableHistoryAggregate[],
+	checkpoint: ReportCheckpoint,
+): boolean {
+	const rowsByPayment = groupReportRowsByPayment(rows, checkpoint);
+	const cohortBucketByPayment = new Map<string, MutableHistoryAggregate | null>();
+	if (dateBasis !== 'RevenueRecognizedAt') {
+		let paymentIndex = 0;
+		for (const [paymentKey, paymentRows] of rowsByPayment) {
+			runReportCheckpoint(paymentIndex, checkpoint);
+			paymentIndex += 1;
+			const entries = paymentRows.map((row) =>
+				getEventBucket(getCohortDate(row, dateBasis), from, to, bucket, readLocalDate, historyByStart),
+			);
+			const starts = new Set(entries.map((entry) => entry?.bucketStart.getTime() ?? null));
+			cohortBucketByPayment.set(paymentKey, starts.size === 1 ? entries[0] : null);
+		}
+	}
+	let hasTotalHistoryGap = false;
+	let hasAdminHistoryGap = false;
+	let hasActorHistoryGap = false;
+	for (const [index, component] of fees.components.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		if (dateBasis === 'RevenueRecognizedAt') {
+			for (const transaction of component.transactions) {
+				const entry = getEventBucket(transaction.blockTime, from, to, bucket, readLocalDate, historyByStart);
+				if (entry == null) {
+					if (transaction.fee !== 0n) {
+						hasTotalHistoryGap = true;
+						if (component.isAdminComplete && component.actorFees === 0n) hasAdminHistoryGap = true;
+					}
+				} else if (transaction.fee !== 0n) {
+					addMetric(entry.metrics.totalCardanoFees, [{ unit: 'lovelace', amount: transaction.fee }]);
+					if (component.isAdminComplete && component.actorFees === 0n)
+						addMetric(entry.metrics.adminCardanoFees, [{ unit: 'lovelace', amount: transaction.fee }]);
+				}
+			}
+			if (component.isAdminComplete && component.actorFees !== 0n && component.admin !== 0n) {
+				hasAdminHistoryGap = true;
+			}
+			if (component.actorFees !== 0n || !component.isActorComplete) hasActorHistoryGap = true;
+			continue;
+		}
+		const ownerPaymentKeys = component.paymentKeys.filter((key) =>
+			(rowsByPayment.get(key) ?? []).some((row) => row.isFeeReconciliationOwner),
+		);
+		const componentEntry =
+			ownerPaymentKeys.length === 1 ? (cohortBucketByPayment.get(ownerPaymentKeys[0]) ?? null) : null;
+		if (component.total !== 0n) {
+			if (componentEntry == null) hasTotalHistoryGap = true;
+			else
+				addMetric(
+					componentEntry.metrics.totalCardanoFees,
+					[{ unit: 'lovelace', amount: component.total }],
+					component.isTotalComplete ? 'complete' : 'partial',
+				);
+		}
+		if (component.admin != null && component.admin !== 0n) {
+			if (componentEntry == null) hasAdminHistoryGap = true;
+			else addMetric(componentEntry.metrics.adminCardanoFees, [{ unit: 'lovelace', amount: component.admin }]);
+		}
+		if (component.actorFees !== 0n) {
+			if (componentEntry == null) hasActorHistoryGap = true;
+			else
+				addMetric(
+					componentEntry.metrics.actorCardanoFees,
+					[{ unit: 'lovelace', amount: component.actorFees }],
+					component.isActorComplete ? 'complete' : 'partial',
+				);
+		} else if (!component.isActorComplete) hasActorHistoryGap = true;
+	}
+	const historyActor = mutableHistory.reduce(
+		(sum, entry) => sum + getAtomicAmount(readMetricAmounts(entry.metrics.actorCardanoFees), 'lovelace'),
+		0n,
+	);
+	const historyTotal = mutableHistory.reduce(
+		(sum, entry) => sum + getAtomicAmount(readMetricAmounts(entry.metrics.totalCardanoFees), 'lovelace'),
+		0n,
+	);
+	const historyAdmin = mutableHistory.reduce(
+		(sum, entry) => sum + getAtomicAmount(readMetricAmounts(entry.metrics.adminCardanoFees), 'lovelace'),
+		0n,
+	);
+	const isTotalHistoryComplete =
+		!hasTotalHistoryGap && fees.totalCompleteness === 'complete' && historyTotal === fees.total;
+	const isAdminHistoryComplete =
+		!hasAdminHistoryGap && fees.adminCompleteness === 'complete' && historyAdmin === fees.admin;
+	const isActorHistoryComplete =
+		!hasActorHistoryGap && fees.actorCompleteness === 'complete' && historyActor === fees.actor;
+	if (!isActorHistoryComplete) markMetricPartial(mutableHistory, 'actorCardanoFees');
+	if (!isTotalHistoryComplete) markMetricPartial(mutableHistory, 'totalCardanoFees');
+	if (!isAdminHistoryComplete) markMetricPartial(mutableHistory, 'adminCardanoFees');
+	return isActorHistoryComplete && isTotalHistoryComplete && isAdminHistoryComplete;
+}
+
+export function aggregateReportRows(
+	rows: readonly ReportRow[],
+	requestedBucket: RequestedReportBucket,
+	timeZone: string,
+	from: Date,
+	to: Date,
+	dateBasis: ReportDateBasis,
+	checkpoint: ReportCheckpoint = NO_REPORT_CHECKPOINT,
+): ReportAggregateResult {
+	rows = assignCompleteReportFeeReconciliation(rows, dateBasis, from, to, checkpoint);
+	checkpoint();
+	const bucket = chooseReportBucket(from, to, requestedBucket);
+	const readLocalDate = createLocalDateReader(timeZone);
+	const mutableHistory = createHistoryBuckets(from, to, bucket, readLocalDate, checkpoint);
+	const historyByStart = new Map(mutableHistory.map((entry) => [entry.bucketStart.getTime(), entry]));
+	const missingTimestampMetrics = new Set<AggregateMetricName>();
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		if (dateBasis === 'RevenueRecognizedAt') {
+			for (const date of getKnownReportTransactionDates(row)) {
+				const entry = getEventBucket(date, from, to, bucket, readLocalDate, historyByStart);
+				if (entry != null) recordHistoryRow(entry, row);
+			}
+			addSellerRevenueHistory(row, from, to, bucket, readLocalDate, historyByStart, missingTimestampMetrics);
+			addBuyerRevenueHistory(row, from, to, bucket, readLocalDate, historyByStart, missingTimestampMetrics);
+		} else {
+			addCohortHistory(row, dateBasis, from, to, bucket, readLocalDate, historyByStart, missingTimestampMetrics);
+		}
+	}
+	const global = aggregateGlobalRows(rows, dateBasis, from, to, checkpoint);
+	const totals = global.metrics;
+	const isFeeHistoryComplete = addFeeHistory(
+		rows,
+		dateBasis,
+		global.fees,
+		from,
+		to,
+		bucket,
+		readLocalDate,
+		historyByStart,
+		mutableHistory,
+		checkpoint,
+	);
+	for (const metricName of missingTimestampMetrics) markMetricPartial(mutableHistory, metricName);
+	if (totals.transactionCountCompleteness === 'partial') {
+		for (const entry of mutableHistory) entry.metrics.transactionCountCompleteness = 'partial';
+	}
+
+	const warnings: ReportWarning[] = [];
+	const detailRowCountsByPayment = new Map<string, number>();
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		detailRowCountsByPayment.set(
+			row.blockchainIdentifier,
+			(detailRowCountsByPayment.get(row.blockchainIdentifier) ?? 0) + 1,
+		);
+	}
+	if (
+		global.fees.components.some(
+			(component) =>
+				component.paymentKeys.length > 1 ||
+				component.paymentKeys.some((key) => (detailRowCountsByPayment.get(key) ?? 0) > 1),
+		)
+	) {
+		warnings.push({
+			code: 'SHARED_CARDANO_FEE_COMPONENT_ALLOCATION',
+			message:
+				'Shared Cardano fee components use one stable request owner for reconciliation. This is not economic wallet attribution.',
+			rowId: null,
+		});
+	}
+	const hasActorFeeAllocation = rows.some((row) => row.actorCardanoFeeAllocation.completeness === 'partial');
+	if (hasActorFeeAllocation) {
+		warnings.push({
+			code: 'HISTORY_ACTOR_CARDANO_FEE_ALLOCATION_PARTIAL',
+			message:
+				'Stored actor Cardano fees use an accounting event for history because their exact transaction time is unavailable.',
+			rowId: null,
+		});
+	}
+	if (totals.transactionCountCompleteness === 'partial') {
+		warnings.push({
+			code: 'TRANSACTION_COUNT_PARTIAL',
+			message:
+				'One or more logical payments lack the accounting time needed to prove date-range membership. Distinct counts are partial.',
+			rowId: null,
+		});
+	}
+	if (
+		totals.actorCardanoFees.completeness === 'partial' ||
+		totals.totalCardanoFees.completeness === 'partial' ||
+		totals.adminCardanoFees.completeness === 'partial'
+	) {
+		warnings.push({
+			code: 'CARDANO_FEE_COVERAGE_PARTIAL',
+			message:
+				'Transaction evidence, filtered related requests, or actor fee timing prevents an exact Cardano fee reconciliation.',
+			rowId: null,
+		});
+	}
+	if (!isFeeHistoryComplete) {
+		warnings.push({
+			code: 'HISTORY_CARDANO_FEE_ALLOCATION_PARTIAL',
+			message: 'Related logical payments do not resolve to one exact fee history bucket.',
+			rowId: null,
+		});
+	}
+	if (missingTimestampMetrics.size > 0) {
+		warnings.push({
+			code: 'HISTORY_ECONOMIC_TIMESTAMP_MISSING',
+			message: 'One or more economic amounts lack the confirmed chain time required for an exact history bucket.',
+			rowId: null,
+		});
+	}
+
+	const wallets = buildWalletAggregates(rows, global.fees, dateBasis, from, to, checkpoint);
+	finalizeAggregate(totals);
+	for (const [index, wallet] of wallets.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		finalizeAggregate(wallet.metrics);
+	}
+	for (const [index, entry] of mutableHistory.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		finalizeAggregate(entry.metrics);
+	}
+
+	return {
+		totals,
+		wallets,
+		history: mutableHistory.map(({ transactionKeys: _transactionKeys, ...entry }) => entry),
+		bucket,
+		warnings,
+		historyFeeCompleteness:
+			!isFeeHistoryComplete ||
+			hasActorFeeAllocation ||
+			totals.actorCardanoFees.completeness === 'partial' ||
+			totals.totalCardanoFees.completeness === 'partial' ||
+			totals.adminCardanoFees.completeness === 'partial'
+				? 'partial'
+				: 'complete',
+	};
+}

--- a/src/services/transaction-report/amounts.spec.ts
+++ b/src/services/transaction-report/amounts.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	accumulateAmounts,
+	addAmounts,
+	createAmountAccumulator,
+	getAtomicAmount,
+	materializeAmounts,
+	normalizeAmounts,
+	subtractAmounts,
+} from './amounts';
+
+describe('transaction report amount arithmetic', () => {
+	it('normalizes and merges duplicate asset units without changing the input', () => {
+		const values = [
+			{ unit: '', amount: 2n },
+			{ unit: 'lovelace', amount: 3n },
+			{ unit: 'policyasset', amount: 4n },
+		];
+
+		expect(normalizeAmounts(values)).toEqual([
+			{ unit: 'lovelace', amount: 5n },
+			{ unit: 'policyasset', amount: 4n },
+		]);
+		expect(values[0]).toEqual({ unit: '', amount: 2n });
+	});
+
+	it('drops exact zero entries', () => {
+		expect(
+			normalizeAmounts([
+				{ unit: 'lovelace', amount: 2n },
+				{ unit: '', amount: -2n },
+			]),
+		).toEqual([]);
+	});
+
+	it('adds asset lists with BigInt precision', () => {
+		expect(addAmounts([{ unit: 'lovelace', amount: 9_007_199_254_740_993n }], [{ unit: '', amount: 7n }])).toEqual([
+			{ unit: 'lovelace', amount: 9_007_199_254_741_000n },
+		]);
+	});
+
+	it('subtracts assets and preserves negative balances', () => {
+		expect(
+			subtractAmounts(
+				[{ unit: 'policyasset', amount: 10n }],
+				[
+					{ unit: 'policyasset', amount: 4n },
+					{ unit: 'lovelace', amount: 2n },
+				],
+			),
+		).toEqual([
+			{ unit: 'lovelace', amount: -2n },
+			{ unit: 'policyasset', amount: 6n },
+		]);
+	});
+
+	it('returns zero for an absent unit', () => {
+		expect(getAtomicAmount([{ unit: 'lovelace', amount: 5n }], 'policyasset')).toBe(0n);
+	});
+
+	it('accumulates growing asset sets and sorts only when materialized', () => {
+		const accumulator = createAmountAccumulator();
+		accumulateAmounts(accumulator, [
+			{ unit: 'policy-b', amount: 2n },
+			{ unit: '', amount: 3n },
+		]);
+		accumulateAmounts(accumulator, [
+			{ unit: 'policy-a', amount: 4n },
+			{ unit: 'lovelace', amount: -1n },
+		]);
+
+		expect(materializeAmounts(accumulator)).toEqual([
+			{ unit: 'lovelace', amount: 2n },
+			{ unit: 'policy-a', amount: 4n },
+			{ unit: 'policy-b', amount: 2n },
+		]);
+	});
+});

--- a/src/services/transaction-report/amounts.ts
+++ b/src/services/transaction-report/amounts.ts
@@ -1,0 +1,59 @@
+import { normalizeAssetUnit } from '@/utils/asset-units';
+
+export type AtomicAmount = Readonly<{
+	unit: string;
+	amount: bigint;
+}>;
+export type AmountAccumulator = Map<string, bigint>;
+
+function sortAmounts(left: AtomicAmount, right: AtomicAmount): number {
+	if (left.unit === 'lovelace') return right.unit === 'lovelace' ? 0 : -1;
+	if (right.unit === 'lovelace') return 1;
+	return left.unit.localeCompare(right.unit);
+}
+
+export function createAmountAccumulator(): AmountAccumulator {
+	return new Map<string, bigint>();
+}
+
+export function accumulateAmounts(totals: AmountAccumulator, values: readonly AtomicAmount[]): void {
+	for (const value of values) {
+		const unit = normalizeAssetUnit(value.unit);
+		totals.set(unit, (totals.get(unit) ?? 0n) + value.amount);
+	}
+}
+
+export function materializeAmounts(totals: ReadonlyMap<string, bigint>): AtomicAmount[] {
+	return Array.from(totals, ([unit, amount]) => ({ unit, amount }))
+		.filter((value) => value.amount !== 0n)
+		.sort(sortAmounts);
+}
+
+export function normalizeAmounts(values: readonly AtomicAmount[]): AtomicAmount[] {
+	const totals = createAmountAccumulator();
+	accumulateAmounts(totals, values);
+	return materializeAmounts(totals);
+}
+
+export function addAmounts(...groups: ReadonlyArray<readonly AtomicAmount[]>): AtomicAmount[] {
+	return normalizeAmounts(groups.flatMap((group) => group));
+}
+
+export function subtractAmounts(
+	minuend: readonly AtomicAmount[],
+	...subtrahends: ReadonlyArray<readonly AtomicAmount[]>
+): AtomicAmount[] {
+	return addAmounts(
+		minuend,
+		...subtrahends.map((group) => group.map((value) => ({ unit: value.unit, amount: -value.amount }))),
+	);
+}
+
+export function getAtomicAmount(values: readonly AtomicAmount[], unit: string): bigint {
+	const normalizedUnit = normalizeAssetUnit(unit);
+	return normalizeAmounts(values).find((value) => value.unit === normalizedUnit)?.amount ?? 0n;
+}
+
+export function cardanoFeeAmount(amount: bigint): AtomicAmount[] {
+	return amount === 0n ? [] : [{ unit: 'lovelace', amount }];
+}

--- a/src/services/transaction-report/checkpoint.ts
+++ b/src/services/transaction-report/checkpoint.ts
@@ -1,0 +1,7 @@
+export type ReportCheckpoint = () => void;
+
+export const NO_REPORT_CHECKPOINT: ReportCheckpoint = () => undefined;
+
+export function runReportCheckpoint(index: number, checkpoint: ReportCheckpoint): void {
+	if (index % 256 === 0) checkpoint();
+}

--- a/src/services/transaction-report/metrics.spec.ts
+++ b/src/services/transaction-report/metrics.spec.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	calculateBuyerMetrics,
+	calculateProtocolFee,
+	calculateSellerMetrics,
+	getSellerGrossRevenue,
+	reconcileCardanoFees,
+	type ReportMetricInput,
+	type ReportOnChainState,
+	type RevenueMode,
+} from './metrics';
+
+const requestedFunds = [
+	{ unit: 'lovelace', amount: 100_000_000n },
+	{ unit: 'policyasset', amount: 1_000n },
+];
+const sellerDisputedFunds = [{ unit: 'policyasset', amount: 400n }];
+
+function metricInput(overrides: Partial<ReportMetricInput> = {}): ReportMetricInput {
+	return {
+		onChainState: 'Withdrawn',
+		paymentSourceType: 'Web3CardanoV1',
+		configuredFeeRatePermille: 50,
+		unlockTime: 1_000n,
+		asOfTime: 2_000n,
+		hasConfirmedFundsLockedTransaction: true,
+		hasConfirmedCurrentStateTransaction: true,
+		requestedFunds,
+		withdrawnForBuyer: [],
+		withdrawnForSeller: sellerDisputedFunds,
+		buyerPayoutCompleteness: 'complete',
+		sellerPayoutCompleteness: 'complete',
+		collateralReturnLovelace: 2_000_000n,
+		buyerCardanoFees: 300_000n,
+		sellerCardanoFees: 200_000n,
+		...overrides,
+	};
+}
+
+describe('getSellerGrossRevenue', () => {
+	const zeroStates: Array<ReportOnChainState | null> = [
+		null,
+		'FundsLocked',
+		'FundsOrDatumInvalid',
+		'RefundRequested',
+		'Disputed',
+		'WithdrawAuthorized',
+		'RefundAuthorized',
+		'RefundWithdrawn',
+	];
+
+	it.each(zeroStates)('returns zero billable and cash revenue for %s', (onChainState) => {
+		const input = metricInput({ onChainState });
+		expect(getSellerGrossRevenue(input, 'Billable')).toEqual([]);
+		expect(getSellerGrossRevenue(input, 'CashReceived')).toEqual([]);
+	});
+
+	it.each<RevenueMode>(['Billable', 'CashReceived', 'RequestedGross'])(
+		'uses requested funds for Withdrawn in %s mode',
+		(mode) => {
+			expect(getSellerGrossRevenue(metricInput(), mode)).toEqual(requestedFunds);
+		},
+	);
+
+	it('uses requested funds for unlocked ResultSubmitted billable revenue', () => {
+		expect(getSellerGrossRevenue(metricInput({ onChainState: 'ResultSubmitted' }), 'Billable')).toEqual(requestedFunds);
+	});
+
+	it('does not recognize locked ResultSubmitted revenue', () => {
+		expect(
+			getSellerGrossRevenue(metricInput({ onChainState: 'ResultSubmitted', unlockTime: 2_001n }), 'Billable'),
+		).toEqual([]);
+	});
+
+	it('uses only the seller disputed payout for billable and cash revenue', () => {
+		const input = metricInput({ onChainState: 'DisputedWithdrawn' });
+		expect(getSellerGrossRevenue(input, 'Billable')).toEqual(sellerDisputedFunds);
+		expect(getSellerGrossRevenue(input, 'CashReceived')).toEqual(sellerDisputedFunds);
+		expect(getSellerGrossRevenue(input, 'RequestedGross')).toEqual(requestedFunds);
+	});
+
+	it('returns null for an incomplete disputed seller payout', () => {
+		expect(
+			getSellerGrossRevenue(
+				metricInput({ onChainState: 'DisputedWithdrawn', sellerPayoutCompleteness: 'partial' }),
+				'Billable',
+			),
+		).toBeNull();
+	});
+
+	it.each(zeroStates)('uses requested funds for %s in RequestedGross mode', (onChainState) => {
+		expect(getSellerGrossRevenue(metricInput({ onChainState }), 'RequestedGross')).toEqual(requestedFunds);
+	});
+
+	it('keeps RequestedGross exact without confirmed chain evidence', () => {
+		expect(
+			getSellerGrossRevenue(
+				metricInput({
+					onChainState: null,
+					hasConfirmedFundsLockedTransaction: false,
+					hasConfirmedCurrentStateTransaction: false,
+				}),
+				'RequestedGross',
+			),
+		).toEqual(requestedFunds);
+	});
+
+	it('returns partial revenue when the current state lacks exact confirmed evidence', () => {
+		expect(getSellerGrossRevenue(metricInput({ hasConfirmedCurrentStateTransaction: false }), 'Billable')).toBeNull();
+	});
+});
+
+describe('calculateProtocolFee', () => {
+	it('uses reconstructed locked ADA and applies the V1 minimum fee', () => {
+		expect(calculateProtocolFee(metricInput(), 'Billable')).toEqual({
+			configuredRatePermille: 50,
+			appliedRatePermille: 50,
+			amounts: [
+				{ unit: 'lovelace', amount: 5_100_000n },
+				{ unit: 'policyasset', amount: 50n },
+			],
+			provenance: 'calculated',
+			basis: 'stored_requested_plus_collateral',
+			completeness: 'reconstructed',
+		});
+	});
+
+	it('applies the ADA floor to token-only payments', () => {
+		const input = metricInput({
+			requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+			collateralReturnLovelace: 2_000_000n,
+		});
+		expect(calculateProtocolFee(input, 'Billable').amounts).toEqual([
+			{ unit: 'lovelace', amount: 1_435_230n },
+			{ unit: 'policyasset', amount: 50n },
+		]);
+	});
+
+	it('uses integer floor division for native assets', () => {
+		const input = metricInput({
+			requestedFunds: [
+				{ unit: 'lovelace', amount: 2_000_000n },
+				{ unit: 'policyasset', amount: 21n },
+			],
+			collateralReturnLovelace: 0n,
+		});
+		expect(calculateProtocolFee(input, 'Billable').amounts).toEqual([
+			{ unit: 'lovelace', amount: 1_435_230n },
+			{ unit: 'policyasset', amount: 1n },
+		]);
+	});
+
+	it('marks an unlocked ResultSubmitted V1 fee as projected', () => {
+		expect(calculateProtocolFee(metricInput({ onChainState: 'ResultSubmitted' }), 'Billable').provenance).toBe(
+			'projected',
+		);
+	});
+
+	it.each([
+		['Withdrawn', 'Billable', 'calculated'],
+		['Withdrawn', 'CashReceived', 'calculated'],
+		['Withdrawn', 'RequestedGross', 'calculated'],
+		['ResultSubmitted', 'Billable', 'projected'],
+		['ResultSubmitted', 'CashReceived', 'not_applicable'],
+		['ResultSubmitted', 'RequestedGross', 'not_applicable'],
+	] as const)('uses %s protocol-fee applicability in %s mode', (onChainState, revenueMode, provenance) => {
+		expect(calculateProtocolFee(metricInput({ onChainState }), revenueMode).provenance).toBe(provenance);
+	});
+
+	it('returns insufficient protocol fee data without exact current-state evidence', () => {
+		expect(calculateProtocolFee(metricInput({ hasConfirmedCurrentStateTransaction: false }), 'Billable')).toMatchObject(
+			{
+				appliedRatePermille: null,
+				amounts: null,
+				provenance: 'insufficient_data',
+				completeness: 'insufficient_data',
+			},
+		);
+	});
+
+	it('returns an exact zero for applicable V2 rows', () => {
+		expect(calculateProtocolFee(metricInput({ paymentSourceType: 'Web3CardanoV2' }), 'Billable')).toEqual({
+			configuredRatePermille: 50,
+			appliedRatePermille: 0,
+			amounts: [],
+			provenance: 'exact_zero',
+			basis: 'contract_version',
+			completeness: 'exact',
+		});
+	});
+
+	it('keeps V2 non-revenue states not applicable', () => {
+		expect(
+			calculateProtocolFee(
+				metricInput({ paymentSourceType: 'Web3CardanoV2', onChainState: 'FundsLocked' }),
+				'Billable',
+			),
+		).toEqual({
+			configuredRatePermille: 50,
+			appliedRatePermille: null,
+			amounts: null,
+			provenance: 'not_applicable',
+			basis: null,
+			completeness: 'not_applicable',
+		});
+	});
+
+	it('returns not applicable for a non-revenue state', () => {
+		expect(calculateProtocolFee(metricInput({ onChainState: 'FundsLocked' }), 'Billable')).toEqual({
+			configuredRatePermille: 50,
+			appliedRatePermille: null,
+			amounts: null,
+			provenance: 'not_applicable',
+			basis: null,
+			completeness: 'not_applicable',
+		});
+	});
+
+	it('returns insufficient data when collateral is unknown', () => {
+		expect(calculateProtocolFee(metricInput({ collateralReturnLovelace: null }), 'Billable')).toEqual({
+			configuredRatePermille: 50,
+			appliedRatePermille: 50,
+			amounts: null,
+			provenance: 'insufficient_data',
+			basis: null,
+			completeness: 'insufficient_data',
+		});
+	});
+
+	it('returns insufficient data when reconstructed token-only ADA is absent', () => {
+		expect(
+			calculateProtocolFee(
+				metricInput({
+					requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+					collateralReturnLovelace: 0n,
+				}),
+				'Billable',
+			),
+		).toMatchObject({
+			amounts: null,
+			provenance: 'insufficient_data',
+			completeness: 'insufficient_data',
+		});
+	});
+
+	it('rejects a negative requested entry before duplicate normalization', () => {
+		expect(() =>
+			calculateProtocolFee(
+				metricInput({
+					requestedFunds: [
+						{ unit: 'lovelace', amount: -1n },
+						{ unit: '', amount: 100_000_001n },
+					],
+				}),
+				'Billable',
+			),
+		).toThrow('requested funds must not be negative');
+	});
+
+	it.each([-1, 1001, 1.5])('rejects invalid fee rate %s', (configuredFeeRatePermille) => {
+		expect(() => calculateProtocolFee(metricInput({ configuredFeeRatePermille }), 'Billable')).toThrow(
+			'configuredFeeRatePermille must be an integer from 0 through 1000',
+		);
+	});
+});
+
+describe('calculateSellerMetrics', () => {
+	it('subtracts protocol and seller Cardano fees from their own asset units', () => {
+		expect(calculateSellerMetrics(metricInput(), 'Billable')).toEqual({
+			grossRevenue: requestedFunds,
+			protocolFee: calculateProtocolFee(metricInput(), 'Billable'),
+			cardanoFees: [{ unit: 'lovelace', amount: 200_000n }],
+			netRevenue: [
+				{ unit: 'lovelace', amount: 94_700_000n },
+				{ unit: 'policyasset', amount: 950n },
+			],
+		});
+	});
+
+	it('returns null net revenue when protocol fee data is incomplete', () => {
+		expect(calculateSellerMetrics(metricInput({ collateralReturnLovelace: null }), 'Billable').netRevenue).toBeNull();
+	});
+});
+
+describe('calculateBuyerMetrics', () => {
+	it('marks confirmed invalid on-chain funds as unknown spend', () => {
+		expect(calculateBuyerMetrics(metricInput({ onChainState: 'FundsOrDatumInvalid' })).grossSpend).toBeNull();
+	});
+
+	it('keeps an invalid request unknown when chain evidence is missing', () => {
+		expect(
+			calculateBuyerMetrics(
+				metricInput({
+					onChainState: 'FundsOrDatumInvalid',
+					hasConfirmedCurrentStateTransaction: false,
+				}),
+			).grossSpend,
+		).toBeNull();
+	});
+	it('shows locked gross spend before settlement', () => {
+		expect(calculateBuyerMetrics(metricInput({ onChainState: 'FundsLocked' }))).toEqual({
+			grossSpend: requestedFunds,
+			returnedFunds: [],
+			cardanoFees: [{ unit: 'lovelace', amount: 300_000n }],
+			netSpend: [
+				{ unit: 'lovelace', amount: 100_300_000n },
+				{ unit: 'policyasset', amount: 1_000n },
+			],
+		});
+	});
+
+	it.each<ReportOnChainState>([
+		'FundsLocked',
+		'ResultSubmitted',
+		'RefundRequested',
+		'Disputed',
+		'WithdrawAuthorized',
+		'RefundAuthorized',
+		'Withdrawn',
+		'RefundWithdrawn',
+		'DisputedWithdrawn',
+	])('returns partial gross spend for %s without confirmed FundsLocked evidence', (onChainState) => {
+		expect(
+			calculateBuyerMetrics(metricInput({ onChainState, hasConfirmedFundsLockedTransaction: false })).grossSpend,
+		).toBeNull();
+	});
+
+	it('returns known zero gross spend for a pending request without FundsLocked evidence', () => {
+		expect(
+			calculateBuyerMetrics(metricInput({ onChainState: null, hasConfirmedFundsLockedTransaction: false })).grossSpend,
+		).toEqual([]);
+	});
+
+	it('uses requested funds as a settled full refund', () => {
+		const result = calculateBuyerMetrics(metricInput({ onChainState: 'RefundWithdrawn' }));
+		expect(result.returnedFunds).toEqual(requestedFunds);
+		expect(result.netSpend).toEqual([{ unit: 'lovelace', amount: 300_000n }]);
+	});
+
+	it('uses the actual disputed buyer payout', () => {
+		const result = calculateBuyerMetrics(
+			metricInput({
+				onChainState: 'DisputedWithdrawn',
+				collateralReturnLovelace: 0n,
+				withdrawnForBuyer: [{ unit: 'policyasset', amount: 600n }],
+			}),
+		);
+		expect(result.returnedFunds).toEqual([{ unit: 'policyasset', amount: 600n }]);
+		expect(result.netSpend).toEqual([
+			{ unit: 'lovelace', amount: 100_300_000n },
+			{ unit: 'policyasset', amount: 400n },
+		]);
+	});
+
+	it('marks a disputed buyer payout with collateral as partial', () => {
+		const result = calculateBuyerMetrics(
+			metricInput({
+				onChainState: 'DisputedWithdrawn',
+				requestedFunds: [{ unit: 'policyasset', amount: 1_000n }],
+				collateralReturnLovelace: 2_000_000n,
+				withdrawnForBuyer: [
+					{ unit: 'lovelace', amount: 2_000_000n },
+					{ unit: 'policyasset', amount: 600n },
+				],
+			}),
+		);
+
+		expect(result.returnedFunds).toBeNull();
+		expect(result.netSpend).toBeNull();
+	});
+
+	it('returns null for incomplete disputed buyer payout data', () => {
+		expect(
+			calculateBuyerMetrics(metricInput({ onChainState: 'DisputedWithdrawn', buyerPayoutCompleteness: 'partial' }))
+				.netSpend,
+		).toBeNull();
+	});
+
+	it.each(['RefundWithdrawn', 'DisputedWithdrawn'] as const)(
+		'returns partial terminal buyer values for %s without exact current-state evidence',
+		(onChainState) => {
+			const result = calculateBuyerMetrics(metricInput({ onChainState, hasConfirmedCurrentStateTransaction: false }));
+			expect(result.returnedFunds).toBeNull();
+			expect(result.netSpend).toBeNull();
+		},
+	);
+});
+
+describe('reconcileCardanoFees', () => {
+	it('assigns the actor difference to admin fees for a complete allocation', () => {
+		expect(
+			reconcileCardanoFees({
+				buyerCardanoFees: 300_000n,
+				sellerCardanoFees: 200_000n,
+				allocatedTotalCardanoFees: 600_000n,
+				isAllocationComplete: true,
+			}),
+		).toEqual({
+			buyerCardanoFees: 300_000n,
+			sellerCardanoFees: 200_000n,
+			adminCardanoFees: 100_000n,
+			totalCardanoFees: 600_000n,
+			completeness: 'complete',
+		});
+	});
+
+	it('marks a shared allocation as partial', () => {
+		expect(
+			reconcileCardanoFees({
+				buyerCardanoFees: 300_000n,
+				sellerCardanoFees: 200_000n,
+				allocatedTotalCardanoFees: null,
+				isAllocationComplete: false,
+			}),
+		).toEqual({
+			buyerCardanoFees: 300_000n,
+			sellerCardanoFees: 200_000n,
+			adminCardanoFees: null,
+			totalCardanoFees: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('marks actor totals above the allocation as inconsistent', () => {
+		expect(
+			reconcileCardanoFees({
+				buyerCardanoFees: 300_000n,
+				sellerCardanoFees: 200_000n,
+				allocatedTotalCardanoFees: 400_000n,
+				isAllocationComplete: true,
+			}),
+		).toMatchObject({
+			adminCardanoFees: null,
+			totalCardanoFees: 400_000n,
+			completeness: 'inconsistent',
+		});
+	});
+});

--- a/src/services/transaction-report/metrics.ts
+++ b/src/services/transaction-report/metrics.ts
@@ -1,0 +1,257 @@
+import { CONSTANTS } from '@masumi/payment-core/config';
+import {
+	addAmounts,
+	cardanoFeeAmount,
+	getAtomicAmount,
+	normalizeAmounts,
+	subtractAmounts,
+	type AtomicAmount,
+} from './amounts';
+
+export type ReportOnChainState =
+	| 'FundsLocked'
+	| 'FundsOrDatumInvalid'
+	| 'ResultSubmitted'
+	| 'RefundRequested'
+	| 'Disputed'
+	| 'WithdrawAuthorized'
+	| 'RefundAuthorized'
+	| 'Withdrawn'
+	| 'RefundWithdrawn'
+	| 'DisputedWithdrawn';
+
+export type RevenueMode = 'Billable' | 'CashReceived' | 'RequestedGross';
+export type ReportPaymentSourceType = 'Web3CardanoV1' | 'Web3CardanoV2';
+export type PayoutCompleteness = 'complete' | 'partial';
+
+export type ReportMetricInput = {
+	onChainState: ReportOnChainState | null;
+	paymentSourceType: ReportPaymentSourceType;
+	configuredFeeRatePermille: number;
+	unlockTime: bigint;
+	asOfTime: bigint;
+	hasConfirmedFundsLockedTransaction: boolean;
+	hasConfirmedCurrentStateTransaction: boolean;
+	requestedFunds: readonly AtomicAmount[];
+	withdrawnForBuyer: readonly AtomicAmount[];
+	withdrawnForSeller: readonly AtomicAmount[];
+	buyerPayoutCompleteness: PayoutCompleteness;
+	sellerPayoutCompleteness: PayoutCompleteness;
+	collateralReturnLovelace: bigint | null;
+	buyerCardanoFees: bigint;
+	sellerCardanoFees: bigint;
+};
+
+export type ProtocolFee = {
+	configuredRatePermille: number;
+	appliedRatePermille: number | null;
+	amounts: AtomicAmount[] | null;
+	provenance: 'calculated' | 'projected' | 'exact_zero' | 'not_applicable' | 'insufficient_data';
+	basis: 'stored_requested_plus_collateral' | 'contract_version' | null;
+	completeness: 'exact' | 'reconstructed' | 'not_applicable' | 'insufficient_data';
+};
+
+function isProtocolFeeApplicable(input: ReportMetricInput, revenueMode: RevenueMode): boolean {
+	if (input.onChainState === 'Withdrawn') return true;
+	return revenueMode === 'Billable' && input.onChainState === 'ResultSubmitted' && input.unlockTime <= input.asOfTime;
+}
+
+function validateFeeRate(configuredFeeRatePermille: number): void {
+	if (
+		!Number.isInteger(configuredFeeRatePermille) ||
+		configuredFeeRatePermille < 0 ||
+		configuredFeeRatePermille > 1000
+	) {
+		throw new RangeError('configuredFeeRatePermille must be an integer from 0 through 1000');
+	}
+}
+
+function validateNonNegativeAmounts(values: readonly AtomicAmount[], fieldName: string): void {
+	if (values.some((value) => value.amount < 0n)) {
+		throw new RangeError(`${fieldName} must not be negative`);
+	}
+}
+
+function insufficientProtocolFee(
+	configuredRatePermille: number,
+	appliedRatePermille: number | null = configuredRatePermille,
+): ProtocolFee {
+	return {
+		configuredRatePermille,
+		appliedRatePermille,
+		amounts: null,
+		provenance: 'insufficient_data',
+		basis: null,
+		completeness: 'insufficient_data',
+	};
+}
+
+export function getSellerGrossRevenue(input: ReportMetricInput, revenueMode: RevenueMode): AtomicAmount[] | null {
+	validateNonNegativeAmounts(input.requestedFunds, 'requested funds');
+	const requestedFunds = normalizeAmounts(input.requestedFunds);
+	if (revenueMode === 'RequestedGross') return requestedFunds;
+
+	if (input.onChainState === 'Withdrawn') {
+		return input.hasConfirmedCurrentStateTransaction ? requestedFunds : null;
+	}
+	if (input.onChainState === 'DisputedWithdrawn') {
+		if (!input.hasConfirmedCurrentStateTransaction) return null;
+		validateNonNegativeAmounts(input.withdrawnForSeller, 'seller withdrawn funds');
+		return input.sellerPayoutCompleteness === 'complete' ? normalizeAmounts(input.withdrawnForSeller) : null;
+	}
+	if (revenueMode === 'Billable' && input.onChainState === 'ResultSubmitted' && input.unlockTime <= input.asOfTime) {
+		return input.hasConfirmedCurrentStateTransaction ? requestedFunds : null;
+	}
+	return [];
+}
+
+export function calculateProtocolFee(input: ReportMetricInput, revenueMode: RevenueMode): ProtocolFee {
+	validateFeeRate(input.configuredFeeRatePermille);
+	if (!isProtocolFeeApplicable(input, revenueMode)) {
+		return {
+			configuredRatePermille: input.configuredFeeRatePermille,
+			appliedRatePermille: null,
+			amounts: null,
+			provenance: 'not_applicable',
+			basis: null,
+			completeness: 'not_applicable',
+		};
+	}
+	if (!input.hasConfirmedCurrentStateTransaction) {
+		return insufficientProtocolFee(input.configuredFeeRatePermille, null);
+	}
+
+	if (input.paymentSourceType === 'Web3CardanoV2') {
+		return {
+			configuredRatePermille: input.configuredFeeRatePermille,
+			appliedRatePermille: 0,
+			amounts: [],
+			provenance: 'exact_zero',
+			basis: 'contract_version',
+			completeness: 'exact',
+		};
+	}
+
+	if (input.collateralReturnLovelace == null) {
+		return insufficientProtocolFee(input.configuredFeeRatePermille);
+	}
+	if (input.collateralReturnLovelace < 0n) {
+		throw new RangeError('collateralReturnLovelace must not be negative');
+	}
+
+	validateNonNegativeAmounts(input.requestedFunds, 'requested funds');
+	const lockedAmounts = addAmounts(input.requestedFunds, cardanoFeeAmount(input.collateralReturnLovelace));
+	if (getAtomicAmount(lockedAmounts, 'lovelace') === 0n) {
+		return insufficientProtocolFee(input.configuredFeeRatePermille);
+	}
+
+	const amounts = normalizeAmounts(
+		lockedAmounts.map((value) => {
+			const proportionalFee = (value.amount * BigInt(input.configuredFeeRatePermille)) / 1000n;
+			const amount =
+				value.unit === 'lovelace' && proportionalFee < CONSTANTS.MIN_COLLATERAL_LOVELACE
+					? CONSTANTS.MIN_COLLATERAL_LOVELACE
+					: proportionalFee;
+			return { unit: value.unit, amount };
+		}),
+	);
+
+	return {
+		configuredRatePermille: input.configuredFeeRatePermille,
+		appliedRatePermille: input.configuredFeeRatePermille,
+		amounts,
+		provenance: input.onChainState === 'Withdrawn' ? 'calculated' : 'projected',
+		basis: 'stored_requested_plus_collateral',
+		completeness: 'reconstructed',
+	};
+}
+
+export function calculateSellerMetrics(input: ReportMetricInput, revenueMode: RevenueMode) {
+	if (input.sellerCardanoFees < 0n) throw new RangeError('seller Cardano fees must not be negative');
+	const grossRevenue = getSellerGrossRevenue(input, revenueMode);
+	const protocolFee = calculateProtocolFee(input, revenueMode);
+	const cardanoFees = cardanoFeeAmount(input.sellerCardanoFees);
+	const hasUnknownProtocolFee = protocolFee.completeness === 'insufficient_data';
+	const netRevenue =
+		grossRevenue == null || hasUnknownProtocolFee
+			? null
+			: subtractAmounts(grossRevenue, protocolFee.amounts ?? [], cardanoFees);
+	return { grossRevenue, protocolFee, cardanoFees, netRevenue };
+}
+
+export function calculateBuyerMetrics(input: ReportMetricInput) {
+	validateNonNegativeAmounts(input.requestedFunds, 'requested funds');
+	validateNonNegativeAmounts(input.withdrawnForBuyer, 'buyer withdrawn funds');
+	if (input.buyerCardanoFees < 0n) throw new RangeError('buyer Cardano fees must not be negative');
+	if (input.collateralReturnLovelace != null && input.collateralReturnLovelace < 0n) {
+		throw new RangeError('collateralReturnLovelace must not be negative');
+	}
+	const grossSpend =
+		input.onChainState == null
+			? []
+			: input.onChainState === 'FundsOrDatumInvalid'
+				? null
+				: input.hasConfirmedFundsLockedTransaction
+					? normalizeAmounts(input.requestedFunds)
+					: null;
+
+	let returnedFunds: AtomicAmount[] | null = [];
+	if (input.onChainState === 'RefundWithdrawn') {
+		returnedFunds = input.hasConfirmedCurrentStateTransaction ? normalizeAmounts(input.requestedFunds) : null;
+	} else if (input.onChainState === 'DisputedWithdrawn') {
+		returnedFunds =
+			input.hasConfirmedCurrentStateTransaction &&
+			input.buyerPayoutCompleteness === 'complete' &&
+			input.collateralReturnLovelace === 0n
+				? normalizeAmounts(input.withdrawnForBuyer)
+				: null;
+	}
+
+	const cardanoFees = cardanoFeeAmount(input.buyerCardanoFees);
+	const netSpend =
+		grossSpend == null || returnedFunds == null
+			? null
+			: addAmounts(subtractAmounts(grossSpend, returnedFunds), cardanoFees);
+	return { grossSpend, returnedFunds, cardanoFees, netSpend };
+}
+
+export function reconcileCardanoFees(input: {
+	buyerCardanoFees: bigint;
+	sellerCardanoFees: bigint;
+	allocatedTotalCardanoFees: bigint | null;
+	isAllocationComplete: boolean;
+}) {
+	if (
+		input.buyerCardanoFees < 0n ||
+		input.sellerCardanoFees < 0n ||
+		(input.allocatedTotalCardanoFees != null && input.allocatedTotalCardanoFees < 0n)
+	) {
+		throw new RangeError('Cardano fees must not be negative');
+	}
+	const actorTotal = input.buyerCardanoFees + input.sellerCardanoFees;
+	if (!input.isAllocationComplete || input.allocatedTotalCardanoFees == null) {
+		return {
+			buyerCardanoFees: input.buyerCardanoFees,
+			sellerCardanoFees: input.sellerCardanoFees,
+			adminCardanoFees: null,
+			totalCardanoFees: null,
+			completeness: 'partial' as const,
+		};
+	}
+	if (input.allocatedTotalCardanoFees < actorTotal) {
+		return {
+			buyerCardanoFees: input.buyerCardanoFees,
+			sellerCardanoFees: input.sellerCardanoFees,
+			adminCardanoFees: null,
+			totalCardanoFees: input.allocatedTotalCardanoFees,
+			completeness: 'inconsistent' as const,
+		};
+	}
+	return {
+		buyerCardanoFees: input.buyerCardanoFees,
+		sellerCardanoFees: input.sellerCardanoFees,
+		adminCardanoFees: input.allocatedTotalCardanoFees - actorTotal,
+		totalCardanoFees: input.allocatedTotalCardanoFees,
+		completeness: 'complete' as const,
+	};
+}

--- a/src/services/transaction-report/records.spec.ts
+++ b/src/services/transaction-report/records.spec.ts
@@ -1,0 +1,836 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	buildReportRow,
+	getReportRowWarnings,
+	serializeReportRow,
+	type ReportMetricWindow,
+	type ReportRequestRecord,
+} from './records';
+
+const COHORT_WINDOW: ReportMetricWindow = {
+	dateBasis: 'CreatedAt',
+	from: new Date('2026-01-01T00:00:00.000Z'),
+	to: new Date('2026-01-03T00:00:00.000Z'),
+};
+
+function blockTime(value: string): number {
+	return Math.floor(new Date(value).getTime() / 1000);
+}
+
+function record(overrides: Partial<ReportRequestRecord> = {}): ReportRequestRecord {
+	return {
+		id: 'request-1',
+		role: 'Seller',
+		requestType: 'PaymentRequest',
+		createdAt: new Date('2026-01-01T00:00:00.000Z'),
+		blockchainIdentifier: 'chain-1',
+		agentIdentifier: 'agent-1',
+		agentName: 'Agent',
+		onChainState: 'Withdrawn',
+		metadata: null,
+		managedWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-wallet',
+			walletVkey: 'wallet-vkey',
+			collectionAddress: 'addr-collection',
+			deletedAt: null,
+		},
+		counterpartyAddress: 'addr-counterparty',
+		buyerReturnAddress: null,
+		sellerReturnAddress: null,
+		paymentSourceType: 'Web3CardanoV1',
+		configuredFeeRatePermille: 50,
+		unlockTime: 1_000n,
+		collateralReturnLovelace: 2_000_000n,
+		requestedFunds: [{ unit: 'lovelace', amount: 100_000_000n }],
+		withdrawnForBuyer: [],
+		withdrawnForSeller: [],
+		buyerPayoutCompleteness: 'complete',
+		sellerPayoutCompleteness: 'complete',
+		buyerCardanoFees: 100_000n,
+		sellerCardanoFees: 200_000n,
+		transactions: [
+			{
+				id: 'tx-1',
+				txHash: 'hash-1',
+				status: 'Confirmed',
+				newOnChainState: 'Withdrawn',
+				blockTime: 1_767_225_700,
+				fees: 400_000n,
+				relatedRequestKeys: ['Seller:request-1'],
+				relatedPaymentKeys: ['chain-1'],
+			},
+		],
+		feeAllocationScope: 'single_request',
+		isFeeReconciliationOwner: true,
+		feeComponentScope: 'complete',
+		...overrides,
+	};
+}
+
+describe('buildReportRow', () => {
+	it('keeps observed actor fees while marking actor and admin allocation partial', () => {
+		const row = buildReportRow(record(), 'Billable', new Date('2026-01-02T00:00:00.000Z'), COHORT_WINDOW);
+		expect(row.buyer).toBeNull();
+		expect(row.seller?.grossRevenue).toEqual([{ unit: 'lovelace', amount: 100_000_000n }]);
+		expect(row.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: 100_000n,
+			sellerCardanoFees: 200_000n,
+			adminCardanoFees: null,
+			totalCardanoFees: 400_000n,
+			completeness: 'partial',
+		});
+		expect(row.actorCardanoFeeAllocation.completeness).toBe('partial');
+		expect(getReportRowWarnings(row).map((warning) => warning.code)).toContain(
+			'ACTOR_CARDANO_FEE_EVENT_ALLOCATION_PARTIAL',
+		);
+	});
+
+	it('discloses disputed buyer collateral payout ambiguity', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'DisputedWithdrawn',
+				buyerPayoutCompleteness: 'partial',
+			}),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(getReportRowWarnings(row)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: 'DISPUTED_PAYOUT_PARTIAL', message: expect.stringContaining('collateral') }),
+			]),
+		);
+	});
+
+	it('keeps incomplete related-payment evidence partial in exported scope metadata', () => {
+		const row = buildReportRow(
+			record({
+				transactions: [
+					{
+						...record().transactions[0],
+						relatedPaymentKeysComplete: false,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-06T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(row.feeComponentScope).toBe('partial');
+	});
+
+	it('gives one paired detail row the exact total without duplicating it', () => {
+		const pairedTransaction = {
+			id: 'tx-paired',
+			txHash: 'hash-paired',
+			status: 'Confirmed',
+			newOnChainState: 'Withdrawn' as const,
+			blockTime: 1_767_225_700,
+			fees: 400_000n,
+			relatedRequestKeys: ['Buyer:buyer-1', 'Seller:seller-1'],
+			relatedPaymentKeys: ['chain-paired'],
+		};
+		const seller = buildReportRow(
+			record({
+				id: 'seller-1',
+				blockchainIdentifier: 'chain-paired',
+				transactions: [pairedTransaction],
+				isFeeReconciliationOwner: false,
+				feeComponentScope: 'partial',
+			}),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+		const buyer = buildReportRow(
+			record({
+				id: 'buyer-1',
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				blockchainIdentifier: 'chain-paired',
+				transactions: [pairedTransaction],
+				isFeeReconciliationOwner: true,
+				feeComponentScope: 'partial',
+			}),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(seller.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: 100_000n,
+			sellerCardanoFees: 200_000n,
+			totalCardanoFees: null,
+			adminCardanoFees: null,
+			completeness: 'partial',
+		});
+		expect(buyer.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: 100_000n,
+			sellerCardanoFees: 200_000n,
+			totalCardanoFees: 400_000n,
+			adminCardanoFees: null,
+			completeness: 'partial',
+		});
+		expect([seller, buyer].filter((row) => row.cardanoFeeReconciliation.totalCardanoFees != null)).toHaveLength(1);
+	});
+
+	it('uses both stored actor fees for a seller-only paired transaction', () => {
+		const row = buildReportRow(
+			record({
+				isFeeReconciliationOwner: true,
+				feeComponentScope: 'partial',
+				transactions: [
+					{
+						id: 'tx-paired',
+						txHash: 'hash-paired',
+						status: 'Confirmed',
+						newOnChainState: 'Withdrawn',
+						blockTime: 1_767_225_700,
+						fees: 400_000n,
+						relatedRequestKeys: ['Buyer:buyer-1', 'Seller:request-1'],
+						relatedPaymentKeys: ['chain-1'],
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(row.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: 100_000n,
+			sellerCardanoFees: 200_000n,
+			totalCardanoFees: 400_000n,
+			adminCardanoFees: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('keeps shared V2 admin fees partial', () => {
+		const row = buildReportRow(
+			record({
+				paymentSourceType: 'Web3CardanoV2',
+				feeAllocationScope: 'shared_or_unknown',
+				feeComponentScope: 'partial',
+				transactions: [
+					{
+						id: 'tx-shared',
+						txHash: 'hash-shared',
+						status: 'Confirmed',
+						newOnChainState: 'Withdrawn',
+						blockTime: 1_767_225_700,
+						fees: 400_000n,
+						relatedRequestKeys: ['Seller:request-1', 'Seller:request-2'],
+						relatedPaymentKeys: ['chain-1', 'chain-2'],
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+		expect(row.cardanoFeeReconciliation).toMatchObject({
+			adminCardanoFees: null,
+			totalCardanoFees: null,
+			completeness: 'partial',
+		});
+		expect(getReportRowWarnings(row).map((warning) => warning.code)).toContain('CARDANO_FEE_RECONCILIATION_PARTIAL');
+	});
+
+	it('ignores old shared fee coverage when current-window evidence is complete', () => {
+		const row = buildReportRow(
+			record({
+				paymentSourceType: 'Web3CardanoV2',
+				buyerCardanoFees: 0n,
+				sellerCardanoFees: 0n,
+				feeAllocationScope: 'shared_or_unknown',
+				feeComponentScope: 'partial',
+				transactions: [
+					{
+						id: 'old-shared',
+						txHash: 'old-shared-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 100_000n,
+						relatedRequestKeys: ['Buyer:old-counterpart', 'Seller:request-1'],
+						relatedPaymentKeys: ['chain-1', 'chain-old-counterpart'],
+					},
+					{
+						id: 'current-single',
+						txHash: 'current-single-hash',
+						status: 'Confirmed',
+						newOnChainState: 'Withdrawn',
+						blockTime: blockTime('2026-01-03T12:00:00.000Z'),
+						fees: 50_000n,
+						relatedRequestKeys: ['Seller:request-1'],
+						relatedPaymentKeys: ['chain-1'],
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-03T00:00:00.000Z'),
+				to: new Date('2026-01-04T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.cardanoFeeReconciliation).toEqual({
+			buyerCardanoFees: 0n,
+			sellerCardanoFees: 0n,
+			adminCardanoFees: null,
+			totalCardanoFees: 50_000n,
+			completeness: 'partial',
+		});
+	});
+
+	it.each(['CreatedAt', 'RevenueRecognizedAt'] as const)(
+		'treats a shared zero fee as exact for %s reports',
+		(dateBasis) => {
+			const row = buildReportRow(
+				record({
+					paymentSourceType: 'Web3CardanoV2',
+					buyerCardanoFees: 0n,
+					sellerCardanoFees: 0n,
+					feeAllocationScope: 'shared_or_unknown',
+					feeComponentScope: 'partial',
+					transactions: [
+						{
+							id: 'shared-zero',
+							txHash: 'shared-zero-hash',
+							status: 'Confirmed',
+							newOnChainState: 'Withdrawn',
+							blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+							fees: 0n,
+							relatedRequestKeys: ['Buyer:shared-zero-sibling', 'Seller:request-1'],
+							relatedPaymentKeys: ['chain-1', 'shared-zero-sibling-chain'],
+						},
+					],
+				}),
+				'Billable',
+				new Date('2026-01-02T00:00:00.000Z'),
+				{
+					dateBasis,
+					from: new Date('2026-01-01T00:00:00.000Z'),
+					to: new Date('2026-01-02T00:00:00.000Z'),
+				},
+			);
+
+			expect(row.cardanoFeeReconciliation).toEqual({
+				buyerCardanoFees: 0n,
+				sellerCardanoFees: 0n,
+				adminCardanoFees: null,
+				totalCardanoFees: 0n,
+				completeness: 'partial',
+			});
+		},
+	);
+
+	it.each(['Pending', 'FailedViaTimeout', 'FailedViaManualReset', 'RolledBack'])(
+		'marks on-chain fee reconciliation partial for %s-only transaction evidence',
+		(status) => {
+			const row = buildReportRow(
+				record({
+					transactions: [
+						{
+							id: `tx-${status.toLowerCase()}`,
+							txHash: `hash-${status.toLowerCase()}`,
+							status,
+							newOnChainState: 'Withdrawn',
+							blockTime: 1_767_225_700,
+							fees: 400_000n,
+							relatedRequestKeys: ['Seller:request-1'],
+							relatedPaymentKeys: ['chain-1'],
+						},
+					],
+				}),
+				'Billable',
+				new Date('2026-01-02T00:00:00.000Z'),
+				COHORT_WINDOW,
+			);
+
+			expect(row.cardanoFeeReconciliation).toMatchObject({
+				adminCardanoFees: null,
+				totalCardanoFees: null,
+				completeness: 'partial',
+			});
+			expect(row.seller).toMatchObject({
+				grossRevenue: null,
+				netRevenue: null,
+				protocolFee: { amounts: null, completeness: 'insufficient_data' },
+			});
+		},
+	);
+
+	it('keeps generic confirmed evidence for fees but not wrong-state seller economics', () => {
+		const wrongStateRecord = record({
+			transactions: [
+				{
+					id: 'lock-only',
+					txHash: 'lock-only-hash',
+					status: 'Confirmed',
+					newOnChainState: 'FundsLocked',
+					blockTime: 1_767_225_700,
+					fees: 400_000n,
+					relatedRequestKeys: ['Seller:request-1'],
+					relatedPaymentKeys: ['chain-1'],
+				},
+			],
+		});
+		const row = buildReportRow(wrongStateRecord, 'Billable', new Date('2026-01-02T00:00:00.000Z'), COHORT_WINDOW);
+		const revenueWindowRow = buildReportRow(wrongStateRecord, 'Billable', new Date('2026-01-02T00:00:00.000Z'), {
+			dateBasis: 'RevenueRecognizedAt',
+			from: new Date('2026-01-01T00:00:00.000Z'),
+			to: new Date('2026-01-02T00:00:00.000Z'),
+		});
+
+		for (const reportRow of [row, revenueWindowRow]) {
+			expect(reportRow.seller).toMatchObject({
+				grossRevenue: null,
+				netRevenue: null,
+				protocolFee: { amounts: null, completeness: 'insufficient_data' },
+			});
+		}
+		expect(row.cardanoFeeReconciliation).toMatchObject({
+			adminCardanoFees: null,
+			totalCardanoFees: 400_000n,
+			completeness: 'partial',
+		});
+	});
+
+	it('builds buyer spend and refund metrics independently of revenue mode', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 0n,
+					},
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-02T00:00:00.000Z'),
+						fees: 0n,
+					},
+				],
+			}),
+			'CashReceived',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+		expect(row.seller).toBeNull();
+		expect(row.buyer?.returnedFunds).toEqual([{ unit: 'lovelace', amount: 100_000_000n }]);
+		expect(row.buyer?.netSpend).toEqual([{ unit: 'lovelace', amount: 100_000n }]);
+	});
+
+	it('returns partial buyer gross without confirmed FundsLocked evidence', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-02T00:00:00.000Z'),
+						fees: 0n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-02T12:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: null,
+			returnedFunds: [{ unit: 'lovelace', amount: 100_000_000n }],
+			netSpend: null,
+		});
+	});
+
+	it('returns partial buyer returns when confirmed evidence has the wrong terminal state', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 0n,
+					},
+					{
+						id: 'withdraw',
+						txHash: 'withdraw-hash',
+						status: 'Confirmed',
+						newOnChainState: 'Withdrawn',
+						blockTime: blockTime('2026-01-02T00:00:00.000Z'),
+						fees: 0n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-02T12:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: [{ unit: 'lovelace', amount: 100_000_000n }],
+			returnedFunds: null,
+			netSpend: null,
+		});
+	});
+
+	it('scopes a refund-only revenue window to the returned value and negative net', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-03T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-03T00:00:00.000Z'),
+				to: new Date('2026-01-04T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: [],
+			returnedFunds: [{ unit: 'lovelace', amount: 100_000_000n }],
+			cardanoFees: [],
+			netSpend: [{ unit: 'lovelace', amount: -100_000_000n }],
+		});
+		expect(row.timestamps.buyerGrossSpendAt?.toISOString()).toBe('2026-01-01T12:00:00.000Z');
+		expect(row.timestamps.buyerReturnedAt?.toISOString()).toBe('2026-01-03T12:00:00.000Z');
+	});
+
+	it('attaches buyer Cardano fees to an in-range lock event', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-03T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: [{ unit: 'lovelace', amount: 100_000_000n }],
+			returnedFunds: [],
+			cardanoFees: [{ unit: 'lovelace', amount: 100_000n }],
+			netSpend: [{ unit: 'lovelace', amount: 100_100_000n }],
+		});
+		expect(row.actorCardanoFeeAllocation.completeness).toBe('partial');
+		expect(getReportRowWarnings(row).map((warning) => warning.code)).toContain(
+			'ACTOR_CARDANO_FEE_EVENT_ALLOCATION_PARTIAL',
+		);
+	});
+
+	it.each(['CreatedAt', 'FundsLockedAt'] as const)('keeps lifetime buyer values for %s cohorts', (dateBasis) => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: blockTime('2026-01-01T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-03T12:00:00.000Z'),
+						fees: 200_000n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis,
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: [{ unit: 'lovelace', amount: 100_000_000n }],
+			returnedFunds: [{ unit: 'lovelace', amount: 100_000_000n }],
+			cardanoFees: [{ unit: 'lovelace', amount: 100_000n }],
+			netSpend: [{ unit: 'lovelace', amount: 100_000n }],
+		});
+		expect(row.actorCardanoFeeAllocation).toMatchObject({ strategy: 'lifetime_cohort', completeness: 'partial' });
+	});
+
+	it('omits seller metrics when seller recognition is outside a revenue window', () => {
+		const row = buildReportRow(record(), 'Billable', new Date('2026-01-04T00:00:00.000Z'), {
+			dateBasis: 'RevenueRecognizedAt',
+			from: new Date('2026-01-03T00:00:00.000Z'),
+			to: new Date('2026-01-04T00:00:00.000Z'),
+		});
+
+		expect(row.seller).toMatchObject({ grossRevenue: [], cardanoFees: [], netRevenue: [] });
+		expect(row.seller?.protocolFee).toMatchObject({ amounts: null, completeness: 'not_applicable' });
+	});
+
+	it('keeps seller metrics and fees at an in-range seller recognition event', () => {
+		const row = buildReportRow(record(), 'Billable', new Date('2026-01-04T00:00:00.000Z'), {
+			dateBasis: 'RevenueRecognizedAt',
+			from: new Date('2026-01-01T00:00:00.000Z'),
+			to: new Date('2026-01-02T00:00:00.000Z'),
+		});
+
+		expect(row.seller).toMatchObject({
+			grossRevenue: [{ unit: 'lovelace', amount: 100_000_000n }],
+			cardanoFees: [{ unit: 'lovelace', amount: 200_000n }],
+			cardanoFeeTiming: 'accounting_allocation',
+		});
+		expect(row.actorCardanoFeeAllocation).toMatchObject({
+			strategy: 'accounting_allocation',
+			completeness: 'partial',
+			attachedAt: new Date('2026-01-01T00:01:40.000Z'),
+		});
+	});
+
+	it('keeps seller economics partial when exact state evidence lacks a chain time', () => {
+		const row = buildReportRow(
+			record({
+				transactions: [
+					{
+						...record().transactions[0],
+						blockTime: null,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.seller).toMatchObject({
+			grossRevenue: null,
+			protocolFee: { amounts: null, completeness: 'insufficient_data' },
+			cardanoFees: [],
+			netRevenue: null,
+		});
+	});
+
+	it('keeps buyer economics partial when exact state evidence lacks chain times', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'lock',
+						txHash: 'lock-hash',
+						status: 'Confirmed',
+						newOnChainState: 'FundsLocked',
+						blockTime: null,
+						fees: 0n,
+					},
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: null,
+						fees: 0n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.buyer).toMatchObject({
+			grossSpend: null,
+			returnedFunds: null,
+			cardanoFees: [],
+			netSpend: null,
+		});
+	});
+
+	it.each([
+		[null, []],
+		['FundsOrDatumInvalid', null],
+	] as const)('scopes %s buyer gross without a chain time', (onChainState, expectedGrossSpend) => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState,
+				transactions: [],
+			}),
+			'Billable',
+			new Date('2026-01-04T00:00:00.000Z'),
+			{
+				dateBasis: 'RevenueRecognizedAt',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		);
+
+		expect(row.buyer?.grossSpend).toEqual(expectedGrossSpend);
+	});
+});
+
+describe('serializeReportRow', () => {
+	it('keeps missing FundsLocked evidence partial at the JSON boundary', () => {
+		const row = buildReportRow(
+			record({
+				role: 'Buyer',
+				requestType: 'PurchaseRequest',
+				onChainState: 'RefundWithdrawn',
+				transactions: [
+					{
+						id: 'refund',
+						txHash: 'refund-hash',
+						status: 'Confirmed',
+						newOnChainState: 'RefundWithdrawn',
+						blockTime: blockTime('2026-01-02T00:00:00.000Z'),
+						fees: 0n,
+					},
+				],
+			}),
+			'Billable',
+			new Date('2026-01-02T12:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+
+		expect(serializeReportRow(row).buyer).toMatchObject({
+			grossSpend: null,
+			returnedFunds: [expect.objectContaining({ rawAmount: '100000000' })],
+			netSpend: null,
+		});
+	});
+
+	it('keeps BigInt values as exact strings at the JSON boundary', () => {
+		const row = buildReportRow(
+			record({ requestedFunds: [{ unit: 'lovelace', amount: 9_007_199_254_740_993n }] }),
+			'Billable',
+			new Date('2026-01-02T00:00:00.000Z'),
+			COHORT_WINDOW,
+		);
+		const serialized = serializeReportRow(row);
+		expect(serialized.seller?.grossRevenue?.[0]).toMatchObject({
+			rawAmount: '9007199254740993',
+			decimalAmount: '9007199254.740993',
+		});
+		expect(serialized.seller?.cardanoFeeTiming).toBe('stored_cumulative');
+		expect(serialized.managedWallet).toMatchObject({ collectionAddress: 'addr-collection' });
+		expect(serialized.cardanoFeeReconciliation).toMatchObject({
+			buyerCardanoFees: {
+				unit: 'lovelace',
+				rawAmount: '100000',
+				decimalAmount: '0.100000',
+				decimals: 6,
+				symbol: 'ADA',
+			},
+			sellerCardanoFees: {
+				unit: 'lovelace',
+				rawAmount: '200000',
+				decimalAmount: '0.200000',
+				decimals: 6,
+				symbol: 'ADA',
+			},
+			adminCardanoFees: null,
+			totalCardanoFees: expect.objectContaining({ rawAmount: '400000', symbol: 'ADA' }),
+		});
+		expect(serialized.actorCardanoFeeAllocation).toEqual({
+			strategy: 'lifetime_cohort',
+			completeness: 'partial',
+			attachedAt: null,
+		});
+		expect(serialized.feeAllocationScope).toBe('single_request');
+		expect(serialized.feeComponentScope).toBe('complete');
+		expect(serialized.cardanoFeeReconciliation.isAggregationOwner).toBe(true);
+		expect(JSON.stringify(serialized)).not.toContain('[object Object]');
+	});
+});

--- a/src/services/transaction-report/records.spec.ts
+++ b/src/services/transaction-report/records.spec.ts
@@ -759,6 +759,16 @@ describe('buildReportRow', () => {
 
 		expect(row.buyer?.grossSpend).toEqual(expectedGrossSpend);
 	});
+
+	it('does not call a one-sided row short of evidence for the side it never had', () => {
+		// A seller row carries no buyer amounts by design. Reading through the
+		// absent side put this note in every export, on every row.
+		const row = buildReportRow(record(), 'Billable', new Date('2026-01-02T00:00:00.000Z'), COHORT_WINDOW);
+
+		expect(row.buyer).toBeNull();
+		expect(row.seller?.grossRevenue).not.toBeNull();
+		expect(getReportRowWarnings(row).map((warning) => warning.code)).not.toContain('ECONOMIC_METRIC_EVIDENCE_PARTIAL');
+	});
 });
 
 describe('serializeReportRow', () => {

--- a/src/services/transaction-report/records.ts
+++ b/src/services/transaction-report/records.ts
@@ -456,7 +456,13 @@ export function getReportRowWarnings(row: ReportRow): ReportWarning[] {
 			rowId: row.id,
 		});
 	}
-	if (row.seller?.grossRevenue == null || row.buyer?.grossSpend == null || row.buyer?.returnedFunds == null) {
+	// Only the side this row actually describes can be missing an amount. A
+	// buyer row has no `seller` at all, so reading through it would report every
+	// buyer row as short of evidence and put the note in every export.
+	const hasUnknownAmount =
+		(row.seller != null && row.seller.grossRevenue == null) ||
+		(row.buyer != null && (row.buyer.grossSpend == null || row.buyer.returnedFunds == null));
+	if (hasUnknownAmount) {
 		warnings.push({
 			code: 'ECONOMIC_METRIC_EVIDENCE_PARTIAL',
 			message:

--- a/src/services/transaction-report/records.ts
+++ b/src/services/transaction-report/records.ts
@@ -1,0 +1,468 @@
+import { serializeReportAmount } from '@/utils/asset-units';
+import { addAmounts, subtractAmounts, type AtomicAmount } from './amounts';
+import {
+	calculateBuyerMetrics,
+	calculateSellerMetrics,
+	reconcileCardanoFees,
+	type PayoutCompleteness,
+	type ReportOnChainState,
+	type ReportPaymentSourceType,
+	type RevenueMode,
+} from './metrics';
+import {
+	getReportFeeTransactions,
+	getReportTimestamps,
+	hasConfirmedOnChainTransaction,
+	hasConfirmedStateTransaction,
+	sumPerRequestConfirmedTransactionFees,
+	type ReportTransactionEvent,
+} from './timestamps';
+
+export type ReportRole = 'Buyer' | 'Seller';
+export type ReportRequestType = 'PaymentRequest' | 'PurchaseRequest';
+
+export type ReportManagedWallet = {
+	id: string;
+	walletAddress: string;
+	walletVkey: string;
+	collectionAddress: string | null;
+	deletedAt: Date | null;
+};
+
+export type ReportMetricWindow = Readonly<{
+	dateBasis: 'CreatedAt' | 'FundsLockedAt' | 'RevenueRecognizedAt';
+	from: Date;
+	to: Date;
+}>;
+
+type ReportCardanoFeeTiming = 'stored_cumulative' | 'accounting_allocation';
+
+export type ReportRequestRecord = {
+	id: string;
+	role: ReportRole;
+	requestType: ReportRequestType;
+	createdAt: Date;
+	blockchainIdentifier: string;
+	agentIdentifier: string | null;
+	agentName: string | null;
+	onChainState: ReportOnChainState | null;
+	metadata: string | null;
+	managedWallet: ReportManagedWallet | null;
+	counterpartyAddress: string | null;
+	buyerReturnAddress: string | null;
+	sellerReturnAddress: string | null;
+	paymentSourceType: ReportPaymentSourceType;
+	configuredFeeRatePermille: number;
+	unlockTime: bigint;
+	collateralReturnLovelace: bigint | null;
+	requestedFunds: readonly AtomicAmount[];
+	withdrawnForBuyer: readonly AtomicAmount[];
+	withdrawnForSeller: readonly AtomicAmount[];
+	buyerPayoutCompleteness: PayoutCompleteness;
+	sellerPayoutCompleteness: PayoutCompleteness;
+	buyerCardanoFees: bigint;
+	sellerCardanoFees: bigint;
+	transactions: readonly ReportTransactionEvent[];
+	feeAllocationScope: 'single_request' | 'shared_or_unknown';
+	isFeeReconciliationOwner: boolean;
+	feeComponentScope: 'complete' | 'partial';
+};
+
+export type ReportWarning = {
+	code: string;
+	message: string;
+	rowId: string | null;
+};
+
+function assertValidMetricWindow(window: ReportMetricWindow): void {
+	if (Number.isNaN(window.from.getTime()) || Number.isNaN(window.to.getTime())) {
+		throw new RangeError('Report metric window dates must be valid');
+	}
+	if (window.to.getTime() <= window.from.getTime()) {
+		throw new RangeError('Report metric window to date must be after from date');
+	}
+}
+
+function isInMetricWindow(value: Date | null, window: ReportMetricWindow): boolean {
+	if (value == null) return false;
+	return value.getTime() >= window.from.getTime() && value.getTime() < window.to.getTime();
+}
+
+function scopeSellerMetrics(
+	metrics: ReturnType<typeof calculateSellerMetrics>,
+	sellerRevenueRecognizedAt: Date | null,
+	fundsLockedAt: Date | null,
+	window: ReportMetricWindow,
+) {
+	const cardanoFeeTiming: ReportCardanoFeeTiming =
+		window.dateBasis === 'RevenueRecognizedAt' ? 'accounting_allocation' : 'stored_cumulative';
+	if (window.dateBasis === 'CreatedAt') return { ...metrics, cardanoFeeTiming };
+	const accountingDate = window.dateBasis === 'FundsLockedAt' ? fundsLockedAt : sellerRevenueRecognizedAt;
+	if (isInMetricWindow(accountingDate, window)) {
+		return { ...metrics, cardanoFeeTiming };
+	}
+	const hasUnplacedEconomicValue =
+		metrics.grossRevenue == null ||
+		metrics.grossRevenue.length > 0 ||
+		metrics.protocolFee.completeness === 'insufficient_data' ||
+		(metrics.protocolFee.amounts?.length ?? 0) > 0;
+	if (accountingDate == null && hasUnplacedEconomicValue) {
+		const hasUnplacedProtocolFee =
+			metrics.protocolFee.completeness !== 'not_applicable' && metrics.protocolFee.provenance !== 'exact_zero';
+		return {
+			grossRevenue: metrics.grossRevenue == null || metrics.grossRevenue.length > 0 ? null : [],
+			protocolFee: hasUnplacedProtocolFee
+				? {
+						...metrics.protocolFee,
+						appliedRatePermille: null,
+						amounts: null,
+						provenance: 'insufficient_data' as const,
+						basis: null,
+						completeness: 'insufficient_data' as const,
+					}
+				: metrics.protocolFee,
+			cardanoFees: [],
+			netRevenue: null,
+			cardanoFeeTiming,
+		};
+	}
+	return {
+		grossRevenue: [],
+		protocolFee: {
+			...metrics.protocolFee,
+			appliedRatePermille: null,
+			amounts: null,
+			provenance: 'not_applicable' as const,
+			basis: null,
+			completeness: 'not_applicable' as const,
+		},
+		cardanoFees: [],
+		netRevenue: [],
+		cardanoFeeTiming,
+	};
+}
+
+function scopeBuyerMetrics(
+	metrics: ReturnType<typeof calculateBuyerMetrics>,
+	timestamps: ReturnType<typeof getReportTimestamps>,
+	window: ReportMetricWindow,
+) {
+	const cardanoFeeTiming: ReportCardanoFeeTiming =
+		window.dateBasis === 'RevenueRecognizedAt' ? 'accounting_allocation' : 'stored_cumulative';
+	if (window.dateBasis === 'CreatedAt') return { ...metrics, cardanoFeeTiming };
+	if (window.dateBasis === 'FundsLockedAt') {
+		if (isInMetricWindow(timestamps.fundsLockedAt, window)) return { ...metrics, cardanoFeeTiming };
+		if (timestamps.fundsLockedAt == null) {
+			const grossSpend = metrics.grossSpend == null || metrics.grossSpend.length > 0 ? null : [];
+			const returnedFunds = metrics.returnedFunds == null || metrics.returnedFunds.length > 0 ? null : [];
+			return {
+				grossSpend,
+				returnedFunds,
+				cardanoFees: [],
+				netSpend: grossSpend == null || returnedFunds == null || metrics.cardanoFees.length > 0 ? null : [],
+				cardanoFeeTiming,
+			};
+		}
+		return { grossSpend: [], returnedFunds: [], cardanoFees: [], netSpend: [], cardanoFeeTiming };
+	}
+
+	const hasGrossSpendInWindow = isInMetricWindow(timestamps.buyerGrossSpendAt, window);
+	const hasReturnedFundsInWindow = isInMetricWindow(timestamps.buyerReturnedAt, window);
+	const grossSpend = hasGrossSpendInWindow
+		? metrics.grossSpend
+		: timestamps.buyerGrossSpendAt == null && (metrics.grossSpend == null || metrics.grossSpend.length > 0)
+			? null
+			: [];
+	const returnedFunds = hasReturnedFundsInWindow
+		? metrics.returnedFunds
+		: timestamps.buyerReturnedAt == null && (metrics.returnedFunds == null || metrics.returnedFunds.length > 0)
+			? null
+			: [];
+	const cardanoFees = hasGrossSpendInWindow ? metrics.cardanoFees : [];
+	const netSpend =
+		grossSpend == null || returnedFunds == null
+			? null
+			: addAmounts(subtractAmounts(grossSpend, returnedFunds), cardanoFees);
+	return { grossSpend, returnedFunds, cardanoFees, netSpend, cardanoFeeTiming };
+}
+
+function reconcileRowCardanoFees(
+	record: ReportRequestRecord,
+	transactionFees: ReturnType<typeof sumPerRequestConfirmedTransactionFees>,
+	buyerCardanoFees: bigint,
+	sellerCardanoFees: bigint,
+	isActorFeeAllocationComplete: boolean,
+	feeComponentScope: ReportRequestRecord['feeComponentScope'],
+) {
+	const hasExactOwnedTotal =
+		record.isFeeReconciliationOwner && transactionFees.completeness === 'complete' && transactionFees.amount != null;
+	if (hasExactOwnedTotal && !isActorFeeAllocationComplete) {
+		return {
+			buyerCardanoFees,
+			sellerCardanoFees,
+			adminCardanoFees: null,
+			totalCardanoFees: transactionFees.amount,
+			completeness: 'partial' as const,
+		};
+	}
+	const reconciliation = reconcileCardanoFees({
+		buyerCardanoFees,
+		sellerCardanoFees,
+		allocatedTotalCardanoFees: hasExactOwnedTotal ? transactionFees.amount : null,
+		isAllocationComplete: hasExactOwnedTotal,
+	});
+	if (!hasExactOwnedTotal || feeComponentScope === 'complete' || reconciliation.completeness === 'inconsistent') {
+		return reconciliation;
+	}
+	return {
+		...reconciliation,
+		adminCardanoFees: null,
+		totalCardanoFees: transactionFees.amount,
+		completeness: 'partial' as const,
+	};
+}
+
+function getRowFeeComponentScope(
+	record: ReportRequestRecord,
+	window: ReportMetricWindow,
+): ReportRequestRecord['feeComponentScope'] {
+	const hasIncompleteTransaction = getReportFeeTransactions(record.transactions, window)
+		.filter((transaction) => transaction.status === 'Confirmed' && transaction.fees !== 0n)
+		.some((transaction) => {
+			if (transaction.relatedPaymentKeysComplete === false) return true;
+			const paymentKeys = Array.from(new Set(transaction.relatedPaymentKeys ?? []));
+			return paymentKeys.length !== 1 || paymentKeys[0] !== record.blockchainIdentifier;
+		});
+	return hasIncompleteTransaction ? 'partial' : 'complete';
+}
+
+export function buildReportRow(
+	record: ReportRequestRecord,
+	revenueMode: RevenueMode,
+	asOf: Date,
+	window: ReportMetricWindow,
+) {
+	assertValidMetricWindow(window);
+	const hasConfirmedTransaction = hasConfirmedOnChainTransaction(record.transactions);
+	const hasConfirmedFundsLockedTransaction = hasConfirmedStateTransaction(record.transactions, 'FundsLocked');
+	const hasConfirmedCurrentStateTransaction =
+		record.onChainState != null && hasConfirmedStateTransaction(record.transactions, record.onChainState);
+	const metricInput = {
+		onChainState: record.onChainState,
+		paymentSourceType: record.paymentSourceType,
+		configuredFeeRatePermille: record.configuredFeeRatePermille,
+		unlockTime: record.unlockTime,
+		asOfTime: BigInt(asOf.getTime()),
+		hasConfirmedFundsLockedTransaction,
+		hasConfirmedCurrentStateTransaction,
+		requestedFunds: record.requestedFunds,
+		withdrawnForBuyer: record.withdrawnForBuyer,
+		withdrawnForSeller: record.withdrawnForSeller,
+		buyerPayoutCompleteness: record.buyerPayoutCompleteness,
+		sellerPayoutCompleteness: record.sellerPayoutCompleteness,
+		collateralReturnLovelace: record.collateralReturnLovelace,
+		buyerCardanoFees: record.buyerCardanoFees,
+		sellerCardanoFees: record.sellerCardanoFees,
+	};
+	const timestamps = getReportTimestamps({
+		createdAt: record.createdAt,
+		onChainState: record.onChainState,
+		unlockTime: record.unlockTime,
+		asOfTime: BigInt(asOf.getTime()),
+		revenueMode,
+		transactions: record.transactions,
+	});
+	const hasKnownFundsLockedMembership =
+		window.dateBasis !== 'FundsLockedAt' || isInMetricWindow(timestamps.fundsLockedAt, window);
+	const transactionFees =
+		!hasKnownFundsLockedMembership || (record.onChainState != null && !hasConfirmedTransaction)
+			? ({ amount: null, completeness: 'partial' } as const)
+			: sumPerRequestConfirmedTransactionFees(
+					record.transactions,
+					record.feeAllocationScope,
+					window,
+					record.blockchainIdentifier,
+				);
+	const feeComponentScope = hasKnownFundsLockedMembership ? getRowFeeComponentScope(record, window) : 'partial';
+	const seller =
+		record.role === 'Seller'
+			? scopeSellerMetrics(
+					calculateSellerMetrics(metricInput, revenueMode),
+					timestamps.sellerRevenueRecognizedAt,
+					timestamps.fundsLockedAt,
+					window,
+				)
+			: null;
+	const buyer =
+		record.role === 'Buyer' ? scopeBuyerMetrics(calculateBuyerMetrics(metricInput), timestamps, window) : null;
+	const actorCardanoFeeAllocation = {
+		strategy:
+			window.dateBasis === 'RevenueRecognizedAt' ? ('accounting_allocation' as const) : ('lifetime_cohort' as const),
+		completeness: 'partial' as const,
+		attachedAt:
+			window.dateBasis !== 'RevenueRecognizedAt'
+				? null
+				: record.role === 'Seller'
+					? timestamps.sellerRevenueRecognizedAt
+					: timestamps.buyerGrossSpendAt,
+	};
+	const reconciliationBuyerCardanoFees =
+		hasKnownFundsLockedMembership &&
+		(window.dateBasis !== 'RevenueRecognizedAt' || isInMetricWindow(timestamps.buyerGrossSpendAt, window))
+			? record.buyerCardanoFees
+			: 0n;
+	const reconciliationSellerCardanoFees =
+		hasKnownFundsLockedMembership &&
+		(window.dateBasis !== 'RevenueRecognizedAt' || isInMetricWindow(timestamps.sellerRevenueRecognizedAt, window))
+			? record.sellerCardanoFees
+			: 0n;
+	const cardanoFeeReconciliation = reconcileRowCardanoFees(
+		record,
+		transactionFees,
+		reconciliationBuyerCardanoFees,
+		reconciliationSellerCardanoFees,
+		false,
+		feeComponentScope,
+	);
+
+	return {
+		...record,
+		feeComponentScope,
+		timestamps,
+		seller,
+		buyer,
+		actorCardanoFeeAllocation,
+		cardanoFeeReconciliation,
+	};
+}
+
+export type ReportRow = ReturnType<typeof buildReportRow>;
+
+function serializeAmounts(amounts: readonly AtomicAmount[] | null) {
+	return amounts?.map(serializeReportAmount) ?? null;
+}
+
+export function serializeReportRow(row: ReportRow) {
+	return {
+		id: row.id,
+		role: row.role,
+		requestType: row.requestType,
+		createdAt: row.createdAt,
+		blockchainIdentifier: row.blockchainIdentifier,
+		agentIdentifier: row.agentIdentifier,
+		agentName: row.agentName,
+		onChainState: row.onChainState,
+		metadata: row.metadata,
+		managedWallet: row.managedWallet,
+		counterpartyAddress: row.counterpartyAddress,
+		buyerReturnAddress: row.buyerReturnAddress,
+		sellerReturnAddress: row.sellerReturnAddress,
+		timestamps: row.timestamps,
+		seller:
+			row.seller == null
+				? null
+				: {
+						grossRevenue: serializeAmounts(row.seller.grossRevenue),
+						protocolFee: {
+							...row.seller.protocolFee,
+							amounts: serializeAmounts(row.seller.protocolFee.amounts),
+						},
+						cardanoFees: serializeAmounts(row.seller.cardanoFees) ?? [],
+						cardanoFeeTiming: row.seller.cardanoFeeTiming,
+						netRevenue: serializeAmounts(row.seller.netRevenue),
+						payoutCompleteness: row.sellerPayoutCompleteness,
+					},
+		buyer:
+			row.buyer == null
+				? null
+				: {
+						grossSpend: serializeAmounts(row.buyer.grossSpend),
+						returnedFunds: serializeAmounts(row.buyer.returnedFunds),
+						cardanoFees: serializeAmounts(row.buyer.cardanoFees) ?? [],
+						cardanoFeeTiming: row.buyer.cardanoFeeTiming,
+						netSpend: serializeAmounts(row.buyer.netSpend),
+						payoutCompleteness: row.buyerPayoutCompleteness,
+					},
+		actorCardanoFeeAllocation: row.actorCardanoFeeAllocation,
+		feeAllocationScope: row.feeAllocationScope,
+		feeComponentScope: row.feeComponentScope,
+		cardanoFeeReconciliation: {
+			buyerCardanoFees: serializeReportAmount({
+				unit: 'lovelace',
+				amount: row.cardanoFeeReconciliation.buyerCardanoFees,
+			}),
+			sellerCardanoFees: serializeReportAmount({
+				unit: 'lovelace',
+				amount: row.cardanoFeeReconciliation.sellerCardanoFees,
+			}),
+			adminCardanoFees:
+				row.cardanoFeeReconciliation.adminCardanoFees == null
+					? null
+					: serializeReportAmount({
+							unit: 'lovelace',
+							amount: row.cardanoFeeReconciliation.adminCardanoFees,
+						}),
+			totalCardanoFees:
+				row.cardanoFeeReconciliation.totalCardanoFees == null
+					? null
+					: serializeReportAmount({
+							unit: 'lovelace',
+							amount: row.cardanoFeeReconciliation.totalCardanoFees,
+						}),
+			completeness: row.cardanoFeeReconciliation.completeness,
+			isAggregationOwner: row.isFeeReconciliationOwner,
+		},
+	};
+}
+
+export function getReportRowWarnings(row: ReportRow): ReportWarning[] {
+	const warnings: ReportWarning[] = [];
+	if (row.seller?.protocolFee.completeness === 'reconstructed') {
+		warnings.push({
+			code: 'PROTOCOL_FEE_RECONSTRUCTED',
+			message:
+				'V1 protocol fee uses the current Payment Source rate and stored requested funds plus collateral. Historical UTxO top-ups can differ.',
+			rowId: row.id,
+		});
+	} else if (row.seller?.protocolFee.completeness === 'insufficient_data') {
+		warnings.push({
+			code: 'PROTOCOL_FEE_INSUFFICIENT_DATA',
+			message:
+				'Confirmed exact-state evidence, chain timing, or stored V1 fee inputs are insufficient for an exact protocol fee.',
+			rowId: row.id,
+		});
+	}
+	if (row.sellerPayoutCompleteness === 'partial' || row.buyerPayoutCompleteness === 'partial') {
+		warnings.push({
+			code: 'DISPUTED_PAYOUT_PARTIAL',
+			message:
+				'Stored disputed payout data lacks complete payout provenance, cannot separate buyer collateral, or uses a different V2 return-address payment key.',
+			rowId: row.id,
+		});
+	}
+	if (row.cardanoFeeReconciliation.completeness !== 'complete') {
+		warnings.push({
+			code: 'CARDANO_FEE_RECONCILIATION_PARTIAL',
+			message:
+				'Shared transaction evidence, aggregation ownership, or incomplete actor components prevent exact per-row admin fee allocation.',
+			rowId: row.id,
+		});
+	}
+	if (row.actorCardanoFeeAllocation.completeness === 'partial') {
+		warnings.push({
+			code: 'ACTOR_CARDANO_FEE_EVENT_ALLOCATION_PARTIAL',
+			message:
+				'Buyer and seller Cardano fee counters are observed cumulative values. Exact historical actor and admin allocation is unavailable from transaction records.',
+			rowId: row.id,
+		});
+	}
+	if (row.seller?.grossRevenue == null || row.buyer?.grossSpend == null || row.buyer?.returnedFunds == null) {
+		warnings.push({
+			code: 'ECONOMIC_METRIC_EVIDENCE_PARTIAL',
+			message:
+				'Confirmed state evidence, chain timing, or payout data are insufficient for one or more economic amounts.',
+			rowId: row.id,
+		});
+	}
+	return warnings;
+}

--- a/src/services/transaction-report/row-groups.ts
+++ b/src/services/transaction-report/row-groups.ts
@@ -1,0 +1,16 @@
+import type { ReportRow } from './records';
+import { NO_REPORT_CHECKPOINT, runReportCheckpoint, type ReportCheckpoint } from './checkpoint';
+
+export function groupReportRowsByPayment(
+	rows: readonly ReportRow[],
+	checkpoint: ReportCheckpoint = NO_REPORT_CHECKPOINT,
+): Map<string, ReportRow[]> {
+	const groups = new Map<string, ReportRow[]>();
+	for (const [index, row] of rows.entries()) {
+		runReportCheckpoint(index, checkpoint);
+		const group = groups.get(row.blockchainIdentifier);
+		if (group == null) groups.set(row.blockchainIdentifier, [row]);
+		else group.push(row);
+	}
+	return groups;
+}

--- a/src/services/transaction-report/timestamps.spec.ts
+++ b/src/services/transaction-report/timestamps.spec.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	getReportTimestamps,
+	hasConfirmedOnChainTransaction,
+	hasConfirmedStateTransaction,
+	mergeReportTransactions,
+	sumPerRequestConfirmedTransactionFees,
+	type ReportTransactionEvent,
+} from './timestamps';
+
+const createdAt = new Date('2026-01-01T00:00:00.000Z');
+
+function event(overrides: Partial<ReportTransactionEvent> = {}): ReportTransactionEvent {
+	return {
+		id: 'tx-1',
+		txHash: 'hash-1',
+		status: 'Confirmed',
+		newOnChainState: 'FundsLocked',
+		blockTime: 1_767_225_700,
+		fees: 100_000n,
+		relatedRequestKeys: ['Seller:request-1'],
+		relatedPaymentKeys: ['chain-1'],
+		...overrides,
+	};
+}
+
+describe('report transaction timestamps', () => {
+	it('uses the earliest confirmed FundsLocked block time', () => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: 'Withdrawn',
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'Billable',
+			transactions: [
+				event({ id: 'later', txHash: 'later', blockTime: 1_767_225_800 }),
+				event({ id: 'earlier', txHash: 'earlier', blockTime: 1_767_225_700 }),
+			],
+		});
+		expect(result.fundsLockedAt?.toISOString()).toBe('2026-01-01T00:01:40.000Z');
+	});
+
+	it('uses unlock time for projected ResultSubmitted revenue', () => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: 'ResultSubmitted',
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'Billable',
+			transactions: [event({ newOnChainState: 'ResultSubmitted' })],
+		});
+		expect(result.sellerRevenueRecognizedAt?.toISOString()).toBe('2026-01-01T00:06:40.000Z');
+	});
+
+	it('keeps Billable revenue at unlock after a later withdrawal', () => {
+		const transactions = [
+			event({ id: 'result', txHash: 'result', newOnChainState: 'ResultSubmitted', blockTime: 1_767_225_800 }),
+			event({ id: 'withdraw', txHash: 'withdraw', newOnChainState: 'Withdrawn', blockTime: 1_767_312_400 }),
+		];
+		const input = {
+			createdAt,
+			onChainState: 'Withdrawn' as const,
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_320_000_000n,
+			transactions,
+		};
+
+		expect(getReportTimestamps({ ...input, revenueMode: 'Billable' }).sellerRevenueRecognizedAt?.toISOString()).toBe(
+			'2026-01-01T00:06:40.000Z',
+		);
+		expect(
+			getReportTimestamps({ ...input, revenueMode: 'CashReceived' }).sellerRevenueRecognizedAt?.toISOString(),
+		).toBe('2026-01-02T00:06:40.000Z');
+	});
+
+	it.each([
+		['wrong state', event()],
+		['missing hash', event({ txHash: null, newOnChainState: 'ResultSubmitted' })],
+		['pending', event({ status: 'Pending', newOnChainState: 'ResultSubmitted' })],
+		['rolled back', event({ status: 'RolledBack', newOnChainState: 'ResultSubmitted' })],
+	] as const)('does not project ResultSubmitted revenue from %s evidence', (_name, transaction) => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: 'ResultSubmitted',
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'Billable',
+			transactions: [transaction],
+		});
+		expect(result.sellerRevenueRecognizedAt).toBeNull();
+	});
+
+	it('uses the terminal chain transition for settled seller revenue and buyer returns', () => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: 'DisputedWithdrawn',
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'CashReceived',
+			transactions: [
+				event(),
+				event({
+					id: 'tx-2',
+					txHash: 'hash-2',
+					newOnChainState: 'DisputedWithdrawn',
+					blockTime: 1_767_226_300,
+				}),
+			],
+		});
+		expect(result.sellerRevenueRecognizedAt?.toISOString()).toBe('2026-01-01T00:11:40.000Z');
+		expect(result.buyerReturnedAt?.toISOString()).toBe('2026-01-01T00:11:40.000Z');
+	});
+
+	it('uses creation time for requested gross revenue', () => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: null,
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'RequestedGross',
+			transactions: [],
+		});
+		expect(result.sellerRevenueRecognizedAt).toEqual(createdAt);
+		expect(result.buyerGrossSpendAt).toBeNull();
+	});
+
+	it('does not substitute database observation time for missing chain time', () => {
+		const result = getReportTimestamps({
+			createdAt,
+			onChainState: 'Withdrawn',
+			unlockTime: 1_767_226_000_000n,
+			asOfTime: 1_767_230_000_000n,
+			revenueMode: 'Billable',
+			transactions: [event({ newOnChainState: 'Withdrawn', blockTime: null })],
+		});
+		expect(result.fundsLockedAt).toBeNull();
+		expect(result.sellerRevenueRecognizedAt).toBeNull();
+	});
+});
+
+describe('transaction history completeness', () => {
+	it('merges many same-hash mirrors into one transaction', () => {
+		const mirrors = Array.from({ length: 5_000 }, (_value, index) =>
+			event({
+				id: `mirror-${index}`,
+				relatedRequestKeys: [`Seller:request-${index}`],
+				relatedPaymentKeys: [`chain-${index}`],
+			}),
+		);
+
+		const merged = mergeReportTransactions(mirrors);
+
+		expect(merged).toHaveLength(1);
+		expect(merged[0].relatedRequestKeys).toHaveLength(5_000);
+		expect(merged[0].relatedPaymentKeys).toHaveLength(5_000);
+	});
+
+	it('requires a confirmed transaction hash', () => {
+		expect(hasConfirmedOnChainTransaction([event()])).toBe(true);
+		expect(hasConfirmedOnChainTransaction([event({ txHash: null })])).toBe(false);
+		expect(hasConfirmedOnChainTransaction([event({ status: 'Pending' })])).toBe(false);
+	});
+
+	it('requires confirmed evidence for the exact requested state', () => {
+		expect(hasConfirmedStateTransaction([event()], 'FundsLocked')).toBe(true);
+		expect(hasConfirmedStateTransaction([event()], 'ResultSubmitted')).toBe(false);
+		expect(hasConfirmedStateTransaction([event({ status: 'RolledBack' })], 'FundsLocked')).toBe(false);
+	});
+
+	it('deduplicates a shared transaction before summing fees', () => {
+		expect(sumPerRequestConfirmedTransactionFees([event(), event({ id: 'duplicate' })], 'single_request')).toEqual({
+			amount: 100_000n,
+			completeness: 'complete',
+		});
+	});
+
+	it('merges and sorts related request keys without row-order dependence', () => {
+		const first = event({
+			id: 'b',
+			relatedRequestKeys: ['Seller:request-2', 'Buyer:request-1'],
+			relatedPaymentKeys: ['chain-2', 'chain-1'],
+		});
+		const second = event({
+			id: 'a',
+			relatedRequestKeys: ['Buyer:request-1', 'Seller:request-1'],
+			relatedPaymentKeys: ['chain-3', 'chain-1'],
+		});
+		const expected = [
+			expect.objectContaining({
+				id: 'a',
+				relatedRequestKeys: ['Buyer:request-1', 'Seller:request-1', 'Seller:request-2'],
+				relatedPaymentKeys: ['chain-1', 'chain-2', 'chain-3'],
+			}),
+		];
+
+		expect(mergeReportTransactions([first, second])).toEqual(expected);
+		expect(mergeReportTransactions([second, first])).toEqual(expected);
+	});
+
+	it('keeps unknown related requests nullable in merged evidence', () => {
+		expect(mergeReportTransactions([event({ relatedRequestKeys: null, relatedPaymentKeys: null })])).toEqual([
+			expect.objectContaining({ relatedRequestKeys: null, relatedPaymentKeys: null }),
+		]);
+	});
+
+	it('marks a confirmed transaction with missing fees as partial', () => {
+		expect(sumPerRequestConfirmedTransactionFees([event({ fees: null })], 'single_request')).toEqual({
+			amount: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('refuses to assign whole shared transaction fees to one request', () => {
+		expect(sumPerRequestConfirmedTransactionFees([event()], 'shared_or_unknown')).toEqual({
+			amount: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('merges duplicate evidence without depending on row order', () => {
+		const incomplete = event({ id: 'a', blockTime: null, fees: null });
+		const complete = event({ id: 'b' });
+		expect(sumPerRequestConfirmedTransactionFees([incomplete, complete], 'single_request')).toEqual({
+			amount: 100_000n,
+			completeness: 'complete',
+		});
+		expect(sumPerRequestConfirmedTransactionFees([complete, incomplete], 'single_request')).toEqual({
+			amount: 100_000n,
+			completeness: 'complete',
+		});
+	});
+
+	it('allows Pending evidence to advance to Confirmed', () => {
+		expect(hasConfirmedOnChainTransaction([event({ id: 'pending', status: 'Pending' }), event()])).toBe(true);
+	});
+
+	it('does not book conflicting terminal transaction statuses', () => {
+		const transactions = [event(), event({ id: 'rolled-back', status: 'RolledBack' })];
+		expect(hasConfirmedOnChainTransaction(transactions)).toBe(false);
+		expect(sumPerRequestConfirmedTransactionFees(transactions, 'single_request')).toEqual({
+			amount: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('marks conflicting duplicate fee evidence as partial', () => {
+		expect(
+			sumPerRequestConfirmedTransactionFees([event(), event({ id: 'conflict', fees: 200_000n })], 'single_request'),
+		).toEqual({ amount: null, completeness: 'partial' });
+	});
+
+	it('sums only transaction fees inside a revenue-recognized window', () => {
+		expect(
+			sumPerRequestConfirmedTransactionFees(
+				[
+					event({ id: 'outside', txHash: 'outside', blockTime: 1_767_225_700, fees: 100_000n }),
+					event({ id: 'inside', txHash: 'inside', blockTime: 1_767_398_500, fees: 50_000n }),
+				],
+				'single_request',
+				{
+					dateBasis: 'RevenueRecognizedAt',
+					from: new Date('2026-01-03T00:00:00.000Z'),
+					to: new Date('2026-01-04T00:00:00.000Z'),
+				},
+				'chain-1',
+			),
+		).toEqual({ amount: 50_000n, completeness: 'complete' });
+	});
+
+	it('marks an in-scope confirmed fee with missing block time partial', () => {
+		expect(
+			sumPerRequestConfirmedTransactionFees(
+				[event({ blockTime: null })],
+				'single_request',
+				{
+					dateBasis: 'RevenueRecognizedAt',
+					from: new Date('2026-01-03T00:00:00.000Z'),
+					to: new Date('2026-01-04T00:00:00.000Z'),
+				},
+				'chain-1',
+			),
+		).toEqual({ amount: null, completeness: 'partial' });
+	});
+
+	it('ignores shared allocation evidence outside a revenue-recognized window', () => {
+		expect(
+			sumPerRequestConfirmedTransactionFees(
+				[
+					event({
+						id: 'outside-shared',
+						txHash: 'outside-shared',
+						blockTime: 1_767_225_700,
+						fees: 100_000n,
+						relatedPaymentKeys: ['chain-1', 'chain-2'],
+					}),
+					event({ id: 'inside-single', txHash: 'inside-single', blockTime: 1_767_398_500, fees: 50_000n }),
+				],
+				'shared_or_unknown',
+				{
+					dateBasis: 'RevenueRecognizedAt',
+					from: new Date('2026-01-03T00:00:00.000Z'),
+					to: new Date('2026-01-04T00:00:00.000Z'),
+				},
+				'chain-1',
+			),
+		).toEqual({ amount: 50_000n, completeness: 'complete' });
+	});
+
+	it.each([
+		['CreatedAt', undefined],
+		[
+			'RevenueRecognizedAt',
+			{
+				dateBasis: 'RevenueRecognizedAt' as const,
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		],
+	])('treats a confirmed shared zero fee as complete for %s', (_dateBasis, window) => {
+		expect(
+			sumPerRequestConfirmedTransactionFees(
+				[event({ fees: 0n, relatedPaymentKeys: ['chain-1', 'chain-2'] })],
+				'shared_or_unknown',
+				window,
+				'chain-1',
+			),
+		).toEqual({ amount: 0n, completeness: 'complete' });
+	});
+});

--- a/src/services/transaction-report/timestamps.ts
+++ b/src/services/transaction-report/timestamps.ts
@@ -1,0 +1,203 @@
+import type { ReportOnChainState, RevenueMode } from './metrics';
+
+export type ReportTransactionEvent = Readonly<{
+	id: string;
+	txHash: string | null;
+	status: string | null;
+	newOnChainState: ReportOnChainState | null;
+	blockTime: number | null;
+	fees: bigint | null;
+	relatedRequestKeys?: readonly string[] | null;
+	relatedPaymentKeys?: readonly string[] | null;
+	relatedPaymentKeysComplete?: boolean;
+}>;
+
+export type ReportTransactionFeeWindow = Readonly<{
+	dateBasis: 'CreatedAt' | 'FundsLockedAt' | 'RevenueRecognizedAt';
+	from: Date;
+	to: Date;
+}>;
+
+function mergeOptionalEvidence<T>(values: ReadonlyArray<T | null>): T | null {
+	const presentValues = values.filter((value): value is T => value != null);
+	if (presentValues.length === 0) return null;
+	return presentValues.every((value) => value === presentValues[0]) ? presentValues[0] : null;
+}
+
+function mergeTransactionStatus(values: ReadonlyArray<string | null>): string | null {
+	const statuses = Array.from(new Set(values.filter((value): value is string => value != null)));
+	if (statuses.length <= 1) return statuses[0] ?? null;
+	const terminalStatuses = statuses.filter((status) => status !== 'Pending');
+	return terminalStatuses.length === 1 ? terminalStatuses[0] : null;
+}
+
+function mergeRelatedKeys(values: ReadonlyArray<readonly string[] | null | undefined>): readonly string[] | null {
+	const presentValues = values.filter((value): value is readonly string[] => value != null);
+	if (presentValues.length === 0) return null;
+	return Array.from(new Set(presentValues.flat())).sort((left, right) => left.localeCompare(right));
+}
+
+export function mergeReportTransactions(transactions: readonly ReportTransactionEvent[]): ReportTransactionEvent[] {
+	const groups = new Map<string, ReportTransactionEvent[]>();
+	for (const transaction of transactions) {
+		const key = transaction.txHash == null ? `id:${transaction.id}` : `hash:${transaction.txHash}`;
+		const group = groups.get(key);
+		if (group == null) groups.set(key, [transaction]);
+		else group.push(transaction);
+	}
+
+	return Array.from(groups.entries())
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([_key, group]) => ({
+			id: group.map((transaction) => transaction.id).sort()[0],
+			txHash: mergeOptionalEvidence(group.map((transaction) => transaction.txHash)),
+			status: mergeTransactionStatus(group.map((transaction) => transaction.status)),
+			newOnChainState: mergeOptionalEvidence(group.map((transaction) => transaction.newOnChainState)),
+			blockTime: mergeOptionalEvidence(group.map((transaction) => transaction.blockTime)),
+			fees: mergeOptionalEvidence(group.map((transaction) => transaction.fees)),
+			relatedRequestKeys: mergeRelatedKeys(group.map((transaction) => transaction.relatedRequestKeys)),
+			relatedPaymentKeys: mergeRelatedKeys(group.map((transaction) => transaction.relatedPaymentKeys)),
+			relatedPaymentKeysComplete: group.every((transaction) => transaction.relatedPaymentKeysComplete !== false),
+		}));
+}
+
+function dateFromBlockTime(blockTime: number | null): Date | null {
+	if (blockTime == null || !Number.isSafeInteger(blockTime) || blockTime < 0) return null;
+	const date = new Date(blockTime * 1000);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getReportFeeTransactions(
+	transactions: readonly ReportTransactionEvent[],
+	window?: ReportTransactionFeeWindow,
+): ReportTransactionEvent[] {
+	return mergeReportTransactions(transactions).filter((transaction) => {
+		if (window?.dateBasis !== 'RevenueRecognizedAt') return true;
+		const blockTime = dateFromBlockTime(transaction.blockTime);
+		return (
+			blockTime == null || (blockTime.getTime() >= window.from.getTime() && blockTime.getTime() < window.to.getTime())
+		);
+	});
+}
+
+function dateFromMilliseconds(milliseconds: bigint): Date | null {
+	if (milliseconds < 0n || milliseconds > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+	const date = new Date(Number(milliseconds));
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getConfirmedStateTime(
+	transactions: readonly ReportTransactionEvent[],
+	state: ReportOnChainState,
+): Date | null {
+	const matchingTimes = mergeReportTransactions(transactions)
+		.filter((transaction) => isConfirmedStateTransaction(transaction, state))
+		.map((transaction) => dateFromBlockTime(transaction.blockTime))
+		.filter((value): value is Date => value != null)
+		.sort((left, right) => left.getTime() - right.getTime());
+	return matchingTimes[0] ?? null;
+}
+
+function isConfirmedStateTransaction(transaction: ReportTransactionEvent, state: ReportOnChainState): boolean {
+	return transaction.status === 'Confirmed' && transaction.txHash != null && transaction.newOnChainState === state;
+}
+
+export function hasConfirmedStateTransaction(
+	transactions: readonly ReportTransactionEvent[],
+	state: ReportOnChainState,
+): boolean {
+	return mergeReportTransactions(transactions).some((transaction) => isConfirmedStateTransaction(transaction, state));
+}
+
+export function hasConfirmedOnChainTransaction(transactions: readonly ReportTransactionEvent[]): boolean {
+	return mergeReportTransactions(transactions).some(
+		(transaction) => transaction.status === 'Confirmed' && transaction.txHash != null,
+	);
+}
+
+export function sumPerRequestConfirmedTransactionFees(
+	transactions: readonly ReportTransactionEvent[],
+	allocationScope: 'single_request' | 'shared_or_unknown',
+	window?: ReportTransactionFeeWindow,
+	currentPaymentKey?: string,
+): {
+	amount: bigint | null;
+	completeness: 'complete' | 'partial';
+} {
+	const mergedTransactions = getReportFeeTransactions(transactions, window);
+	if (mergedTransactions.some((transaction) => transaction.status == null)) {
+		return { amount: null, completeness: 'partial' };
+	}
+	const confirmedTransactions = mergedTransactions.filter((transaction) => transaction.status === 'Confirmed');
+	if (
+		confirmedTransactions.some(
+			(transaction) =>
+				transaction.txHash == null ||
+				transaction.fees == null ||
+				transaction.fees < 0n ||
+				(window?.dateBasis === 'RevenueRecognizedAt' && dateFromBlockTime(transaction.blockTime) == null),
+		)
+	) {
+		return { amount: null, completeness: 'partial' };
+	}
+	const hasAmbiguousNonzeroFee = confirmedTransactions.some((transaction) => {
+		if (transaction.fees === 0n) return false;
+		if (transaction.relatedPaymentKeysComplete === false) return true;
+		if (currentPaymentKey == null) return allocationScope === 'shared_or_unknown';
+		const paymentKeys = Array.from(new Set(transaction.relatedPaymentKeys ?? []));
+		return paymentKeys.length !== 1 || paymentKeys[0] !== currentPaymentKey;
+	});
+	if (hasAmbiguousNonzeroFee) return { amount: null, completeness: 'partial' };
+	return {
+		amount: confirmedTransactions.reduce((total, transaction) => total + transaction.fees!, 0n),
+		completeness: 'complete',
+	};
+}
+
+export function getReportTimestamps(input: {
+	createdAt: Date;
+	onChainState: ReportOnChainState | null;
+	unlockTime: bigint;
+	asOfTime: bigint;
+	revenueMode: RevenueMode;
+	transactions: readonly ReportTransactionEvent[];
+}) {
+	const fundsLockedAt = getConfirmedStateTime(input.transactions, 'FundsLocked');
+	const withdrawnAt =
+		input.onChainState === 'Withdrawn' ? getConfirmedStateTime(input.transactions, 'Withdrawn') : null;
+	let sellerRevenueRecognizedAt: Date | null = null;
+	if (input.revenueMode === 'RequestedGross') {
+		sellerRevenueRecognizedAt = input.createdAt;
+	} else if (
+		input.revenueMode === 'Billable' &&
+		input.onChainState === 'ResultSubmitted' &&
+		input.unlockTime <= input.asOfTime &&
+		hasConfirmedStateTransaction(input.transactions, 'ResultSubmitted')
+	) {
+		sellerRevenueRecognizedAt = dateFromMilliseconds(input.unlockTime);
+	} else if (input.onChainState === 'Withdrawn') {
+		const unlockAt = dateFromMilliseconds(input.unlockTime);
+		const wasBillableBeforeWithdrawal =
+			input.revenueMode === 'Billable' &&
+			unlockAt != null &&
+			withdrawnAt != null &&
+			unlockAt.getTime() <= withdrawnAt.getTime() &&
+			hasConfirmedStateTransaction(input.transactions, 'ResultSubmitted');
+		sellerRevenueRecognizedAt = wasBillableBeforeWithdrawal ? unlockAt : withdrawnAt;
+	} else if (input.onChainState === 'DisputedWithdrawn') {
+		sellerRevenueRecognizedAt = getConfirmedStateTime(input.transactions, input.onChainState);
+	}
+
+	const buyerReturnedAt =
+		input.onChainState === 'RefundWithdrawn' || input.onChainState === 'DisputedWithdrawn'
+			? getConfirmedStateTime(input.transactions, input.onChainState)
+			: null;
+
+	return {
+		createdAt: input.createdAt,
+		fundsLockedAt,
+		sellerRevenueRecognizedAt,
+		buyerGrossSpendAt: fundsLockedAt,
+		buyerReturnedAt,
+	};
+}


### PR DESCRIPTION
The report's own model: one request row in, one set of figures out. No database access and no HTTP.

- `timestamps.ts`: which date each figure belongs to, per revenue mode.
- `records.ts`, `metrics.ts`, `amounts.ts`: per-row seller and buyer figures.
- `aggregate*.ts`: adding rows up into totals, per-wallet and per-bucket views.
- `access.ts`, `row-groups.ts`, `fee-split.ts`.

17 files, 5,467 lines. This layer imports nothing from the query, export or route layers, which is what lets the stack compile bottom-up.

---

**Part of a 6-PR split of #739.** That branch is 69 files and 34,694 lines, over the review-tooling limits, so nothing could review it as one change. It is split here by layer, bottom-up.

Verified before opening:
- The six branches together reproduce `feat/transaction-report-core` exactly. `git diff --stat origin/feat/transaction-report-core <tip>` is empty.
- `npx tsc --noEmit` reports 0 errors on each of the six branches in order, so every step of the stack compiles on its own.
- No file content was changed, reworded, or moved between layers beyond assigning each file to the layer that owns it.