### PR TITLE
feat(reports): add the report query layer

### DIFF
--- a/src/services/transaction-report/load-budget.ts
+++ b/src/services/transaction-report/load-budget.ts
@@ -1,0 +1,99 @@
+import { normalizeAssetUnit } from '@/utils/asset-units';
+import createHttpError from 'http-errors';
+import type { ReportRequestRecord, ReportRow } from './records';
+
+export type ReportLoadBudgetLimits = {
+	maxEvents?: number;
+	maxMetadataBytes?: number;
+	maxAssetEntries?: number;
+	maxAssetUnits?: number;
+	maxSerializedBytes?: number;
+};
+
+const DEFAULT_MAX_EVENTS = 500_000;
+const DEFAULT_MAX_METADATA_BYTES = 16 * 1024 * 1024;
+const DEFAULT_MAX_ASSET_ENTRIES = 500_000;
+const DEFAULT_MAX_ASSET_UNITS = 10_000;
+const DEFAULT_MAX_SERIALIZED_BYTES = 64 * 1024 * 1024;
+
+function stringBytes(value: string | null | undefined): number {
+	return value == null ? 0 : Buffer.byteLength(value, 'utf8');
+}
+
+function recordAmounts(record: ReportRequestRecord) {
+	return [...record.requestedFunds, ...record.withdrawnForBuyer, ...record.withdrawnForSeller];
+}
+
+function serializeBigInt(_key: string, item: unknown): unknown {
+	return typeof item === 'bigint' ? item.toString() : item;
+}
+
+function serializedBytes(value: ReportRequestRecord | ReportRow): number {
+	return Buffer.byteLength(JSON.stringify(value, serializeBigInt), 'utf8');
+}
+
+function reportLimitError(label: string, maximum: number): Error {
+	return createHttpError(413, `Report exceeds ${maximum} ${label}. Narrow the report filters.`);
+}
+
+type RecordCost = {
+	events: number;
+	metadataBytes: number;
+	assetEntries: number;
+	assetUnits: string[];
+	serializedBytes: number;
+};
+
+export function createReportLoadBudget(
+	limits: ReportLoadBudgetLimits = {},
+): (record: ReportRequestRecord, row?: ReportRow) => void {
+	const maxEvents = limits.maxEvents ?? DEFAULT_MAX_EVENTS;
+	const maxMetadataBytes = limits.maxMetadataBytes ?? DEFAULT_MAX_METADATA_BYTES;
+	const maxAssetEntries = limits.maxAssetEntries ?? DEFAULT_MAX_ASSET_ENTRIES;
+	const maxAssetUnits = limits.maxAssetUnits ?? DEFAULT_MAX_ASSET_UNITS;
+	const maxSerializedBytes = limits.maxSerializedBytes ?? DEFAULT_MAX_SERIALIZED_BYTES;
+	const costs = new Map<string, RecordCost>();
+	const assetUnitCounts = new Map<string, number>();
+	let eventCount = 0;
+	let metadataBytes = 0;
+	let assetEntryCount = 0;
+	let totalSerializedBytes = 0;
+
+	return (record, row) => {
+		const key = `${record.requestType}:${record.id}`;
+		const previous = costs.get(key);
+		if (previous != null) {
+			eventCount -= previous.events;
+			metadataBytes -= previous.metadataBytes;
+			assetEntryCount -= previous.assetEntries;
+			totalSerializedBytes -= previous.serializedBytes;
+			for (const unit of previous.assetUnits) {
+				const count = assetUnitCounts.get(unit)! - 1;
+				if (count === 0) assetUnitCounts.delete(unit);
+				else assetUnitCounts.set(unit, count);
+			}
+		}
+		const amounts = recordAmounts(record);
+		const cost: RecordCost = {
+			events: record.transactions.length,
+			metadataBytes: stringBytes(record.metadata),
+			assetEntries: amounts.length,
+			assetUnits: Array.from(new Set(amounts.map((amount) => normalizeAssetUnit(amount.unit)))),
+			serializedBytes: serializedBytes(record) + (row == null ? 0 : serializedBytes(row)),
+		};
+		costs.set(key, cost);
+		eventCount += cost.events;
+		metadataBytes += cost.metadataBytes;
+		assetEntryCount += cost.assetEntries;
+		totalSerializedBytes += cost.serializedBytes;
+		for (const unit of cost.assetUnits) assetUnitCounts.set(unit, (assetUnitCounts.get(unit) ?? 0) + 1);
+
+		if (eventCount > maxEvents) throw reportLimitError('transaction events', maxEvents);
+		if (metadataBytes > maxMetadataBytes) throw reportLimitError('metadata bytes', maxMetadataBytes);
+		if (assetEntryCount > maxAssetEntries) throw reportLimitError('asset entries', maxAssetEntries);
+		if (assetUnitCounts.size > maxAssetUnits) throw reportLimitError('unique asset units', maxAssetUnits);
+		if (totalSerializedBytes > maxSerializedBytes) {
+			throw reportLimitError('serialized bytes', maxSerializedBytes);
+		}
+	};
+}

--- a/src/services/transaction-report/query-bounds.ts
+++ b/src/services/transaction-report/query-bounds.ts
@@ -1,0 +1,22 @@
+import createHttpError from 'http-errors';
+
+export const REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST = 100;
+export const REPORT_MAX_FUND_ROWS_PER_REQUEST = 1_000;
+
+export function assertBoundedRequestRelations(
+	transactionHistory: { length: number },
+	...fundRelations: Array<{ length: number }>
+): void {
+	if (transactionHistory.length > REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST) {
+		throw createHttpError(
+			413,
+			`Report request exceeds ${REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST} transaction history rows. Narrow the report filters.`,
+		);
+	}
+	if (fundRelations.some((relation) => relation.length > REPORT_MAX_FUND_ROWS_PER_REQUEST)) {
+		throw createHttpError(
+			413,
+			`Report request exceeds ${REPORT_MAX_FUND_ROWS_PER_REQUEST} fund rows. Narrow the report filters.`,
+		);
+	}
+}

--- a/src/services/transaction-report/query-cursor.ts
+++ b/src/services/transaction-report/query-cursor.ts
@@ -1,0 +1,216 @@
+import { PaymentSourceType } from '@/generated/prisma/client';
+import { CONFIG } from '@masumi/payment-core/config';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import createHttpError from 'http-errors';
+import type { ReportPaymentSourceType } from './metrics';
+import type { ReportQueryFilters } from './query';
+
+export type ReportRoleCursor = { createdAt: Date; id: string };
+export type ReportCursorPositions = { Buyer: ReportRoleCursor | null; Seller: ReportRoleCursor | null };
+export type ReportCursorSnapshot = {
+	asOf: Date;
+	paymentSourceId: string;
+	paymentSourceType: ReportPaymentSourceType;
+	feeRatePermille: number;
+	filterFingerprint: string;
+};
+export type DecodedReportCursor = {
+	positions: ReportCursorPositions;
+	snapshot: ReportCursorSnapshot | null;
+};
+export type ReportFilterFingerprintInput = Pick<
+	ReportQueryFilters,
+	| 'paymentSourceId'
+	| 'authorizedManagedWalletIds'
+	| 'externalAddresses'
+	| 'roles'
+	| 'states'
+	| 'from'
+	| 'to'
+	| 'dateBasis'
+	| 'revenueMode'
+> & { timeZone: string };
+
+type SerializedRoleCursor = { createdAt: string; id: string };
+type SerializedReportCursor = {
+	version: 2;
+	positions: { Buyer: SerializedRoleCursor | null; Seller: SerializedRoleCursor | null };
+	snapshot: {
+		asOf: string;
+		paymentSourceId: string;
+		paymentSourceType: ReportPaymentSourceType;
+		feeRatePermille: number;
+		filterFingerprint: string;
+	};
+};
+
+const REPORT_CURSOR_MAX_LENGTH = 16_384;
+const EMPTY_REPORT_CURSOR_POSITIONS: ReportCursorPositions = { Buyer: null, Seller: null };
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const SHA256_BASE64URL_LENGTH = 43;
+
+function sortedUnique(values: readonly string[]): string[] {
+	return Array.from(new Set(values)).sort();
+}
+
+export function createReportFilterFingerprint(input: ReportFilterFingerprintInput): string {
+	const canonical = {
+		paymentSourceId: input.paymentSourceId,
+		authorizedManagedWalletIds:
+			input.authorizedManagedWalletIds == null ? null : sortedUnique(input.authorizedManagedWalletIds),
+		externalAddresses: sortedUnique(input.externalAddresses),
+		roles: sortedUnique(input.roles),
+		states: sortedUnique(input.states),
+		from: input.from.toISOString(),
+		to: input.to.toISOString(),
+		dateBasis: input.dateBasis,
+		revenueMode: input.revenueMode,
+		timeZone: input.timeZone,
+	};
+	return createHash('sha256').update(JSON.stringify(canonical)).digest('base64url');
+}
+
+export function createReportCursorSnapshot(
+	filters: ReportQueryFilters,
+	filterFingerprint: string,
+): ReportCursorSnapshot {
+	return {
+		asOf: filters.asOf,
+		paymentSourceId: filters.paymentSourceId,
+		paymentSourceType: filters.paymentSourceType,
+		feeRatePermille: filters.configuredFeeRatePermille,
+		filterFingerprint,
+	};
+}
+
+function cursorSignature(payload: string): Buffer {
+	return createHmac('sha256', CONFIG.ENCRYPTION_KEY).update(payload).digest();
+}
+
+export function encodeReportCursor(cursor: {
+	positions: ReportCursorPositions;
+	snapshot: ReportCursorSnapshot;
+}): string {
+	const serialized: SerializedReportCursor = {
+		version: 2,
+		positions: serializeCursorPositions(cursor.positions),
+		snapshot: {
+			asOf: cursor.snapshot.asOf.toISOString(),
+			paymentSourceId: cursor.snapshot.paymentSourceId,
+			paymentSourceType: cursor.snapshot.paymentSourceType,
+			feeRatePermille: cursor.snapshot.feeRatePermille,
+			filterFingerprint: cursor.snapshot.filterFingerprint,
+		},
+	};
+	const payload = Buffer.from(JSON.stringify(serialized)).toString('base64url');
+	return `${payload}.${cursorSignature(payload).toString('base64url')}`;
+}
+
+function serializeCursorPositions(positions: ReportCursorPositions) {
+	const encode = (cursor: ReportRoleCursor | null): SerializedRoleCursor | null =>
+		cursor == null ? null : { createdAt: cursor.createdAt.toISOString(), id: cursor.id };
+	return { Buyer: encode(positions.Buyer), Seller: encode(positions.Seller) };
+}
+
+function parseRoleCursor(value: unknown): ReportRoleCursor | null {
+	if (value == null) return null;
+	if (typeof value !== 'object' || Array.isArray(value)) throw createHttpError(400, 'Invalid report cursor');
+	const candidate = value as { createdAt?: unknown; id?: unknown };
+	if (typeof candidate.createdAt !== 'string' || typeof candidate.id !== 'string' || candidate.id.length === 0) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	const createdAt = new Date(candidate.createdAt);
+	if (Number.isNaN(createdAt.getTime()) || createdAt.toISOString() !== candidate.createdAt) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	return { createdAt, id: candidate.id };
+}
+
+function parseCursorSnapshot(value: unknown): ReportCursorSnapshot {
+	if (typeof value !== 'object' || value == null || Array.isArray(value)) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	const candidate = value as {
+		asOf?: unknown;
+		paymentSourceId?: unknown;
+		paymentSourceType?: unknown;
+		feeRatePermille?: unknown;
+		filterFingerprint?: unknown;
+	};
+	if (
+		typeof candidate.asOf !== 'string' ||
+		typeof candidate.paymentSourceId !== 'string' ||
+		candidate.paymentSourceId.length === 0 ||
+		(candidate.paymentSourceType !== PaymentSourceType.Web3CardanoV1 &&
+			candidate.paymentSourceType !== PaymentSourceType.Web3CardanoV2) ||
+		typeof candidate.feeRatePermille !== 'number' ||
+		!Number.isSafeInteger(candidate.feeRatePermille) ||
+		candidate.feeRatePermille < 0 ||
+		typeof candidate.filterFingerprint !== 'string' ||
+		candidate.filterFingerprint.length !== SHA256_BASE64URL_LENGTH ||
+		!BASE64URL_PATTERN.test(candidate.filterFingerprint)
+	) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	const asOf = new Date(candidate.asOf);
+	if (Number.isNaN(asOf.getTime()) || asOf.toISOString() !== candidate.asOf) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	return {
+		asOf,
+		paymentSourceId: candidate.paymentSourceId,
+		paymentSourceType: candidate.paymentSourceType,
+		feeRatePermille: candidate.feeRatePermille,
+		filterFingerprint: candidate.filterFingerprint,
+	};
+}
+
+function parseSignedCursor(value: string): unknown {
+	if (value.length > REPORT_CURSOR_MAX_LENGTH) throw createHttpError(400, 'Invalid report cursor');
+	const parts = value.split('.');
+	if (
+		parts.length !== 2 ||
+		parts[0].length === 0 ||
+		parts[1].length === 0 ||
+		!BASE64URL_PATTERN.test(parts[0]) ||
+		!BASE64URL_PATTERN.test(parts[1])
+	) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	const actualSignature = Buffer.from(parts[1], 'base64url');
+	const expectedSignature = cursorSignature(parts[0]);
+	if (actualSignature.length !== expectedSignature.length || !timingSafeEqual(actualSignature, expectedSignature)) {
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+	return JSON.parse(Buffer.from(parts[0], 'base64url').toString('utf8')) as unknown;
+}
+
+export function decodeReportCursor(value: string | undefined): DecodedReportCursor {
+	if (value == null) return { positions: { ...EMPTY_REPORT_CURSOR_POSITIONS }, snapshot: null };
+	try {
+		const parsed = parseSignedCursor(value);
+		if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
+			throw createHttpError(400, 'Invalid report cursor');
+		}
+		const candidate = parsed as { version?: unknown; positions?: unknown; snapshot?: unknown };
+		if (
+			candidate.version !== 2 ||
+			typeof candidate.positions !== 'object' ||
+			candidate.positions == null ||
+			Array.isArray(candidate.positions)
+		) {
+			throw createHttpError(400, 'Invalid report cursor');
+		}
+		const positions = candidate.positions as { Buyer?: unknown; Seller?: unknown };
+		if (!('Buyer' in positions) || !('Seller' in positions)) {
+			throw createHttpError(400, 'Invalid report cursor');
+		}
+		return {
+			positions: { Buyer: parseRoleCursor(positions.Buyer), Seller: parseRoleCursor(positions.Seller) },
+			snapshot: parseCursorSnapshot(candidate.snapshot),
+		};
+	} catch (error) {
+		if (createHttpError.isHttpError(error)) throw error;
+		throw createHttpError(400, 'Invalid report cursor');
+	}
+}

--- a/src/services/transaction-report/query-index-migration.spec.ts
+++ b/src/services/transaction-report/query-index-migration.spec.ts
@@ -2,16 +2,25 @@ import { describe, expect, it } from '@jest/globals';
 import { readFile } from 'node:fs/promises';
 
 describe('transaction report txHash index migration', () => {
-	it('creates the index with one idempotent concurrent statement', async () => {
+	it('creates the index with one concurrent statement and no IF NOT EXISTS', async () => {
 		const migration = await readFile(
 			new URL('../../../prisma/migrations/20260824160000_add_transaction_tx_hash_index/migration.sql', import.meta.url),
 			'utf8',
 		);
+		// Prisma runs a migration inside a transaction unless the whole file is a
+		// single CONCURRENTLY statement, so the guard has to read the executable
+		// part only. The recovery note in the comments names DROP INDEX on purpose.
+		const statements = migration
+			.split('\n')
+			.filter((line) => !line.trimStart().startsWith('--'))
+			.join('\n')
+			.trim();
 
-		expect(migration.trim()).toBe(
-			'CREATE INDEX CONCURRENTLY IF NOT EXISTS "Transaction_txHash_idx" ON "Transaction"("txHash");',
-		);
-		expect(migration).not.toMatch(/DROP INDEX/);
-		expect(migration).not.toMatch(/\b(?:BEGIN|COMMIT)\b/);
+		expect(statements).toBe('CREATE INDEX CONCURRENTLY "Transaction_txHash_idx" ON "Transaction"("txHash");');
+		// IF NOT EXISTS would skip an invalid index left by a failed build and
+		// report success for ever while the planner never used it.
+		expect(statements).not.toMatch(/IF NOT EXISTS/);
+		expect(statements).not.toMatch(/DROP INDEX/);
+		expect(statements).not.toMatch(/\b(?:BEGIN|COMMIT)\b/);
 	});
 });

--- a/src/services/transaction-report/query-index-migration.spec.ts
+++ b/src/services/transaction-report/query-index-migration.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+
+describe('transaction report txHash index migration', () => {
+	it('creates the index with one idempotent concurrent statement', async () => {
+		const migration = await readFile(
+			new URL('../../../prisma/migrations/20260824160000_add_transaction_tx_hash_index/migration.sql', import.meta.url),
+			'utf8',
+		);
+
+		expect(migration.trim()).toBe(
+			'CREATE INDEX CONCURRENTLY IF NOT EXISTS "Transaction_txHash_idx" ON "Transaction"("txHash");',
+		);
+		expect(migration).not.toMatch(/DROP INDEX/);
+		expect(migration).not.toMatch(/\b(?:BEGIN|COMMIT)\b/);
+	});
+});

--- a/src/services/transaction-report/query-metadata.ts
+++ b/src/services/transaction-report/query-metadata.ts
@@ -1,0 +1,63 @@
+import { Prisma } from '@/generated/prisma/client';
+import createHttpError from 'http-errors';
+
+export type ReportMetadataReader = Pick<Prisma.TransactionClient, '$queryRaw'>;
+
+const REPORT_MAX_METADATA_BYTES_PER_REQUEST = 64 * 1024;
+
+type ReportMetadataRow = { id: string; metadata: string | null; isOversized: boolean };
+
+function assertQueryActive(signal?: AbortSignal): void {
+	if (signal?.aborted) throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+}
+
+function isReportMetadataRow(value: unknown): value is ReportMetadataRow {
+	if (value == null || typeof value !== 'object') return false;
+	const row = value as Partial<ReportMetadataRow>;
+	return (
+		typeof row.id === 'string' &&
+		(row.metadata == null || typeof row.metadata === 'string') &&
+		typeof row.isOversized === 'boolean'
+	);
+}
+
+function metadataQuery(requestType: 'PaymentRequest' | 'PurchaseRequest', requestIds: readonly string[]): Prisma.Sql {
+	const boundedColumns = Prisma.sql`
+		"id",
+		CASE
+			WHEN COALESCE(octet_length("metadata"), 0) <= ${REPORT_MAX_METADATA_BYTES_PER_REQUEST}
+			THEN "metadata"
+			ELSE NULL
+		END AS "metadata",
+		COALESCE(octet_length("metadata"), 0) > ${REPORT_MAX_METADATA_BYTES_PER_REQUEST} AS "isOversized"
+	`;
+	return requestType === 'PaymentRequest'
+		? Prisma.sql`SELECT ${boundedColumns} FROM "PaymentRequest" WHERE "id" IN (${Prisma.join(requestIds)})`
+		: Prisma.sql`SELECT ${boundedColumns} FROM "PurchaseRequest" WHERE "id" IN (${Prisma.join(requestIds)})`;
+}
+
+export async function loadReportMetadata(
+	requestType: 'PaymentRequest' | 'PurchaseRequest',
+	requestIds: readonly string[],
+	database: ReportMetadataReader,
+	signal?: AbortSignal,
+): Promise<Map<string, string | null>> {
+	if (requestIds.length === 0) return new Map();
+	assertQueryActive(signal);
+	const rows = await database.$queryRaw<ReportMetadataRow[]>(metadataQuery(requestType, requestIds));
+	assertQueryActive(signal);
+	if (!Array.isArray(rows) || rows.some((row) => !isReportMetadataRow(row))) {
+		throw createHttpError(500, 'Report metadata query returned an invalid result.');
+	}
+	if (rows.some((row) => row.isOversized)) {
+		throw createHttpError(
+			413,
+			`Report request metadata exceeds ${REPORT_MAX_METADATA_BYTES_PER_REQUEST} bytes. Narrow the report filters.`,
+		);
+	}
+	const metadataById = new Map(rows.map((row) => [row.id, row.metadata]));
+	if (requestIds.some((id) => !metadataById.has(id))) {
+		throw createHttpError(500, 'Report metadata snapshot is incomplete.');
+	}
+	return metadataById;
+}

--- a/src/services/transaction-report/query-payouts.spec.ts
+++ b/src/services/transaction-report/query-payouts.spec.ts
@@ -1,0 +1,83 @@
+import { jest } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import { OnChainState, PaymentSourceType } from '@/generated/prisma/client';
+
+const mockResolvePaymentKeyHash = jest.fn() as Mock<(address: string) => string>;
+
+jest.unstable_mockModule('@meshsdk/core-cst', () => ({
+	resolvePaymentKeyHash: mockResolvePaymentKeyHash,
+}));
+
+const { getReportPayoutCompleteness } = await import('./query-payouts');
+
+describe('getReportPayoutCompleteness', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockResolvePaymentKeyHash.mockReturnValue('wallet-vkey');
+	});
+
+	it.each([PaymentSourceType.Web3CardanoV1, PaymentSourceType.Web3CardanoV2])(
+		'marks disputed %s buyer collateral as partial',
+		(paymentSourceType) => {
+			expect(
+				getReportPayoutCompleteness({
+					paymentSourceType,
+					onChainState: OnChainState.DisputedWithdrawn,
+					returnAddress: 'addr-return',
+					expectedWalletVkey: 'wallet-vkey',
+					buyerCollateralReturnLovelace: 2_000_000n,
+				}),
+			).toBe('partial');
+		},
+	);
+
+	it('marks an unknown disputed buyer collateral value as partial', () => {
+		expect(
+			getReportPayoutCompleteness({
+				paymentSourceType: PaymentSourceType.Web3CardanoV1,
+				onChainState: OnChainState.DisputedWithdrawn,
+				returnAddress: null,
+				expectedWalletVkey: null,
+				buyerCollateralReturnLovelace: null,
+			}),
+		).toBe('partial');
+	});
+
+	it('marks an empty V1 disputed payout partial because legacy rows have no payout provenance', () => {
+		expect(
+			getReportPayoutCompleteness({
+				paymentSourceType: PaymentSourceType.Web3CardanoV1,
+				onChainState: OnChainState.DisputedWithdrawn,
+				returnAddress: null,
+				expectedWalletVkey: null,
+				buyerCollateralReturnLovelace: 0n,
+				hasStoredPayoutEvidence: false,
+			}),
+		).toBe('partial');
+	});
+
+	it('keeps a nonempty V1 disputed payout complete', () => {
+		expect(
+			getReportPayoutCompleteness({
+				paymentSourceType: PaymentSourceType.Web3CardanoV1,
+				onChainState: OnChainState.DisputedWithdrawn,
+				returnAddress: null,
+				expectedWalletVkey: null,
+				buyerCollateralReturnLovelace: 0n,
+				hasStoredPayoutEvidence: true,
+			}),
+		).toBe('complete');
+	});
+
+	it('requires the V2 return address to match the expected wallet key', () => {
+		const input = {
+			paymentSourceType: PaymentSourceType.Web3CardanoV2,
+			onChainState: OnChainState.DisputedWithdrawn,
+			returnAddress: 'addr-return',
+			expectedWalletVkey: 'wallet-vkey',
+		};
+		expect(getReportPayoutCompleteness(input)).toBe('complete');
+		mockResolvePaymentKeyHash.mockReturnValue('different-vkey');
+		expect(getReportPayoutCompleteness(input)).toBe('partial');
+	});
+});

--- a/src/services/transaction-report/query-payouts.ts
+++ b/src/services/transaction-report/query-payouts.ts
@@ -1,0 +1,39 @@
+import { OnChainState, PaymentSourceType } from '@/generated/prisma/client';
+import { resolvePaymentKeyHash } from '@meshsdk/core-cst';
+import type { PayoutCompleteness, ReportPaymentSourceType } from './metrics';
+
+export function getReportPayoutCompleteness(input: {
+	paymentSourceType: ReportPaymentSourceType;
+	onChainState: OnChainState | null;
+	returnAddress: string | null;
+	expectedWalletVkey: string | null;
+	buyerCollateralReturnLovelace?: bigint | null;
+	hasStoredPayoutEvidence?: boolean;
+}): PayoutCompleteness {
+	if (
+		input.onChainState === OnChainState.DisputedWithdrawn &&
+		input.buyerCollateralReturnLovelace !== undefined &&
+		input.buyerCollateralReturnLovelace !== 0n
+	) {
+		return 'partial';
+	}
+	if (
+		input.paymentSourceType === PaymentSourceType.Web3CardanoV1 &&
+		input.onChainState === OnChainState.DisputedWithdrawn &&
+		input.hasStoredPayoutEvidence !== true
+	) {
+		return 'partial';
+	}
+	if (
+		input.paymentSourceType !== PaymentSourceType.Web3CardanoV2 ||
+		input.onChainState !== OnChainState.DisputedWithdrawn
+	) {
+		return 'complete';
+	}
+	if (input.returnAddress == null || input.expectedWalletVkey == null) return 'partial';
+	try {
+		return resolvePaymentKeyHash(input.returnAddress) === input.expectedWalletVkey ? 'complete' : 'partial';
+	} catch {
+		return 'partial';
+	}
+}

--- a/src/services/transaction-report/query-transactions.ts
+++ b/src/services/transaction-report/query-transactions.ts
@@ -1,0 +1,331 @@
+import { Prisma, TransactionStatus } from '@/generated/prisma/client';
+import createHttpError from 'http-errors';
+import type { ReportRequestRecord } from './records';
+import { mergeReportTransactions, type ReportTransactionEvent } from './timestamps';
+
+export type ReportTransactionReader = Pick<Prisma.TransactionClient, 'transaction'>;
+
+const REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION = 100;
+const REPORT_MAX_TRANSACTION_HASHES_PER_ENRICHMENT = 5_000;
+const REPORT_MAX_ENRICHED_TRANSACTIONS = 5_000;
+const REPORT_TRANSACTION_HYDRATION_BATCH_SIZE = 50;
+const REPORT_MAX_RELATED_REQUEST_ROWS_PER_ENRICHMENT = 100_000;
+
+const relatedRequestSelect = { id: true, blockchainIdentifier: true } as const;
+const reportTransactionScalarSelect = {
+	id: true,
+	txHash: true,
+	status: true,
+	newOnChainState: true,
+	blockTime: true,
+	fees: true,
+} as const;
+
+export const attachedReportTransactionSelect = reportTransactionScalarSelect satisfies Prisma.TransactionSelect;
+
+export const reportTransactionSelect = {
+	...reportTransactionScalarSelect,
+	PaymentRequestCurrent: { take: REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION + 1, select: relatedRequestSelect },
+	PurchaseRequestCurrent: { take: REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION + 1, select: relatedRequestSelect },
+	PaymentRequestHistory: { take: REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION + 1, select: relatedRequestSelect },
+	PurchaseRequestHistory: { take: REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION + 1, select: relatedRequestSelect },
+} satisfies Prisma.TransactionSelect;
+
+type SelectedReportTransaction = Prisma.TransactionGetPayload<{ select: typeof reportTransactionSelect }>;
+type SelectedAttachedReportTransaction = Prisma.TransactionGetPayload<{
+	select: typeof attachedReportTransactionSelect;
+}>;
+type TransactionEvidenceAccumulator = {
+	id: string;
+	txHashes: Set<string>;
+	statuses: Set<string>;
+	states: Set<NonNullable<ReportTransactionEvent['newOnChainState']>>;
+	blockTimes: Set<number>;
+	fees: Set<bigint>;
+	relatedRequestKeys: Set<string>;
+	relatedPaymentKeys: Set<string>;
+};
+
+function sortedUnique(values: readonly string[]): string[] {
+	return Array.from(new Set(values)).sort();
+}
+
+function assertReportQueryActive(signal?: AbortSignal): void {
+	if (signal?.aborted) throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+}
+
+export function mapAttachedReportTransaction(
+	transaction: SelectedAttachedReportTransaction | null,
+): ReportTransactionEvent | null {
+	return transaction == null
+		? null
+		: {
+				...transaction,
+				relatedRequestKeys: null,
+				relatedPaymentKeys: null,
+				relatedPaymentKeysComplete: false,
+			};
+}
+
+function relatedRequestKeys(transaction: SelectedReportTransaction): string[] {
+	return sortedUnique([
+		...transaction.PaymentRequestCurrent.map((request) => `Seller:${request.id}`),
+		...transaction.PaymentRequestHistory.map((request) => `Seller:${request.id}`),
+		...transaction.PurchaseRequestCurrent.map((request) => `Buyer:${request.id}`),
+		...transaction.PurchaseRequestHistory.map((request) => `Buyer:${request.id}`),
+	]);
+}
+
+function relatedPaymentKeys(transaction: SelectedReportTransaction): string[] {
+	return sortedUnique([
+		...transaction.PaymentRequestCurrent.map((request) => request.blockchainIdentifier),
+		...transaction.PaymentRequestHistory.map((request) => request.blockchainIdentifier),
+		...transaction.PurchaseRequestCurrent.map((request) => request.blockchainIdentifier),
+		...transaction.PurchaseRequestHistory.map((request) => request.blockchainIdentifier),
+	]);
+}
+
+export function mapReportTransaction(transaction: SelectedReportTransaction | null): ReportTransactionEvent | null {
+	if (
+		transaction != null &&
+		[
+			transaction.PaymentRequestCurrent,
+			transaction.PaymentRequestHistory,
+			transaction.PurchaseRequestCurrent,
+			transaction.PurchaseRequestHistory,
+		].some((requests) => requests.length > REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION)
+	) {
+		throw createHttpError(
+			413,
+			`Report transaction exceeds ${REPORT_MAX_RELATED_REQUESTS_PER_TRANSACTION} related requests. Narrow the report filters.`,
+		);
+	}
+	return transaction == null
+		? null
+		: {
+				id: transaction.id,
+				txHash: transaction.txHash,
+				status: transaction.status,
+				newOnChainState: transaction.newOnChainState,
+				blockTime: transaction.blockTime,
+				fees: transaction.fees,
+				relatedRequestKeys: relatedRequestKeys(transaction),
+				relatedPaymentKeys: relatedPaymentKeys(transaction),
+			};
+}
+
+export function reportFeeAllocationScope(
+	transactions: readonly ReportTransactionEvent[],
+): ReportRequestRecord['feeAllocationScope'] {
+	const merged = mergeReportTransactions(transactions);
+	if (merged.length === 0) return 'shared_or_unknown';
+	return merged.some(
+		(transaction) =>
+			transaction.relatedPaymentKeysComplete === false || new Set(transaction.relatedPaymentKeys ?? []).size !== 1,
+	)
+		? 'shared_or_unknown'
+		: 'single_request';
+}
+
+export function reportFeeComponentScope(
+	transactions: readonly ReportTransactionEvent[],
+	currentPaymentKey: string,
+): ReportRequestRecord['feeComponentScope'] {
+	let hasConfirmedTransaction = false;
+	for (const transaction of mergeReportTransactions(transactions)) {
+		if (transaction.status !== TransactionStatus.Confirmed) continue;
+		hasConfirmedTransaction = true;
+		if (transaction.fees === 0n) continue;
+		if (transaction.relatedPaymentKeysComplete === false) return 'partial';
+		const paymentKeys = sortedUnique(transaction.relatedPaymentKeys ?? []);
+		if (paymentKeys.length !== 1 || paymentKeys[0] !== currentPaymentKey) return 'partial';
+	}
+	return hasConfirmedTransaction ? 'complete' : 'partial';
+}
+
+function addPresent<T>(values: Set<T>, value: T | null): void {
+	if (value != null) values.add(value);
+}
+
+function accumulateTransactionEvidence(
+	accumulators: Map<string, TransactionEvidenceAccumulator>,
+	event: ReportTransactionEvent,
+): void {
+	if (event.txHash == null) return;
+	let accumulator = accumulators.get(event.txHash);
+	if (accumulator == null) {
+		accumulator = {
+			id: event.id,
+			txHashes: new Set(),
+			statuses: new Set(),
+			states: new Set(),
+			blockTimes: new Set(),
+			fees: new Set(),
+			relatedRequestKeys: new Set(),
+			relatedPaymentKeys: new Set(),
+		};
+		accumulators.set(event.txHash, accumulator);
+	}
+	if (event.id.localeCompare(accumulator.id) < 0) accumulator.id = event.id;
+	addPresent(accumulator.txHashes, event.txHash);
+	addPresent(accumulator.statuses, event.status);
+	addPresent(accumulator.states, event.newOnChainState);
+	addPresent(accumulator.blockTimes, event.blockTime);
+	addPresent(accumulator.fees, event.fees);
+	for (const key of event.relatedRequestKeys ?? []) accumulator.relatedRequestKeys.add(key);
+	for (const key of event.relatedPaymentKeys ?? []) accumulator.relatedPaymentKeys.add(key);
+}
+
+function oneOrNull<T>(values: Set<T>): T | null {
+	const first = values.values().next();
+	return values.size === 1 && !first.done ? first.value : null;
+}
+
+function mergedStatus(statuses: Set<string>): string | null {
+	if (statuses.size <= 1) return statuses.values().next().value ?? null;
+	const terminalStatuses = Array.from(statuses).filter((status) => status !== 'Pending');
+	return terminalStatuses.length === 1 ? terminalStatuses[0] : null;
+}
+
+function materializeTransactionEvidence(
+	txHash: string,
+	accumulator: TransactionEvidenceAccumulator,
+): ReportTransactionEvent {
+	const fees = oneOrNull(accumulator.fees);
+	return {
+		id: accumulator.id,
+		txHash: oneOrNull(accumulator.txHashes) ?? txHash,
+		status: mergedStatus(accumulator.statuses),
+		newOnChainState: oneOrNull(accumulator.states),
+		blockTime: oneOrNull(accumulator.blockTimes),
+		fees,
+		relatedRequestKeys: Array.from(accumulator.relatedRequestKeys).sort((left, right) => left.localeCompare(right)),
+		relatedPaymentKeys: Array.from(accumulator.relatedPaymentKeys).sort((left, right) => left.localeCompare(right)),
+		relatedPaymentKeysComplete: fees === 0n,
+	};
+}
+
+export async function enrichReportTransactionEvidence(
+	records: readonly ReportRequestRecord[],
+	database: ReportTransactionReader,
+	signal?: AbortSignal,
+): Promise<ReportRequestRecord[]> {
+	assertReportQueryActive(signal);
+	const txHashSet = new Set<string>();
+	for (const record of records) {
+		assertReportQueryActive(signal);
+		for (const transaction of record.transactions) {
+			assertReportQueryActive(signal);
+			if (transaction.txHash != null) txHashSet.add(transaction.txHash);
+			if (txHashSet.size > REPORT_MAX_TRANSACTION_HASHES_PER_ENRICHMENT) {
+				throw createHttpError(
+					413,
+					`Report evidence exceeds ${REPORT_MAX_TRANSACTION_HASHES_PER_ENRICHMENT} transaction hashes. Narrow the report filters.`,
+				);
+			}
+		}
+	}
+	const txHashes = Array.from(txHashSet).sort();
+	if (txHashes.length === 0) return [...records];
+
+	const scalarTransactions = await database.transaction.findMany({
+		where: { txHash: { in: txHashes } },
+		take: REPORT_MAX_ENRICHED_TRANSACTIONS + 1,
+		select: attachedReportTransactionSelect,
+	});
+	assertReportQueryActive(signal);
+	if (scalarTransactions.length > REPORT_MAX_ENRICHED_TRANSACTIONS) {
+		throw createHttpError(
+			413,
+			`Report evidence exceeds ${REPORT_MAX_ENRICHED_TRANSACTIONS} transactions. Narrow the report filters.`,
+		);
+	}
+	const evidence = new Map<string, TransactionEvidenceAccumulator>();
+	const requestStateAmbiguousHashes = new Set<string>();
+	const hydratedTransactionIds = new Set<string>();
+	let relatedRequestRows = 0;
+	for (let offset = 0; offset < scalarTransactions.length; offset += REPORT_TRANSACTION_HYDRATION_BATCH_SIZE) {
+		assertReportQueryActive(signal);
+		const transactionIds = scalarTransactions
+			.slice(offset, offset + REPORT_TRANSACTION_HYDRATION_BATCH_SIZE)
+			.map((transaction) => transaction.id);
+		const transactionIdSet = new Set(transactionIds);
+		const transactions = await database.transaction.findMany({
+			where: { id: { in: transactionIds } },
+			take: REPORT_TRANSACTION_HYDRATION_BATCH_SIZE + 1,
+			select: reportTransactionSelect,
+		});
+		assertReportQueryActive(signal);
+		if (transactions.length > REPORT_TRANSACTION_HYDRATION_BATCH_SIZE) {
+			throw createHttpError(
+				413,
+				`Report evidence hydration exceeds ${REPORT_TRANSACTION_HYDRATION_BATCH_SIZE} transactions per batch. Narrow the report filters.`,
+			);
+		}
+		for (const transaction of transactions) {
+			assertReportQueryActive(signal);
+			if (!transactionIdSet.has(transaction.id)) {
+				throw createHttpError(500, 'Report transaction evidence query returned an invalid result.');
+			}
+			hydratedTransactionIds.add(transaction.id);
+			relatedRequestRows +=
+				transaction.PaymentRequestCurrent.length +
+				transaction.PaymentRequestHistory.length +
+				transaction.PurchaseRequestCurrent.length +
+				transaction.PurchaseRequestHistory.length;
+			if (relatedRequestRows > REPORT_MAX_RELATED_REQUEST_ROWS_PER_ENRICHMENT) {
+				throw createHttpError(
+					413,
+					`Report evidence exceeds ${REPORT_MAX_RELATED_REQUEST_ROWS_PER_ENRICHMENT} related request rows. Narrow the report filters.`,
+				);
+			}
+			const event = mapReportTransaction(transaction);
+			if (event != null) {
+				if (event.txHash != null && new Set(event.relatedPaymentKeys ?? []).size > 1) {
+					requestStateAmbiguousHashes.add(event.txHash);
+				}
+				accumulateTransactionEvidence(evidence, event);
+			}
+		}
+	}
+	if (scalarTransactions.some((transaction) => !hydratedTransactionIds.has(transaction.id))) {
+		throw createHttpError(500, 'Report transaction evidence snapshot is incomplete.');
+	}
+	const mergedEventByHash = new Map<string, ReportTransactionEvent>();
+	for (const [txHash, accumulator] of evidence) {
+		assertReportQueryActive(signal);
+		mergedEventByHash.set(txHash, materializeTransactionEvidence(txHash, accumulator));
+	}
+
+	return records.map((record) => {
+		assertReportQueryActive(signal);
+		const evidence: ReportTransactionEvent[] = [];
+		for (const transaction of record.transactions) {
+			assertReportQueryActive(signal);
+			if (transaction.txHash == null) {
+				evidence.push({ ...transaction, relatedPaymentKeysComplete: false });
+				continue;
+			}
+			const sameHashEvent = mergedEventByHash.get(transaction.txHash);
+			evidence.push(
+				sameHashEvent == null
+					? { ...transaction, relatedPaymentKeysComplete: false }
+					: {
+							...transaction,
+							newOnChainState: requestStateAmbiguousHashes.has(transaction.txHash) ? null : transaction.newOnChainState,
+							fees: sameHashEvent.fees,
+							relatedRequestKeys: sameHashEvent.relatedRequestKeys,
+							relatedPaymentKeys: sameHashEvent.relatedPaymentKeys,
+							relatedPaymentKeysComplete: sameHashEvent.relatedPaymentKeysComplete,
+						},
+			);
+		}
+		const merged = mergeReportTransactions(evidence);
+		return {
+			...record,
+			transactions: merged,
+			feeAllocationScope: reportFeeAllocationScope(merged),
+			feeComponentScope: reportFeeComponentScope(merged, record.blockchainIdentifier),
+		};
+	});
+}

--- a/src/services/transaction-report/query.spec.ts
+++ b/src/services/transaction-report/query.spec.ts
@@ -1,0 +1,992 @@
+import { jest } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import { OnChainState, PaymentSourceType } from '@/generated/prisma/client';
+import type { ReportQueryFilters } from './query';
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+const mockFindPayments = jest.fn() as AnyMock;
+const mockFindPurchases = jest.fn() as AnyMock;
+const mockFindTransactions = jest.fn() as AnyMock;
+const mockQueryRaw = jest.fn() as AnyMock;
+const mockResolvePaymentKeyHash = jest.fn() as AnyMock;
+
+jest.unstable_mockModule('@masumi/payment-core/db', () => ({
+	prisma: {
+		paymentRequest: { findMany: mockFindPayments },
+		purchaseRequest: { findMany: mockFindPurchases },
+		transaction: { findMany: mockFindTransactions },
+		$queryRaw: mockQueryRaw,
+	},
+}));
+
+jest.unstable_mockModule('@masumi/payment-core/config', () => ({
+	CONFIG: { ENCRYPTION_KEY: 'report-cursor-test-key-with-32-characters' },
+	CONSTANTS: { MIN_COLLATERAL_LOVELACE: 1_435_230n },
+}));
+
+jest.unstable_mockModule('@meshsdk/core-cst', () => ({
+	resolvePaymentKeyHash: mockResolvePaymentKeyHash,
+}));
+
+const {
+	createReportCursorSnapshot,
+	createReportFilterFingerprint,
+	decodeReportCursor,
+	encodeReportCursor,
+	queryReportFeeComponentClosure,
+	queryReportPage,
+} = await import('./query');
+const { buildReportRow } = await import('./records');
+
+function filters(overrides: Partial<ReportQueryFilters> = {}): ReportQueryFilters {
+	return {
+		paymentSourceId: 'source-1',
+		paymentSourceType: PaymentSourceType.Web3CardanoV2,
+		configuredFeeRatePermille: 0,
+		authorizedManagedWalletIds: ['wallet-1'],
+		externalAddresses: [],
+		roles: ['Buyer', 'Seller'],
+		states: [],
+		from: new Date('2026-01-01T00:00:00.000Z'),
+		to: new Date('2026-02-01T00:00:00.000Z'),
+		dateBasis: 'CreatedAt',
+		revenueMode: 'Billable',
+		asOf: new Date('2026-02-02T00:00:00.000Z'),
+		...overrides,
+	};
+}
+
+type TransactionRelations = {
+	paymentCurrentIds?: string[];
+	paymentHistoryIds?: string[];
+	purchaseCurrentIds?: string[];
+	purchaseHistoryIds?: string[];
+	blockchainIdentifiers?: Record<string, string>;
+};
+
+function transaction(
+	newOnChainState: OnChainState = OnChainState.FundsLocked,
+	relations: TransactionRelations = { paymentCurrentIds: ['payment-1'] },
+) {
+	const relatedRequest = (id: string) => ({
+		id,
+		blockchainIdentifier: relations.blockchainIdentifiers?.[id] ?? `chain-${id}`,
+	});
+	return {
+		id: `tx-${newOnChainState}`,
+		txHash: `hash-${newOnChainState}`,
+		status: 'Confirmed',
+		newOnChainState,
+		blockTime: 1_767_225_700,
+		fees: 200_000n,
+		PaymentRequestCurrent: (relations.paymentCurrentIds ?? []).map(relatedRequest),
+		PaymentRequestHistory: (relations.paymentHistoryIds ?? []).map(relatedRequest),
+		PurchaseRequestCurrent: (relations.purchaseCurrentIds ?? []).map(relatedRequest),
+		PurchaseRequestHistory: (relations.purchaseHistoryIds ?? []).map(relatedRequest),
+	};
+}
+
+function mockIndexedTransactions(transactions: ReturnType<typeof transaction>[]): void {
+	mockFindTransactions.mockImplementation(({ where }: { where: Record<string, { in: string[] }> }) => {
+		const txHashes = where.txHash?.in;
+		if (txHashes != null)
+			return transactions.filter((value) => value.txHash != null && txHashes.includes(value.txHash));
+		const transactionIds = where.id?.in;
+		return transactionIds == null ? [] : transactions.filter((value) => transactionIds.includes(value.id));
+	});
+}
+
+function paymentRecord(id: string, createdAt: string) {
+	return {
+		id,
+		createdAt: new Date(createdAt),
+		blockchainIdentifier: `chain-${id}`,
+		agentIdentifier: null,
+		agentName: null,
+		onChainState: OnChainState.FundsLocked,
+		metadata: null,
+		unlockTime: 1_800_000_000_000n,
+		collateralReturnLovelace: 0n,
+		buyerReturnAddress: null,
+		sellerReturnAddress: null,
+		totalBuyerCardanoFees: 100_000n,
+		totalSellerCardanoFees: 0n,
+		BuyerWallet: { walletAddress: 'addr-buyer', walletVkey: 'buyer-vkey' },
+		SmartContractWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-seller',
+			walletVkey: 'seller-vkey',
+			collectionAddress: 'addr-collection',
+			deletedAt: null,
+		},
+		RequestedFunds: [{ unit: 'lovelace', amount: 10_000_000n }],
+		WithdrawnForBuyer: [],
+		WithdrawnForSeller: [],
+		CurrentTransaction: transaction(OnChainState.FundsLocked, { paymentCurrentIds: [id] }),
+		TransactionHistory: [],
+	};
+}
+
+function purchaseRecord(id: string, createdAt: string) {
+	return {
+		id,
+		createdAt: new Date(createdAt),
+		blockchainIdentifier: `chain-${id}`,
+		agentIdentifier: null,
+		agentName: null,
+		onChainState: OnChainState.FundsLocked,
+		metadata: null,
+		unlockTime: 1_800_000_000_000n,
+		collateralReturnLovelace: 0n,
+		buyerReturnAddress: null,
+		sellerReturnAddress: null,
+		totalBuyerCardanoFees: 100_000n,
+		totalSellerCardanoFees: 0n,
+		SellerWallet: { walletAddress: 'addr-seller', walletVkey: 'seller-vkey' },
+		SmartContractWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-buyer',
+			walletVkey: 'buyer-vkey',
+			collectionAddress: 'addr-collection',
+			deletedAt: null,
+		},
+		PaidFunds: [{ unit: 'lovelace', amount: 10_000_000n }],
+		WithdrawnForBuyer: [],
+		WithdrawnForSeller: [],
+		CurrentTransaction: transaction(OnChainState.FundsLocked, { purchaseCurrentIds: [id] }),
+		TransactionHistory: [],
+	};
+}
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	mockFindPayments.mockResolvedValue([]);
+	mockFindPurchases.mockResolvedValue([]);
+	mockFindTransactions.mockResolvedValue([]);
+	mockQueryRaw.mockImplementation(async (query: { values?: unknown[] }) =>
+		(query.values ?? [])
+			.filter((value): value is string => typeof value === 'string')
+			.map((id) => ({ id, metadata: null, isOversized: false })),
+	);
+	mockResolvePaymentKeyHash.mockReturnValue('same-vkey');
+});
+
+describe('report cursor', () => {
+	it('round trips signed role positions and snapshot semantics', () => {
+		const positions = {
+			Buyer: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'buyer-1' },
+			Seller: { createdAt: new Date('2026-01-03T00:00:00.000Z'), id: 'seller-1' },
+		};
+		const input = filters();
+		const filterFingerprint = createReportFilterFingerprint({ ...input, timeZone: 'Europe/Prague' });
+		const snapshot = createReportCursorSnapshot(input, filterFingerprint);
+		expect(decodeReportCursor(encodeReportCursor({ positions, snapshot }))).toEqual({ positions, snapshot });
+	});
+
+	it('returns empty internal positions and no snapshot when a cursor is absent', () => {
+		expect(decodeReportCursor(undefined)).toEqual({
+			positions: { Buyer: null, Seller: null },
+			snapshot: null,
+		});
+	});
+
+	it('makes filter fingerprints independent of set-like filter order', () => {
+		const input = filters({
+			authorizedManagedWalletIds: ['wallet-2', 'wallet-1'],
+			externalAddresses: ['addr-2', 'addr-1'],
+			roles: ['Seller', 'Buyer'],
+			states: [OnChainState.Withdrawn, OnChainState.FundsLocked],
+		});
+		const first = createReportFilterFingerprint({ ...input, timeZone: 'Europe/Prague' });
+		const second = createReportFilterFingerprint({
+			...input,
+			authorizedManagedWalletIds: ['wallet-1', 'wallet-2', 'wallet-1'],
+			externalAddresses: ['addr-1', 'addr-2'],
+			roles: ['Buyer', 'Seller'],
+			states: [OnChainState.FundsLocked, OnChainState.Withdrawn],
+			timeZone: 'Europe/Prague',
+		});
+		expect(first).toBe(second);
+	});
+
+	it('changes the fingerprint for every bound report filter', () => {
+		const input = filters();
+		const base = createReportFilterFingerprint({ ...input, timeZone: 'Etc/UTC' });
+		const variations = [
+			{ ...input, paymentSourceId: 'source-2', timeZone: 'Etc/UTC' },
+			{ ...input, authorizedManagedWalletIds: ['wallet-2'], timeZone: 'Etc/UTC' },
+			{ ...input, externalAddresses: ['addr-external'], timeZone: 'Etc/UTC' },
+			{ ...input, roles: ['Seller'] as ReportQueryFilters['roles'], timeZone: 'Etc/UTC' },
+			{ ...input, states: [OnChainState.Withdrawn], timeZone: 'Etc/UTC' },
+			{ ...input, from: new Date('2026-01-02T00:00:00.000Z'), timeZone: 'Etc/UTC' },
+			{ ...input, to: new Date('2026-01-31T00:00:00.000Z'), timeZone: 'Etc/UTC' },
+			{ ...input, dateBasis: 'FundsLockedAt' as const, timeZone: 'Etc/UTC' },
+			{ ...input, revenueMode: 'CashReceived' as const, timeZone: 'Etc/UTC' },
+			{ ...input, timeZone: 'Europe/Prague' },
+		];
+
+		for (const variation of variations) {
+			expect(createReportFilterFingerprint(variation)).not.toBe(base);
+		}
+	});
+
+	it('rejects malformed cursors', () => {
+		expect(() => decodeReportCursor('not-json')).toThrow('Invalid report cursor');
+	});
+
+	it('rejects a cursor whose signed payload was changed', () => {
+		const input = filters();
+		const positions = { Buyer: null, Seller: null };
+		const snapshot = createReportCursorSnapshot(
+			input,
+			createReportFilterFingerprint({ ...input, timeZone: 'Etc/UTC' }),
+		);
+		const encoded = encodeReportCursor({ positions, snapshot });
+		const [payload, signature] = encoded.split('.');
+		const replacement = payload[0] === 'A' ? 'B' : 'A';
+		const tampered = `${replacement}${payload.slice(1)}.${signature}`;
+		expect(() => decodeReportCursor(tampered)).toThrow('Invalid report cursor');
+	});
+});
+
+describe('queryReportPage', () => {
+	it('keeps Payment Source ID, wallet scope, and external address as cumulative filters', async () => {
+		await queryReportPage(
+			filters({ externalAddresses: ['addr-external'], states: [OnChainState.Withdrawn] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+
+		expect(mockFindPayments).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					paymentSourceId: 'source-1',
+					smartContractWalletId: { in: ['wallet-1'] },
+					onChainState: { in: [OnChainState.Withdrawn] },
+					AND: expect.arrayContaining([
+						expect.objectContaining({ createdAt: expect.any(Object) }),
+						expect.objectContaining({ OR: expect.any(Array) }),
+					]),
+				}),
+			}),
+		);
+		const paymentWhere = mockFindPayments.mock.calls[0][0].where;
+		expect(paymentWhere.PaymentSource).toBeUndefined();
+		expect(paymentWhere.deletedAt).toBeUndefined();
+		expect(paymentWhere.AND[1]).toEqual(
+			expect.objectContaining({
+				OR: expect.arrayContaining([
+					{ SmartContractWallet: { is: { collectionAddress: { in: ['addr-external'] } } } },
+					{ SmartContractWallet: { is: { walletAddress: { in: ['addr-external'] } } } },
+				]),
+			}),
+		);
+		expect(paymentWhere.AND[2]).toEqual({
+			createdAt: { lte: new Date('2026-02-02T00:00:00.000Z') },
+			nextActionOrOnChainStateOrResultLastChangedAt: { lte: new Date('2026-02-02T00:00:00.000Z') },
+		});
+		const purchaseWhere = mockFindPurchases.mock.calls[0][0].where;
+		expect(purchaseWhere.AND[1]).toEqual(
+			expect.objectContaining({
+				OR: expect.arrayContaining([
+					{ SmartContractWallet: { is: { collectionAddress: { in: ['addr-external'] } } } },
+					{ SmartContractWallet: { is: { walletAddress: { in: ['addr-external'] } } } },
+				]),
+			}),
+		);
+	});
+
+	it('maps the Pending state filter to null on-chain state', async () => {
+		await queryReportPage(filters({ states: ['Pending'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(mockFindPayments.mock.calls[0][0].where.onChainState).toBeNull();
+		expect(mockFindPurchases.mock.calls[0][0].where.onChainState).toBeNull();
+	});
+
+	it('uses confirmed FundsLocked chain time for that date basis', async () => {
+		await queryReportPage(
+			filters({ dateBasis: 'FundsLockedAt', roles: ['Seller'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		const paymentWhere = mockFindPayments.mock.calls[0][0].where;
+		expect(paymentWhere.AND[0]).toEqual(
+			expect.objectContaining({
+				OR: expect.arrayContaining([
+					expect.objectContaining({
+						OR: expect.arrayContaining([
+							expect.objectContaining({
+								CurrentTransaction: {
+									is: expect.objectContaining({
+										status: 'Confirmed',
+										newOnChainState: OnChainState.FundsLocked,
+									}),
+								},
+							}),
+						]),
+					}),
+					expect.objectContaining({ AND: expect.any(Array) }),
+				]),
+			}),
+		);
+	});
+
+	it('includes confirmed fee-only events in revenue-recognized queries', async () => {
+		await queryReportPage(
+			filters({ dateBasis: 'RevenueRecognizedAt', revenueMode: 'CashReceived' }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		const feeEvent = expect.objectContaining({
+			OR: expect.arrayContaining([
+				expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({
+							CurrentTransaction: {
+								is: expect.objectContaining({ status: 'Confirmed', blockTime: expect.any(Object) }),
+							},
+						}),
+					]),
+				}),
+				expect.objectContaining({ OR: expect.any(Array) }),
+			]),
+		});
+		expect(mockFindPayments.mock.calls[0][0].where.AND[0].OR).toEqual(expect.arrayContaining([feeEvent]));
+		expect(mockFindPurchases.mock.calls[0][0].where.AND[0].OR).toEqual(expect.arrayContaining([feeEvent]));
+	});
+
+	it('includes unlocked Withdrawn rows in Billable revenue-recognized queries', async () => {
+		await queryReportPage(
+			filters({ dateBasis: 'RevenueRecognizedAt', revenueMode: 'Billable', roles: ['Seller'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+
+		expect(mockFindPayments.mock.calls[0][0].where.AND[0].OR).toEqual(
+			expect.arrayContaining([
+				{
+					onChainState: { in: [OnChainState.ResultSubmitted, OnChainState.Withdrawn] },
+					unlockTime: {
+						gte: BigInt(new Date('2026-01-01T00:00:00.000Z').getTime()),
+						lt: BigInt(new Date('2026-02-01T00:00:00.000Z').getTime()),
+						lte: BigInt(new Date('2026-02-02T00:00:00.000Z').getTime()),
+					},
+				},
+			]),
+		);
+	});
+
+	it('merges buyer and seller rows with stable exclusive role cursors', async () => {
+		mockFindPayments.mockResolvedValue([
+			paymentRecord('seller-new', '2026-01-03T00:00:00.000Z'),
+			paymentRecord('seller-old', '2026-01-01T00:00:00.000Z'),
+		]);
+		mockFindPurchases.mockResolvedValue([purchaseRecord('buyer-middle', '2026-01-02T00:00:00.000Z')]);
+
+		const result = await queryReportPage(filters(), { Buyer: null, Seller: null }, 2);
+		expect(result.records.map((record) => record.id)).toEqual(['seller-new', 'buyer-middle']);
+		expect(result.nextCursor).toEqual({
+			Seller: { createdAt: new Date('2026-01-03T00:00:00.000Z'), id: 'seller-new' },
+			Buyer: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'buyer-middle' },
+		});
+	});
+
+	it('marks a disputed V2 payout partial when its return payment key differs', async () => {
+		mockResolvePaymentKeyHash.mockReturnValue('different-vkey');
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-disputed', '2026-01-03T00:00:00.000Z'),
+				onChainState: OnChainState.DisputedWithdrawn,
+				sellerReturnAddress: 'addr-return',
+			},
+		]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+		expect(result.records[0].sellerPayoutCompleteness).toBe('partial');
+	});
+
+	it.each([
+		['Seller', 'sellerPayoutCompleteness'],
+		['Buyer', 'buyerPayoutCompleteness'],
+	] as const)('marks a disputed V2 %s payout partial when its return address is missing', async (role, field) => {
+		if (role === 'Seller') {
+			mockFindPayments.mockResolvedValue([
+				{
+					...paymentRecord('seller-missing-return', '2026-01-03T00:00:00.000Z'),
+					onChainState: OnChainState.DisputedWithdrawn,
+					sellerReturnAddress: null,
+				},
+			]);
+		} else {
+			mockFindPurchases.mockResolvedValue([
+				{
+					...purchaseRecord('buyer-missing-return', '2026-01-03T00:00:00.000Z'),
+					onChainState: OnChainState.DisputedWithdrawn,
+					buyerReturnAddress: null,
+				},
+			]);
+		}
+
+		const result = await queryReportPage(filters({ roles: [role] }), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records[0][field]).toBe('partial');
+	});
+
+	it.each([PaymentSourceType.Web3CardanoV1, PaymentSourceType.Web3CardanoV2])(
+		'marks a disputed %s buyer payout partial when collateral cannot be separated',
+		async (paymentSourceType) => {
+			mockResolvePaymentKeyHash.mockReturnValue('buyer-vkey');
+			mockFindPurchases.mockResolvedValue([
+				{
+					...purchaseRecord('buyer-collateral', '2026-01-03T00:00:00.000Z'),
+					onChainState: OnChainState.DisputedWithdrawn,
+					buyerReturnAddress: 'addr-return',
+					collateralReturnLovelace: 2_000_000n,
+				},
+			]);
+
+			const result = await queryReportPage(
+				filters({ paymentSourceType, roles: ['Buyer'] }),
+				{ Buyer: null, Seller: null },
+				50,
+			);
+
+			expect(result.records[0].buyerPayoutCompleteness).toBe('partial');
+		},
+	);
+
+	it('uses stored payout rows as V1 disputed payout provenance', async () => {
+		mockFindPayments
+			.mockResolvedValueOnce([
+				{
+					...paymentRecord('seller-legacy-empty', '2026-01-03T00:00:00.000Z'),
+					onChainState: OnChainState.DisputedWithdrawn,
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					...paymentRecord('seller-modern-payout', '2026-01-03T00:00:00.000Z'),
+					onChainState: OnChainState.DisputedWithdrawn,
+					WithdrawnForSeller: [{ unit: 'lovelace', amount: 5_000_000n }],
+				},
+			]);
+		const input = filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1, roles: ['Seller'] });
+
+		const empty = await queryReportPage(input, { Buyer: null, Seller: null }, 50);
+		const nonempty = await queryReportPage(input, { Buyer: null, Seller: null }, 50);
+
+		expect(empty.records[0].sellerPayoutCompleteness).toBe('partial');
+		expect(nonempty.records[0].sellerPayoutCompleteness).toBe('complete');
+	});
+
+	it('keeps collection address in the canonical managed wallet output', async () => {
+		mockFindPayments.mockResolvedValue([paymentRecord('seller-1', '2026-01-03T00:00:00.000Z')]);
+
+		const result = await queryReportPage(
+			filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1, roles: ['Seller'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		expect(result.records[0].managedWallet).toEqual(expect.objectContaining({ collectionAddress: 'addr-collection' }));
+	});
+
+	it.each([
+		{
+			name: 'transaction history',
+			override: {
+				TransactionHistory: Array.from({ length: 101 }, (_value, index) => ({
+					...transaction(),
+					id: `history-${index}`,
+					txHash: `history-hash-${index}`,
+				})),
+			},
+		},
+		{
+			name: 'asset relations',
+			override: {
+				RequestedFunds: Array.from({ length: 1_001 }, (_value, index) => ({
+					unit: `policy-${index}`,
+					amount: 1n,
+				})),
+			},
+		},
+	])('rejects an oversized nested $name relation', async ({ override }) => {
+		mockFindPayments.mockResolvedValue([
+			{ ...paymentRecord('bounded-relations', '2026-01-03T00:00:00.000Z'), ...override },
+		]);
+
+		await expect(
+			queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50),
+		).rejects.toMatchObject({ status: 413 });
+	});
+
+	it('rejects oversized inverse request relations in bounded same-hash evidence', async () => {
+		const record = paymentRecord('bounded-related-requests', '2026-01-03T00:00:00.000Z');
+		mockFindPayments.mockResolvedValue([record]);
+		mockFindTransactions.mockResolvedValue([
+			transaction(OnChainState.FundsLocked, {
+				paymentHistoryIds: Array.from({ length: 101 }, (_value, index) => `related-${index}`),
+			}),
+		]);
+
+		await expect(
+			queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50),
+		).rejects.toMatchObject({ status: 413 });
+	});
+
+	it('hydrates bounded metadata without selecting unbounded text in the main query', async () => {
+		const record = paymentRecord('bounded-metadata', '2026-01-03T00:00:00.000Z');
+		mockFindPayments.mockResolvedValue([record]);
+		mockQueryRaw.mockResolvedValue([{ id: record.id, metadata: '{"safe":true}', isOversized: false }]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(mockFindPayments.mock.calls[0][0].select.metadata).toBeUndefined();
+		expect(result.records[0].metadata).toBe('{"safe":true}');
+		const rawQuery = mockQueryRaw.mock.calls[0][0] as { sql: string };
+		expect(rawQuery.sql).toContain('CASE');
+		expect(rawQuery.sql).toContain('octet_length');
+	});
+
+	it('rejects oversized metadata before the database returns its text', async () => {
+		const record = paymentRecord('oversized-metadata', '2026-01-03T00:00:00.000Z');
+		mockFindPayments.mockResolvedValue([record]);
+		mockQueryRaw.mockResolvedValue([{ id: record.id, metadata: null, isOversized: true }]);
+
+		await expect(
+			queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50),
+		).rejects.toMatchObject({ status: 413 });
+		expect(mockFindPayments.mock.calls[0][0].select.metadata).toBeUndefined();
+	});
+
+	it('rejects an oversized same-hash evidence query', async () => {
+		mockFindPayments.mockResolvedValue([paymentRecord('bounded-evidence', '2026-01-03T00:00:00.000Z')]);
+		mockFindTransactions.mockResolvedValue(
+			Array.from({ length: 5_001 }, (_value, index) => ({
+				...transaction(),
+				id: `evidence-${index}`,
+			})),
+		);
+
+		await expect(
+			queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50),
+		).rejects.toMatchObject({ status: 413 });
+	});
+
+	it('marks a real multi-request transaction as shared and exposes stable coverage keys', async () => {
+		const sharedTransaction = transaction(OnChainState.FundsLocked, {
+			purchaseCurrentIds: ['buyer-batch', 'buyer-sibling'],
+		});
+		mockFindPurchases.mockResolvedValue([
+			{
+				...purchaseRecord('buyer-batch', '2026-01-03T00:00:00.000Z'),
+				CurrentTransaction: sharedTransaction,
+			},
+		]);
+		mockFindTransactions.mockResolvedValue([sharedTransaction]);
+
+		const result = await queryReportPage(
+			filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1, roles: ['Buyer'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		expect(result.records[0].feeAllocationScope).toBe('shared_or_unknown');
+		expect(result.records[0].transactions[0].relatedRequestKeys).toEqual(['Buyer:buyer-batch', 'Buyer:buyer-sibling']);
+		expect(result.records[0].transactions[0].relatedPaymentKeys).toEqual(['chain-buyer-batch', 'chain-buyer-sibling']);
+	});
+
+	it('merges repeated attached transactions but keeps missing indexed evidence partial', async () => {
+		const currentTransaction = transaction(OnChainState.FundsLocked, {
+			paymentCurrentIds: ['seller-repeated'],
+		});
+		const historicalTransaction = transaction(OnChainState.FundsLocked, {
+			paymentHistoryIds: ['seller-repeated'],
+		});
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-repeated', '2026-01-03T00:00:00.000Z'),
+				CurrentTransaction: currentTransaction,
+				TransactionHistory: [historicalTransaction],
+			},
+		]);
+
+		const result = await queryReportPage(
+			filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1, roles: ['Seller'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		expect(result.records[0].feeAllocationScope).toBe('shared_or_unknown');
+		expect(result.records[0].feeComponentScope).toBe('partial');
+		expect(result.records[0].isFeeReconciliationOwner).toBe(true);
+		expect(result.records[0].transactions).toHaveLength(1);
+		expect(result.records[0].transactions[0].relatedRequestKeys).toBeNull();
+		expect(result.records[0].transactions[0].relatedPaymentKeys).toBeNull();
+	});
+
+	it('keeps paired mirror evidence partial without indexed batch membership', async () => {
+		const pairedTransaction = transaction(OnChainState.FundsLocked, {
+			paymentCurrentIds: ['seller-paired'],
+			purchaseCurrentIds: ['buyer-paired'],
+			blockchainIdentifiers: {
+				'seller-paired': 'chain-paired',
+				'buyer-paired': 'chain-paired',
+			},
+		});
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-paired', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'chain-paired',
+				CurrentTransaction: pairedTransaction,
+			},
+		]);
+
+		const result = await queryReportPage(
+			filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1, roles: ['Seller'] }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		expect(result.records[0].feeAllocationScope).toBe('shared_or_unknown');
+		expect(result.records[0].feeComponentScope).toBe('partial');
+		expect(result.records[0].isFeeReconciliationOwner).toBe(true);
+		expect(result.records[0].transactions[0].relatedRequestKeys).toBeNull();
+		expect(result.records[0].transactions[0].relatedPaymentKeys).toBeNull();
+	});
+
+	it('assigns paired payment ownership to Buyer when both roles are requested', async () => {
+		const pairedTransaction = transaction(OnChainState.FundsLocked, {
+			paymentCurrentIds: ['seller-paired'],
+			purchaseCurrentIds: ['buyer-paired'],
+			blockchainIdentifiers: {
+				'seller-paired': 'chain-paired',
+				'buyer-paired': 'chain-paired',
+			},
+		});
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-paired', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'chain-paired',
+				CurrentTransaction: pairedTransaction,
+			},
+		]);
+		mockFindPurchases.mockResolvedValue([
+			{
+				...purchaseRecord('buyer-paired', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'chain-paired',
+				CurrentTransaction: pairedTransaction,
+			},
+		]);
+
+		const result = await queryReportPage(
+			filters({ paymentSourceType: PaymentSourceType.Web3CardanoV1 }),
+			{ Buyer: null, Seller: null },
+			50,
+		);
+		const buyer = result.records.find((record) => record.role === 'Buyer');
+		const seller = result.records.find((record) => record.role === 'Seller');
+		expect(buyer).toMatchObject({
+			isFeeReconciliationOwner: true,
+			feeComponentScope: 'partial',
+			feeAllocationScope: 'shared_or_unknown',
+		});
+		expect(seller).toMatchObject({
+			isFeeReconciliationOwner: false,
+			feeComponentScope: 'partial',
+			feeAllocationScope: 'shared_or_unknown',
+		});
+	});
+
+	it('marks a selected mirror partial after indexed same-hash evidence finds a filtered sibling', async () => {
+		const selected = paymentRecord('v2-mirror', '2026-01-03T00:00:00.000Z');
+		const sibling = transaction(OnChainState.FundsLocked, { paymentCurrentIds: ['v2-sibling'] });
+		sibling.txHash = selected.CurrentTransaction.txHash;
+		mockFindPayments.mockResolvedValue([selected]);
+		mockFindTransactions.mockResolvedValue([selected.CurrentTransaction, sibling]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(mockFindTransactions).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { txHash: { in: [selected.CurrentTransaction.txHash] } } }),
+		);
+		expect(result.records[0].transactions[0].relatedPaymentKeys).toEqual(['chain-v2-mirror', 'chain-v2-sibling']);
+		expect(result.records[0]).toMatchObject({
+			feeAllocationScope: 'shared_or_unknown',
+			feeComponentScope: 'partial',
+		});
+		expect(result.records[0].transactions[0].relatedPaymentKeysComplete).toBe(false);
+	});
+
+	it('preserves request-specific states when indexed mirrors share one transaction hash', async () => {
+		const selected = {
+			...paymentRecord('v2-result', '2026-01-03T00:00:00.000Z'),
+			onChainState: OnChainState.ResultSubmitted,
+			CurrentTransaction: transaction(OnChainState.ResultSubmitted, {
+				paymentCurrentIds: ['v2-result'],
+			}),
+		};
+		const sibling = transaction(OnChainState.Disputed, { paymentCurrentIds: ['v2-disputed'] });
+		sibling.txHash = selected.CurrentTransaction.txHash;
+		mockFindPayments.mockResolvedValue([selected]);
+		mockIndexedTransactions([selected.CurrentTransaction, sibling]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records[0].transactions[0]).toMatchObject({
+			newOnChainState: OnChainState.ResultSubmitted,
+			relatedPaymentKeys: ['chain-v2-disputed', 'chain-v2-result'],
+			relatedPaymentKeysComplete: false,
+		});
+	});
+
+	it('keeps a shared transaction row state unknown across distinct payments', async () => {
+		const sharedTransaction = transaction(OnChainState.ResultSubmitted, {
+			paymentCurrentIds: ['v2-result', 'v2-disputed'],
+		});
+		const selected = {
+			...paymentRecord('v2-result', '2026-01-03T00:00:00.000Z'),
+			onChainState: OnChainState.ResultSubmitted,
+			CurrentTransaction: sharedTransaction,
+		};
+		mockFindPayments.mockResolvedValue([selected]);
+		mockIndexedTransactions([sharedTransaction]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records[0].transactions[0]).toMatchObject({
+			newOnChainState: null,
+			relatedPaymentKeys: ['chain-v2-disputed', 'chain-v2-result'],
+			relatedPaymentKeysComplete: false,
+		});
+	});
+
+	it('merges same-hash database mirrors once before attaching evidence to each row', async () => {
+		const records = Array.from({ length: 100 }, (_value, index) => {
+			const value = paymentRecord(`mirror-${index}`, '2026-01-03T00:00:00.000Z');
+			value.CurrentTransaction.id = `mirror-tx-${index}`;
+			value.CurrentTransaction.txHash = 'shared-mirror-hash';
+			return value;
+		});
+		mockFindPayments.mockResolvedValue(records);
+		mockIndexedTransactions(
+			records.map((record) => ({
+				...record.CurrentTransaction,
+				PaymentRequestCurrent: [{ id: record.id, blockchainIdentifier: record.blockchainIdentifier }],
+			})),
+		);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 100);
+
+		expect(result.records).toHaveLength(100);
+		expect(result.records.every((record) => record.transactions.length === 1)).toBe(true);
+		expect(result.records.every((record) => record.transactions[0].relatedPaymentKeys?.length === 100)).toBe(true);
+	});
+
+	it('bounds relation hydration batches and cumulative related request rows', async () => {
+		const selected = paymentRecord('bounded-hydration', '2026-01-03T00:00:00.000Z');
+		const relatedIds = Array.from({ length: 100 }, (_value, index) => `related-${index}`);
+		const mirrors = Array.from({ length: 251 }, (_value, index) => ({
+			...transaction(OnChainState.FundsLocked, {
+				paymentCurrentIds: relatedIds,
+				paymentHistoryIds: relatedIds,
+				purchaseCurrentIds: relatedIds,
+				purchaseHistoryIds: relatedIds,
+			}),
+			id: `bounded-hydration-${index}`,
+			txHash: selected.CurrentTransaction.txHash,
+		}));
+		mockFindPayments.mockResolvedValue([selected]);
+		mockIndexedTransactions(mirrors);
+
+		await expect(
+			queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50),
+		).rejects.toMatchObject({
+			status: 413,
+			message: expect.stringContaining('100000 related request rows'),
+		});
+		const [scalarCall, ...hydrationCalls] = mockFindTransactions.mock.calls.map(([input]) => input);
+		expect(scalarCall.select.PaymentRequestCurrent).toBeUndefined();
+		expect(hydrationCalls).toHaveLength(6);
+		expect(hydrationCalls.every((call) => call.where.id.in.length <= 50)).toBe(true);
+	});
+
+	it('keeps a nonzero indexed fee partial without attested on-chain batch membership', async () => {
+		mockFindPayments.mockResolvedValue([paymentRecord('v2-mirror', '2026-01-03T00:00:00.000Z')]);
+		mockIndexedTransactions([
+			{
+				...paymentRecord('v2-mirror', '2026-01-03T00:00:00.000Z').CurrentTransaction,
+			},
+		]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records[0]).toMatchObject({
+			feeAllocationScope: 'shared_or_unknown',
+			feeComponentScope: 'partial',
+		});
+		expect(result.records[0].transactions[0].relatedPaymentKeysComplete).toBe(false);
+		const row = buildReportRow(result.records[0], 'Billable', filters().asOf, {
+			dateBasis: 'CreatedAt',
+			from: filters().from,
+			to: filters().to,
+		});
+		expect(row.cardanoFeeReconciliation).toMatchObject({
+			adminCardanoFees: null,
+			totalCardanoFees: null,
+			completeness: 'partial',
+		});
+	});
+
+	it('keeps an indexed zero-fee transaction exact without batch membership attestation', async () => {
+		const selected = paymentRecord('zero-fee', '2026-01-03T00:00:00.000Z');
+		selected.CurrentTransaction.fees = 0n;
+		mockFindPayments.mockResolvedValue([selected]);
+		mockIndexedTransactions([selected.CurrentTransaction]);
+
+		const result = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records[0]).toMatchObject({
+			feeAllocationScope: 'single_request',
+			feeComponentScope: 'complete',
+		});
+		expect(result.records[0].transactions[0].relatedPaymentKeysComplete).toBe(true);
+	});
+
+	it('finds an in-scope Buyer counterpart outside the current Buyer page', async () => {
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-cross-page', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'chain-cross-page',
+			},
+		]);
+		mockFindPurchases.mockResolvedValueOnce([]).mockResolvedValueOnce([{ blockchainIdentifier: 'chain-cross-page' }]);
+
+		const result = await queryReportPage(
+			filters(),
+			{
+				Buyer: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'buyer-page-cursor' },
+				Seller: null,
+			},
+			50,
+		);
+
+		expect(result.records[0]).toMatchObject({ role: 'Seller', isFeeReconciliationOwner: false });
+		expect(mockFindPurchases).toHaveBeenCalledTimes(2);
+		const pageWhere = mockFindPurchases.mock.calls[0][0].where;
+		const ownershipWhere = mockFindPurchases.mock.calls[1][0].where;
+		expect(pageWhere.OR).toBeDefined();
+		expect(ownershipWhere.OR).toBeUndefined();
+		expect(ownershipWhere.AND).toEqual(pageWhere.AND);
+		expect(ownershipWhere.blockchainIdentifier).toEqual({ in: ['chain-cross-page'] });
+	});
+
+	it('keeps fee ownership on a Seller when no Buyer row exists', async () => {
+		mockFindPayments.mockResolvedValue([paymentRecord('seller-only', '2026-01-03T00:00:00.000Z')]);
+
+		const result = await queryReportPage(filters(), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records).toHaveLength(1);
+		expect(result.records[0]).toMatchObject({ role: 'Seller', isFeeReconciliationOwner: true });
+	});
+
+	it('keeps fee ownership on a Seller when its Buyer counterpart is outside the filters', async () => {
+		const pairedTransaction = transaction(OnChainState.FundsLocked, {
+			paymentCurrentIds: ['seller-filtered-pair'],
+			purchaseCurrentIds: ['buyer-filtered-out'],
+			blockchainIdentifiers: {
+				'seller-filtered-pair': 'chain-filtered-pair',
+				'buyer-filtered-out': 'chain-filtered-pair',
+			},
+		});
+		mockFindPayments.mockResolvedValue([
+			{
+				...paymentRecord('seller-filtered-pair', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'chain-filtered-pair',
+				CurrentTransaction: pairedTransaction,
+			},
+		]);
+		mockFindPurchases.mockResolvedValue([]);
+
+		const result = await queryReportPage(filters(), { Buyer: null, Seller: null }, 50);
+
+		expect(result.records).toHaveLength(1);
+		expect(result.records[0]).toMatchObject({ role: 'Seller', isFeeReconciliationOwner: true });
+	});
+
+	it('uses an injected transaction client for repeatable-read aggregate queries', async () => {
+		const transactionPaymentFindMany = jest.fn() as AnyMock;
+		const transactionPurchaseFindMany = jest.fn() as AnyMock;
+		transactionPaymentFindMany.mockResolvedValue([]);
+		transactionPurchaseFindMany.mockResolvedValue([]);
+
+		await queryReportPage(filters(), { Buyer: null, Seller: null }, 50, {
+			paymentRequest: { findMany: transactionPaymentFindMany },
+			purchaseRequest: { findMany: transactionPurchaseFindMany },
+		} as never);
+
+		expect(transactionPaymentFindMany).toHaveBeenCalledTimes(1);
+		expect(transactionPurchaseFindMany).toHaveBeenCalledTimes(1);
+		expect(mockFindPayments).not.toHaveBeenCalled();
+		expect(mockFindPurchases).not.toHaveBeenCalled();
+	});
+});
+
+describe('queryReportFeeComponentClosure', () => {
+	it('loads a filtered transitive shared-fee component', async () => {
+		const relatedTransaction = (id: string, relatedIds: string[], blockchainIdentifiers: Record<string, string>) => ({
+			...transaction(OnChainState.Withdrawn, {
+				paymentHistoryIds: relatedIds,
+				blockchainIdentifiers,
+			}),
+			id,
+			txHash: `hash-${id}`,
+		});
+		const identifiers = { a: 'payment-a', b: 'payment-b', c: 'payment-c' };
+		const txAB = relatedTransaction('ab', ['a', 'b'], identifiers);
+		const txBC = relatedTransaction('bc', ['b', 'c'], identifiers);
+		const records = [
+			{
+				...paymentRecord('a', '2026-01-03T00:00:00.000Z'),
+				blockchainIdentifier: 'payment-a',
+				CurrentTransaction: txAB,
+			},
+			{
+				...paymentRecord('b', '2026-01-02T00:00:00.000Z'),
+				blockchainIdentifier: 'payment-b',
+				CurrentTransaction: txAB,
+				TransactionHistory: [txBC],
+			},
+			{
+				...paymentRecord('c', '2026-01-01T00:00:00.000Z'),
+				blockchainIdentifier: 'payment-c',
+				CurrentTransaction: txBC,
+			},
+		];
+		mockFindPayments.mockImplementation(({ where }) => {
+			const keys = where.blockchainIdentifier?.in as string[] | undefined;
+			return keys == null
+				? records.slice(0, 2)
+				: records.filter((record) => keys.includes(record.blockchainIdentifier));
+		});
+		mockFindPurchases.mockResolvedValue([]);
+		mockIndexedTransactions([txAB, txBC]);
+
+		const page = await queryReportPage(filters({ roles: ['Seller'] }), { Buyer: null, Seller: null }, 1);
+		const closure = await queryReportFeeComponentClosure(page.records, filters({ roles: ['Seller'] }));
+
+		expect(closure.map((record) => record.blockchainIdentifier).sort()).toEqual([
+			'payment-a',
+			'payment-b',
+			'payment-c',
+		]);
+		await expect(
+			queryReportFeeComponentClosure(page.records, filters({ roles: ['Seller'] }), undefined, {
+				maxSerializedBytes: 1,
+			}),
+		).rejects.toMatchObject({ status: 413 });
+		await expect(
+			queryReportFeeComponentClosure(page.records, filters({ roles: ['Seller'] }), undefined, {
+				maxQueryRows: 1,
+			}),
+		).rejects.toMatchObject({ status: 413 });
+	});
+});

--- a/src/services/transaction-report/query.spec.ts
+++ b/src/services/transaction-report/query.spec.ts
@@ -873,10 +873,32 @@ describe('queryReportPage', () => {
 		expect(mockFindPurchases).toHaveBeenCalledTimes(2);
 		const pageWhere = mockFindPurchases.mock.calls[0][0].where;
 		const ownershipWhere = mockFindPurchases.mock.calls[1][0].where;
-		expect(pageWhere.OR).toBeDefined();
-		expect(ownershipWhere.OR).toBeUndefined();
-		expect(ownershipWhere.AND).toEqual(pageWhere.AND);
+		// The cursor sits inside AND. A second top-level OR would replace the one
+		// the state filter puts there.
+		expect(pageWhere.OR).toBeUndefined();
+		const pageCursorClause = pageWhere.AND[pageWhere.AND.length - 1];
+		expect(pageCursorClause.OR).toBeDefined();
+		// The ownership lookup must not be cursor-limited, or a counterpart on an
+		// earlier page stays invisible.
+		expect(ownershipWhere.AND[ownershipWhere.AND.length - 1]).toEqual({});
+		expect(ownershipWhere.AND.slice(0, -1)).toEqual(pageWhere.AND.slice(0, -1));
 		expect(ownershipWhere.blockchainIdentifier).toEqual({ in: ['chain-cross-page'] });
+	});
+
+	it('keeps a mixed state filter on every page, not just the first', async () => {
+		mockFindPayments.mockResolvedValue([]);
+
+		await queryReportPage(
+			filters({ roles: ['Seller'], states: ['Pending', OnChainState.Withdrawn] }),
+			{ Buyer: null, Seller: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'seller-page-cursor' } },
+			50,
+		);
+
+		const where = mockFindPayments.mock.calls[0][0].where;
+		// The state filter owns the one top-level OR.
+		expect(where.OR).toEqual([{ onChainState: { in: [OnChainState.Withdrawn] } }, { onChainState: null }]);
+		// The cursor is still applied, from inside AND.
+		expect(where.AND[where.AND.length - 1].OR).toBeDefined();
 	});
 
 	it('keeps fee ownership on a Seller when no Buyer row exists', async () => {

--- a/src/services/transaction-report/query.ts
+++ b/src/services/transaction-report/query.ts
@@ -55,7 +55,13 @@ export type {
 	ReportRoleCursor,
 } from './query-cursor';
 
-const STATES_AFTER_FUNDS_LOCKED = Object.values(OnChainState);
+// Every on-chain state, deliberately. A request with no usable `FundsLocked`
+// transition is admitted so the report can mark it undateable rather than drop
+// it: such a row carries a null `fundsLockedAt`, so `getEventBucket` in
+// `aggregate.ts` puts it in no history bucket and the affected metrics turn
+// partial under HISTORY_ECONOMIC_TIMESTAMP_MISSING. Narrowing this list, or
+// adding a date predicate here, would remove that signal.
+const ALL_ON_CHAIN_STATES = Object.values(OnChainState);
 const REPORT_FEE_CONTEXT_MAX_ROWS = 5_000;
 const REPORT_FEE_CONTEXT_MAX_EVENTS = 100_000;
 const REPORT_FEE_CONTEXT_MAX_QUERY_ROWS = 250;
@@ -181,10 +187,7 @@ function sellerDateWhere(filters: ReportQueryFilters): Prisma.PaymentRequestWher
 			OR: [
 				paymentTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
 				{
-					AND: [
-						{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
-						missingUsableTransitionWhere(OnChainState.FundsLocked),
-					],
+					AND: [{ onChainState: { in: ALL_ON_CHAIN_STATES } }, missingUsableTransitionWhere(OnChainState.FundsLocked)],
 				},
 			],
 		};
@@ -227,10 +230,7 @@ function buyerDateWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWher
 			OR: [
 				purchaseTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
 				{
-					AND: [
-						{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
-						missingUsableTransitionWhere(OnChainState.FundsLocked),
-					],
+					AND: [{ onChainState: { in: ALL_ON_CHAIN_STATES } }, missingUsableTransitionWhere(OnChainState.FundsLocked)],
 				},
 			],
 		};
@@ -239,10 +239,7 @@ function buyerDateWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWher
 		OR: [
 			purchaseTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
 			{
-				AND: [
-					{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
-					missingUsableTransitionWhere(OnChainState.FundsLocked),
-				],
+				AND: [{ onChainState: { in: ALL_ON_CHAIN_STATES } }, missingUsableTransitionWhere(OnChainState.FundsLocked)],
 			},
 			purchaseTransitionWhere(OnChainState.RefundWithdrawn, filters.from, filters.to),
 			{

--- a/src/services/transaction-report/query.ts
+++ b/src/services/transaction-report/query.ts
@@ -1,0 +1,736 @@
+import { OnChainState, Prisma, TransactionStatus } from '@/generated/prisma/client';
+import { prisma } from '@masumi/payment-core/db';
+import createHttpError from 'http-errors';
+import type { ReportPaymentSourceType, RevenueMode } from './metrics';
+import { getReportPayoutCompleteness } from './query-payouts';
+import { loadReportMetadata } from './query-metadata';
+import {
+	assertBoundedRequestRelations,
+	REPORT_MAX_FUND_ROWS_PER_REQUEST,
+	REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST,
+} from './query-bounds';
+import type { ReportRequestRecord, ReportRole } from './records';
+import type { ReportCursorPositions, ReportRoleCursor } from './query-cursor';
+import { createReportLoadBudget, type ReportLoadBudgetLimits } from './load-budget';
+import {
+	attachedReportTransactionSelect,
+	enrichReportTransactionEvidence,
+	mapAttachedReportTransaction,
+	reportFeeAllocationScope,
+	reportFeeComponentScope,
+} from './query-transactions';
+
+export type ReportDateBasis = 'CreatedAt' | 'FundsLockedAt' | 'RevenueRecognizedAt';
+export type ReportStateFilter = OnChainState | 'Pending';
+
+export type ReportQueryFilters = {
+	paymentSourceId: string;
+	paymentSourceType: ReportPaymentSourceType;
+	configuredFeeRatePermille: number;
+	authorizedManagedWalletIds: string[] | null;
+	externalAddresses: string[];
+	roles: ReportRole[];
+	states: ReportStateFilter[];
+	from: Date;
+	to: Date;
+	dateBasis: ReportDateBasis;
+	revenueMode: RevenueMode;
+	asOf: Date;
+};
+export type ReportQueryClient = Pick<
+	Prisma.TransactionClient,
+	'paymentRequest' | 'purchaseRequest' | 'transaction' | '$queryRaw'
+>;
+export {
+	createReportCursorSnapshot,
+	createReportFilterFingerprint,
+	decodeReportCursor,
+	encodeReportCursor,
+} from './query-cursor';
+export type {
+	DecodedReportCursor,
+	ReportCursorPositions,
+	ReportCursorSnapshot,
+	ReportFilterFingerprintInput,
+	ReportRoleCursor,
+} from './query-cursor';
+
+const STATES_AFTER_FUNDS_LOCKED = Object.values(OnChainState);
+const REPORT_FEE_CONTEXT_MAX_ROWS = 5_000;
+const REPORT_FEE_CONTEXT_MAX_EVENTS = 100_000;
+const REPORT_FEE_CONTEXT_MAX_QUERY_ROWS = 250;
+const REPORT_FEE_CONTEXT_PAYMENT_KEY_BATCH_SIZE = 100;
+const REPORT_FEE_CONTEXT_MAX_PAYMENT_KEYS = 10_000;
+const REPORT_FEE_CONTEXT_MAX_SERIALIZED_BYTES = 32 * 1024 * 1024;
+const REPORT_FEE_CONTEXT_MAX_METADATA_BYTES = 8 * 1024 * 1024;
+
+const paymentReportSelect = {
+	id: true,
+	createdAt: true,
+	blockchainIdentifier: true,
+	agentIdentifier: true,
+	agentName: true,
+	onChainState: true,
+	unlockTime: true,
+	collateralReturnLovelace: true,
+	buyerReturnAddress: true,
+	sellerReturnAddress: true,
+	totalBuyerCardanoFees: true,
+	totalSellerCardanoFees: true,
+	BuyerWallet: { select: { walletAddress: true, walletVkey: true } },
+	SmartContractWallet: {
+		select: { id: true, walletAddress: true, walletVkey: true, collectionAddress: true, deletedAt: true },
+	},
+	RequestedFunds: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	WithdrawnForBuyer: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	WithdrawnForSeller: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	CurrentTransaction: { select: attachedReportTransactionSelect },
+	TransactionHistory: {
+		take: REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST + 1,
+		select: attachedReportTransactionSelect,
+	},
+} satisfies Prisma.PaymentRequestSelect;
+
+const purchaseReportSelect = {
+	id: true,
+	createdAt: true,
+	blockchainIdentifier: true,
+	agentIdentifier: true,
+	agentName: true,
+	onChainState: true,
+	unlockTime: true,
+	collateralReturnLovelace: true,
+	buyerReturnAddress: true,
+	sellerReturnAddress: true,
+	totalBuyerCardanoFees: true,
+	totalSellerCardanoFees: true,
+	SellerWallet: { select: { walletAddress: true, walletVkey: true } },
+	SmartContractWallet: {
+		select: { id: true, walletAddress: true, walletVkey: true, collectionAddress: true, deletedAt: true },
+	},
+	PaidFunds: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	WithdrawnForBuyer: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	WithdrawnForSeller: { take: REPORT_MAX_FUND_ROWS_PER_REQUEST + 1, select: { unit: true, amount: true } },
+	CurrentTransaction: { select: attachedReportTransactionSelect },
+	TransactionHistory: {
+		take: REPORT_MAX_TRANSACTION_HISTORY_PER_REQUEST + 1,
+		select: attachedReportTransactionSelect,
+	},
+} satisfies Prisma.PurchaseRequestSelect;
+
+type PaymentReportRecord = Prisma.PaymentRequestGetPayload<{ select: typeof paymentReportSelect }>;
+type PurchaseReportRecord = Prisma.PurchaseRequestGetPayload<{ select: typeof purchaseReportSelect }>;
+
+function sortedUnique(values: readonly string[]): string[] {
+	return Array.from(new Set(values)).sort();
+}
+
+function blockTimeRange(from: Date, to: Date) {
+	return {
+		gte: Math.ceil(from.getTime() / 1000),
+		lt: Math.ceil(to.getTime() / 1000),
+	};
+}
+
+function transactionTransitionFilter(state: OnChainState, from: Date, to: Date): Prisma.TransactionWhereInput {
+	return {
+		status: TransactionStatus.Confirmed,
+		newOnChainState: state,
+		blockTime: blockTimeRange(from, to),
+	};
+}
+
+function transactionRelationWhere(transaction: Prisma.TransactionWhereInput) {
+	return { OR: [{ CurrentTransaction: { is: transaction } }, { TransactionHistory: { some: transaction } }] };
+}
+
+function missingUsableTransitionWhere(state: OnChainState) {
+	return {
+		NOT: transactionRelationWhere({
+			status: TransactionStatus.Confirmed,
+			txHash: { not: null },
+			newOnChainState: state,
+			blockTime: { not: null },
+		}),
+	};
+}
+
+function paymentTransitionWhere(state: OnChainState, from: Date, to: Date): Prisma.PaymentRequestWhereInput {
+	const transaction = transactionTransitionFilter(state, from, to);
+	return transactionRelationWhere(transaction);
+}
+
+function purchaseTransitionWhere(state: OnChainState, from: Date, to: Date): Prisma.PurchaseRequestWhereInput {
+	const transaction = transactionTransitionFilter(state, from, to);
+	return transactionRelationWhere(transaction);
+}
+
+function feeEventWhere(from: Date, to: Date) {
+	return {
+		OR: [
+			transactionRelationWhere({ status: TransactionStatus.Confirmed, blockTime: blockTimeRange(from, to) }),
+			transactionRelationWhere({ status: TransactionStatus.Confirmed, blockTime: null }),
+		],
+	};
+}
+
+function sellerDateWhere(filters: ReportQueryFilters): Prisma.PaymentRequestWhereInput {
+	if (filters.dateBasis === 'CreatedAt') return { createdAt: { gte: filters.from, lt: filters.to } };
+	if (filters.dateBasis === 'FundsLockedAt') {
+		return {
+			OR: [
+				paymentTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
+				{
+					AND: [
+						{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
+						missingUsableTransitionWhere(OnChainState.FundsLocked),
+					],
+				},
+			],
+		};
+	}
+	const feeEvent = feeEventWhere(filters.from, filters.to);
+	if (filters.revenueMode === 'RequestedGross') {
+		return { OR: [{ createdAt: { gte: filters.from, lt: filters.to } }, feeEvent] };
+	}
+
+	const settledStates = [OnChainState.Withdrawn, OnChainState.DisputedWithdrawn] as const;
+	const settled = settledStates.map((state) => ({
+		AND: [
+			{ onChainState: state },
+			{
+				OR: [paymentTransitionWhere(state, filters.from, filters.to), missingUsableTransitionWhere(state)],
+			},
+		],
+	}));
+	if (filters.revenueMode === 'CashReceived') return { OR: [...settled, feeEvent] };
+	return {
+		OR: [
+			...settled,
+			feeEvent,
+			{
+				onChainState: { in: [OnChainState.ResultSubmitted, OnChainState.Withdrawn] },
+				unlockTime: {
+					gte: BigInt(filters.from.getTime()),
+					lt: BigInt(filters.to.getTime()),
+					lte: BigInt(filters.asOf.getTime()),
+				},
+			},
+		],
+	};
+}
+
+function buyerDateWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWhereInput {
+	if (filters.dateBasis === 'CreatedAt') return { createdAt: { gte: filters.from, lt: filters.to } };
+	if (filters.dateBasis === 'FundsLockedAt') {
+		return {
+			OR: [
+				purchaseTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
+				{
+					AND: [
+						{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
+						missingUsableTransitionWhere(OnChainState.FundsLocked),
+					],
+				},
+			],
+		};
+	}
+	return {
+		OR: [
+			purchaseTransitionWhere(OnChainState.FundsLocked, filters.from, filters.to),
+			{
+				AND: [
+					{ onChainState: { in: STATES_AFTER_FUNDS_LOCKED } },
+					missingUsableTransitionWhere(OnChainState.FundsLocked),
+				],
+			},
+			purchaseTransitionWhere(OnChainState.RefundWithdrawn, filters.from, filters.to),
+			{
+				AND: [
+					{ onChainState: OnChainState.RefundWithdrawn },
+					missingUsableTransitionWhere(OnChainState.RefundWithdrawn),
+				],
+			},
+			purchaseTransitionWhere(OnChainState.DisputedWithdrawn, filters.from, filters.to),
+			{
+				AND: [
+					{ onChainState: OnChainState.DisputedWithdrawn },
+					missingUsableTransitionWhere(OnChainState.DisputedWithdrawn),
+				],
+			},
+			feeEventWhere(filters.from, filters.to),
+		],
+	};
+}
+
+function cursorWhere(cursor: ReportRoleCursor | null) {
+	if (cursor == null) return {};
+	return {
+		OR: [{ createdAt: { lt: cursor.createdAt } }, { createdAt: cursor.createdAt, id: { lt: cursor.id } }],
+	};
+}
+
+function snapshotBoundaryWhere(asOf: Date) {
+	// This is a monotonic boundary, not historical reconstruction. Requests whose
+	// next action, state, or result changed after the snapshot are excluded instead of rewound.
+	return {
+		createdAt: { lte: asOf },
+		nextActionOrOnChainStateOrResultLastChangedAt: { lte: asOf },
+	};
+}
+
+function managedWalletWhere(authorizedManagedWalletIds: string[] | null) {
+	return authorizedManagedWalletIds == null ? {} : { smartContractWalletId: { in: authorizedManagedWalletIds } };
+}
+
+function requestStateWhere(states: readonly ReportStateFilter[]) {
+	if (states.length === 0) return {};
+	const onChainStates = states.filter((state): state is OnChainState => state !== 'Pending');
+	if (!states.includes('Pending')) return { onChainState: { in: onChainStates } };
+	if (onChainStates.length === 0) return { onChainState: null };
+	return { OR: [{ onChainState: { in: onChainStates } }, { onChainState: null }] };
+}
+
+function paymentExternalAddressWhere(externalAddresses: string[]): Prisma.PaymentRequestWhereInput {
+	if (externalAddresses.length === 0) return {};
+	return {
+		OR: [
+			{ buyerReturnAddress: { in: externalAddresses } },
+			{ sellerReturnAddress: { in: externalAddresses } },
+			{ BuyerWallet: { is: { walletAddress: { in: externalAddresses } } } },
+			{ SmartContractWallet: { is: { collectionAddress: { in: externalAddresses } } } },
+			{ SmartContractWallet: { is: { walletAddress: { in: externalAddresses } } } },
+		],
+	};
+}
+
+function purchaseExternalAddressWhere(externalAddresses: string[]): Prisma.PurchaseRequestWhereInput {
+	if (externalAddresses.length === 0) return {};
+	return {
+		OR: [
+			{ buyerReturnAddress: { in: externalAddresses } },
+			{ sellerReturnAddress: { in: externalAddresses } },
+			{ SellerWallet: { is: { walletAddress: { in: externalAddresses } } } },
+			{ SmartContractWallet: { is: { collectionAddress: { in: externalAddresses } } } },
+			{ SmartContractWallet: { is: { walletAddress: { in: externalAddresses } } } },
+		],
+	};
+}
+
+function buyerScopeWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWhereInput {
+	return {
+		paymentSourceId: filters.paymentSourceId,
+		...managedWalletWhere(filters.authorizedManagedWalletIds),
+		...requestStateWhere(filters.states),
+		AND: [
+			buyerDateWhere(filters),
+			purchaseExternalAddressWhere(filters.externalAddresses),
+			snapshotBoundaryWhere(filters.asOf),
+		],
+	};
+}
+
+function sellerScopeWhere(filters: ReportQueryFilters): Prisma.PaymentRequestWhereInput {
+	return {
+		paymentSourceId: filters.paymentSourceId,
+		...managedWalletWhere(filters.authorizedManagedWalletIds),
+		...requestStateWhere(filters.states),
+		AND: [
+			sellerDateWhere(filters),
+			paymentExternalAddressWhere(filters.externalAddresses),
+			snapshotBoundaryWhere(filters.asOf),
+		],
+	};
+}
+
+function paymentToReportRecord(
+	record: PaymentReportRecord,
+	metadata: string | null,
+	filters: ReportQueryFilters,
+): ReportRequestRecord {
+	assertBoundedRequestRelations(
+		record.TransactionHistory,
+		record.RequestedFunds,
+		record.WithdrawnForBuyer,
+		record.WithdrawnForSeller,
+	);
+	const sourceTransactions = [record.CurrentTransaction, ...record.TransactionHistory];
+	const transactions = sourceTransactions
+		.map(mapAttachedReportTransaction)
+		.filter((value): value is NonNullable<typeof value> => value != null)
+		.map((value) => ({ ...value, relatedPaymentKeysComplete: false }));
+	return {
+		id: record.id,
+		role: 'Seller',
+		requestType: 'PaymentRequest',
+		createdAt: record.createdAt,
+		blockchainIdentifier: record.blockchainIdentifier,
+		agentIdentifier: record.agentIdentifier,
+		agentName: record.agentName,
+		onChainState: record.onChainState,
+		metadata,
+		managedWallet: record.SmartContractWallet,
+		counterpartyAddress: record.BuyerWallet?.walletAddress ?? null,
+		buyerReturnAddress: record.buyerReturnAddress,
+		sellerReturnAddress: record.sellerReturnAddress,
+		paymentSourceType: filters.paymentSourceType,
+		configuredFeeRatePermille: filters.configuredFeeRatePermille,
+		unlockTime: record.unlockTime,
+		collateralReturnLovelace: record.collateralReturnLovelace,
+		requestedFunds: record.RequestedFunds,
+		withdrawnForBuyer: record.WithdrawnForBuyer,
+		withdrawnForSeller: record.WithdrawnForSeller,
+		buyerPayoutCompleteness: getReportPayoutCompleteness({
+			paymentSourceType: filters.paymentSourceType,
+			onChainState: record.onChainState,
+			returnAddress: record.buyerReturnAddress,
+			expectedWalletVkey: record.BuyerWallet?.walletVkey ?? null,
+			buyerCollateralReturnLovelace: record.collateralReturnLovelace,
+			hasStoredPayoutEvidence: record.WithdrawnForBuyer.length > 0,
+		}),
+		sellerPayoutCompleteness: getReportPayoutCompleteness({
+			paymentSourceType: filters.paymentSourceType,
+			onChainState: record.onChainState,
+			returnAddress: record.sellerReturnAddress,
+			expectedWalletVkey: record.SmartContractWallet?.walletVkey ?? null,
+			hasStoredPayoutEvidence: record.WithdrawnForSeller.length > 0,
+		}),
+		buyerCardanoFees: record.totalBuyerCardanoFees,
+		sellerCardanoFees: record.totalSellerCardanoFees,
+		transactions,
+		feeAllocationScope: reportFeeAllocationScope(transactions),
+		isFeeReconciliationOwner: true,
+		feeComponentScope: reportFeeComponentScope(transactions, record.blockchainIdentifier),
+	};
+}
+
+function purchaseToReportRecord(
+	record: PurchaseReportRecord,
+	metadata: string | null,
+	filters: ReportQueryFilters,
+): ReportRequestRecord {
+	assertBoundedRequestRelations(
+		record.TransactionHistory,
+		record.PaidFunds,
+		record.WithdrawnForBuyer,
+		record.WithdrawnForSeller,
+	);
+	const sourceTransactions = [record.CurrentTransaction, ...record.TransactionHistory];
+	const transactions = sourceTransactions
+		.map(mapAttachedReportTransaction)
+		.filter((value): value is NonNullable<typeof value> => value != null)
+		.map((value) => ({ ...value, relatedPaymentKeysComplete: false }));
+	return {
+		id: record.id,
+		role: 'Buyer',
+		requestType: 'PurchaseRequest',
+		createdAt: record.createdAt,
+		blockchainIdentifier: record.blockchainIdentifier,
+		agentIdentifier: record.agentIdentifier,
+		agentName: record.agentName,
+		onChainState: record.onChainState,
+		metadata,
+		managedWallet: record.SmartContractWallet,
+		counterpartyAddress: record.SellerWallet.walletAddress,
+		buyerReturnAddress: record.buyerReturnAddress,
+		sellerReturnAddress: record.sellerReturnAddress,
+		paymentSourceType: filters.paymentSourceType,
+		configuredFeeRatePermille: filters.configuredFeeRatePermille,
+		unlockTime: record.unlockTime,
+		collateralReturnLovelace: record.collateralReturnLovelace,
+		requestedFunds: record.PaidFunds,
+		withdrawnForBuyer: record.WithdrawnForBuyer,
+		withdrawnForSeller: record.WithdrawnForSeller,
+		buyerPayoutCompleteness: getReportPayoutCompleteness({
+			paymentSourceType: filters.paymentSourceType,
+			onChainState: record.onChainState,
+			returnAddress: record.buyerReturnAddress,
+			expectedWalletVkey: record.SmartContractWallet?.walletVkey ?? null,
+			buyerCollateralReturnLovelace: record.collateralReturnLovelace,
+			hasStoredPayoutEvidence: record.WithdrawnForBuyer.length > 0,
+		}),
+		sellerPayoutCompleteness: getReportPayoutCompleteness({
+			paymentSourceType: filters.paymentSourceType,
+			onChainState: record.onChainState,
+			returnAddress: record.sellerReturnAddress,
+			expectedWalletVkey: record.SellerWallet.walletVkey,
+			hasStoredPayoutEvidence: record.WithdrawnForSeller.length > 0,
+		}),
+		buyerCardanoFees: record.totalBuyerCardanoFees,
+		sellerCardanoFees: record.totalSellerCardanoFees,
+		transactions,
+		feeAllocationScope: reportFeeAllocationScope(transactions),
+		isFeeReconciliationOwner: true,
+		feeComponentScope: reportFeeComponentScope(transactions, record.blockchainIdentifier),
+	};
+}
+
+async function findSellerRecords(
+	filters: ReportQueryFilters,
+	cursor: ReportRoleCursor | null,
+	take: number,
+	database: ReportQueryClient,
+	signal?: AbortSignal,
+) {
+	if (!filters.roles.includes('Seller')) return [];
+	assertQueryActive(signal);
+	const result = await database.paymentRequest.findMany({
+		where: {
+			...sellerScopeWhere(filters),
+			...cursorWhere(cursor),
+		},
+		orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+		take,
+		select: paymentReportSelect,
+	});
+	assertQueryActive(signal);
+	const metadataById = await loadReportMetadata(
+		'PaymentRequest',
+		result.map((record) => record.id),
+		database,
+		signal,
+	);
+	return result.map((record) => paymentToReportRecord(record, metadataById.get(record.id) ?? null, filters));
+}
+
+async function findFeeContextRecords(
+	filters: ReportQueryFilters,
+	paymentKeys: string[],
+	maxQueryRows: number,
+	database: ReportQueryClient,
+	signal?: AbortSignal,
+): Promise<ReportRequestRecord[]> {
+	assertQueryActive(signal);
+	const sellerRecords = filters.roles.includes('Seller')
+		? await database.paymentRequest.findMany({
+				where: { ...sellerScopeWhere(filters), blockchainIdentifier: { in: paymentKeys } },
+				take: maxQueryRows + 1,
+				select: paymentReportSelect,
+			})
+		: [];
+	assertQueryActive(signal);
+	if (sellerRecords.length > maxQueryRows) {
+		throw createHttpError(413, `Report fee context query exceeds ${maxQueryRows} rows. Narrow the report filters.`);
+	}
+	const sellerMetadata = await loadReportMetadata(
+		'PaymentRequest',
+		sellerRecords.map((record) => record.id),
+		database,
+		signal,
+	);
+	const buyerRecords = filters.roles.includes('Buyer')
+		? await database.purchaseRequest.findMany({
+				where: { ...buyerScopeWhere(filters), blockchainIdentifier: { in: paymentKeys } },
+				take: maxQueryRows + 1,
+				select: purchaseReportSelect,
+			})
+		: [];
+	assertQueryActive(signal);
+	if (buyerRecords.length > maxQueryRows) {
+		throw createHttpError(413, `Report fee context query exceeds ${maxQueryRows} rows. Narrow the report filters.`);
+	}
+	const buyerMetadata = await loadReportMetadata(
+		'PurchaseRequest',
+		buyerRecords.map((record) => record.id),
+		database,
+		signal,
+	);
+	return [
+		...sellerRecords.map((record) => paymentToReportRecord(record, sellerMetadata.get(record.id) ?? null, filters)),
+		...buyerRecords.map((record) => purchaseToReportRecord(record, buyerMetadata.get(record.id) ?? null, filters)),
+	];
+}
+
+function reportRequestKey(record: ReportRequestRecord): string {
+	return `${record.requestType}:${record.id}`;
+}
+
+function assertQueryActive(signal?: AbortSignal): void {
+	if (signal?.aborted) throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+}
+
+export async function queryReportFeeComponentClosure(
+	seedRecords: readonly ReportRequestRecord[],
+	filters: ReportQueryFilters,
+	database: ReportQueryClient = prisma,
+	limits: ReportLoadBudgetLimits & {
+		maxRows?: number;
+		maxQueryRows?: number;
+		maxPaymentKeys?: number;
+		signal?: AbortSignal;
+	} = {},
+): Promise<ReportRequestRecord[]> {
+	const maxRows = limits.maxRows ?? REPORT_FEE_CONTEXT_MAX_ROWS;
+	const maxQueryRows = limits.maxQueryRows ?? REPORT_FEE_CONTEXT_MAX_QUERY_ROWS;
+	const maxPaymentKeys = limits.maxPaymentKeys ?? REPORT_FEE_CONTEXT_MAX_PAYMENT_KEYS;
+	const signal = limits.signal;
+	const consumeBudget = createReportLoadBudget({
+		...limits,
+		maxEvents: limits.maxEvents ?? REPORT_FEE_CONTEXT_MAX_EVENTS,
+		maxMetadataBytes: limits.maxMetadataBytes ?? REPORT_FEE_CONTEXT_MAX_METADATA_BYTES,
+		maxSerializedBytes: limits.maxSerializedBytes ?? REPORT_FEE_CONTEXT_MAX_SERIALIZED_BYTES,
+	});
+	const records = new Map<string, ReportRequestRecord>();
+	const pendingPaymentKeys = new Set<string>();
+	const queriedPaymentKeys = new Set<string>();
+	const addRelatedPaymentKeys = (batch: readonly ReportRequestRecord[]) => {
+		for (const record of batch) {
+			assertQueryActive(signal);
+			const paymentKeys = [
+				record.blockchainIdentifier,
+				...record.transactions.flatMap((transaction) => transaction.relatedPaymentKeys ?? []),
+			];
+			for (const key of paymentKeys) {
+				if (!queriedPaymentKeys.has(key)) pendingPaymentKeys.add(key);
+				if (pendingPaymentKeys.size + queriedPaymentKeys.size > maxPaymentKeys) {
+					throw createHttpError(
+						413,
+						`Report fee context exceeds ${maxPaymentKeys} payment keys. Narrow the report filters.`,
+					);
+				}
+			}
+		}
+	};
+	for (const record of seedRecords) {
+		assertQueryActive(signal);
+		consumeBudget(record);
+		records.set(reportRequestKey(record), record);
+	}
+	if (records.size > maxRows) {
+		throw createHttpError(413, `Report fee context exceeds ${maxRows} rows. Narrow the report filters.`);
+	}
+	addRelatedPaymentKeys(seedRecords);
+
+	while (pendingPaymentKeys.size > 0) {
+		assertQueryActive(signal);
+		const paymentKeys = Array.from(pendingPaymentKeys).slice(0, REPORT_FEE_CONTEXT_PAYMENT_KEY_BATCH_SIZE);
+		for (const key of paymentKeys) {
+			pendingPaymentKeys.delete(key);
+			queriedPaymentKeys.add(key);
+		}
+		const batch = await enrichReportTransactionEvidence(
+			await findFeeContextRecords(filters, paymentKeys, maxQueryRows, database, signal),
+			database,
+			signal,
+		);
+		assertQueryActive(signal);
+		for (const record of batch) {
+			assertQueryActive(signal);
+			const key = reportRequestKey(record);
+			consumeBudget(record);
+			records.set(key, record);
+		}
+		if (records.size > maxRows) {
+			throw createHttpError(413, `Report fee context exceeds ${maxRows} rows. Narrow the report filters.`);
+		}
+		addRelatedPaymentKeys(batch);
+	}
+
+	const result = Array.from(records.values());
+	const buyerPaymentKeys = new Set(
+		result.filter((record) => record.role === 'Buyer').map((record) => record.blockchainIdentifier),
+	);
+	return result.map((record) =>
+		record.role === 'Seller'
+			? { ...record, isFeeReconciliationOwner: !buyerPaymentKeys.has(record.blockchainIdentifier) }
+			: record,
+	);
+}
+
+async function findBuyerRecords(
+	filters: ReportQueryFilters,
+	cursor: ReportRoleCursor | null,
+	take: number,
+	database: ReportQueryClient,
+	signal?: AbortSignal,
+) {
+	if (!filters.roles.includes('Buyer')) return [];
+	assertQueryActive(signal);
+	const result = await database.purchaseRequest.findMany({
+		where: {
+			...buyerScopeWhere(filters),
+			...cursorWhere(cursor),
+		},
+		orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+		take,
+		select: purchaseReportSelect,
+	});
+	assertQueryActive(signal);
+	const metadataById = await loadReportMetadata(
+		'PurchaseRequest',
+		result.map((record) => record.id),
+		database,
+		signal,
+	);
+	return result.map((record) => purchaseToReportRecord(record, metadataById.get(record.id) ?? null, filters));
+}
+
+async function assignFeeReconciliationOwners(
+	records: ReportRequestRecord[],
+	filters: ReportQueryFilters,
+	database: ReportQueryClient,
+	signal?: AbortSignal,
+): Promise<ReportRequestRecord[]> {
+	const sellerPaymentKeys = sortedUnique(
+		records.filter((record) => record.role === 'Seller').map((record) => record.blockchainIdentifier),
+	);
+	if (!filters.roles.includes('Buyer') || sellerPaymentKeys.length === 0) return records;
+	assertQueryActive(signal);
+	const buyers = await database.purchaseRequest.findMany({
+		where: { ...buyerScopeWhere(filters), blockchainIdentifier: { in: sellerPaymentKeys } },
+		select: { blockchainIdentifier: true },
+	});
+	assertQueryActive(signal);
+	const buyerPaymentKeys = new Set(buyers.map((record) => record.blockchainIdentifier));
+	return records.map((record) =>
+		record.role === 'Seller'
+			? { ...record, isFeeReconciliationOwner: !buyerPaymentKeys.has(record.blockchainIdentifier) }
+			: record,
+	);
+}
+
+function compareRecords(left: ReportRequestRecord, right: ReportRequestRecord): number {
+	const dateDifference = right.createdAt.getTime() - left.createdAt.getTime();
+	if (dateDifference !== 0) return dateDifference;
+	if (left.role !== right.role) return left.role === 'Seller' ? -1 : 1;
+	return right.id.localeCompare(left.id);
+}
+
+function nextRoleCursor(
+	rows: readonly ReportRequestRecord[],
+	role: ReportRole,
+	previous: ReportRoleCursor | null,
+): ReportRoleCursor | null {
+	const roleRows = rows.filter((candidate) => candidate.role === role);
+	const row = roleRows[roleRows.length - 1];
+	return row == null ? previous : { createdAt: row.createdAt, id: row.id };
+}
+
+export async function queryReportPage(
+	filters: ReportQueryFilters,
+	cursor: ReportCursorPositions,
+	limit: number,
+	database: ReportQueryClient = prisma,
+	signal?: AbortSignal,
+): Promise<{ records: ReportRequestRecord[]; nextCursor: ReportCursorPositions | null }> {
+	assertQueryActive(signal);
+	const takePerRole = limit + 1;
+	const [sellerRecords, buyerRecords] = await Promise.all([
+		findSellerRecords(filters, cursor.Seller, takePerRole, database, signal),
+		findBuyerRecords(filters, cursor.Buyer, takePerRole, database, signal),
+	]);
+	assertQueryActive(signal);
+	const merged = [...sellerRecords, ...buyerRecords].sort(compareRecords);
+	const enriched = await enrichReportTransactionEvidence(merged.slice(0, limit), database, signal);
+	assertQueryActive(signal);
+	const records = await assignFeeReconciliationOwners(enriched, filters, database, signal);
+	assertQueryActive(signal);
+	if (merged.length <= limit) return { records, nextCursor: null };
+	return {
+		records,
+		nextCursor: {
+			Seller: nextRoleCursor(records, 'Seller', cursor.Seller),
+			Buyer: nextRoleCursor(records, 'Buyer', cursor.Buyer),
+		},
+	};
+}

--- a/src/services/transaction-report/query.ts
+++ b/src/services/transaction-report/query.ts
@@ -317,7 +317,15 @@ function purchaseExternalAddressWhere(externalAddresses: string[]): Prisma.Purch
 	};
 }
 
-function buyerScopeWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWhereInput {
+// The cursor belongs inside AND, never spread beside the other clauses.
+// requestStateWhere returns a top-level OR for a mixed Pending plus on-chain
+// filter and cursorWhere returns one too, so spreading both put two OR keys in
+// one object literal: the cursor won and every page after the first ignored the
+// state filter.
+function buyerScopeWhere(
+	filters: ReportQueryFilters,
+	cursor: ReportRoleCursor | null = null,
+): Prisma.PurchaseRequestWhereInput {
 	return {
 		paymentSourceId: filters.paymentSourceId,
 		...managedWalletWhere(filters.authorizedManagedWalletIds),
@@ -326,11 +334,16 @@ function buyerScopeWhere(filters: ReportQueryFilters): Prisma.PurchaseRequestWhe
 			buyerDateWhere(filters),
 			purchaseExternalAddressWhere(filters.externalAddresses),
 			snapshotBoundaryWhere(filters.asOf),
+			cursorWhere(cursor),
 		],
 	};
 }
 
-function sellerScopeWhere(filters: ReportQueryFilters): Prisma.PaymentRequestWhereInput {
+// See buyerScopeWhere: the cursor has to stay inside AND.
+function sellerScopeWhere(
+	filters: ReportQueryFilters,
+	cursor: ReportRoleCursor | null = null,
+): Prisma.PaymentRequestWhereInput {
 	return {
 		paymentSourceId: filters.paymentSourceId,
 		...managedWalletWhere(filters.authorizedManagedWalletIds),
@@ -339,6 +352,7 @@ function sellerScopeWhere(filters: ReportQueryFilters): Prisma.PaymentRequestWhe
 			sellerDateWhere(filters),
 			paymentExternalAddressWhere(filters.externalAddresses),
 			snapshotBoundaryWhere(filters.asOf),
+			cursorWhere(cursor),
 		],
 	};
 }
@@ -475,10 +489,7 @@ async function findSellerRecords(
 	if (!filters.roles.includes('Seller')) return [];
 	assertQueryActive(signal);
 	const result = await database.paymentRequest.findMany({
-		where: {
-			...sellerScopeWhere(filters),
-			...cursorWhere(cursor),
-		},
+		where: sellerScopeWhere(filters, cursor),
 		orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
 		take,
 		select: paymentReportSelect,
@@ -647,10 +658,7 @@ async function findBuyerRecords(
 	if (!filters.roles.includes('Buyer')) return [];
 	assertQueryActive(signal);
 	const result = await database.purchaseRequest.findMany({
-		where: {
-			...buyerScopeWhere(filters),
-			...cursorWhere(cursor),
-		},
+		where: buyerScopeWhere(filters, cursor),
 		orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
 		take,
 		select: purchaseReportSelect,


### PR DESCRIPTION
Reads requests, transactions and payouts out of Postgres and hands the domain layer plain records.

- `query.ts` and `query-transactions.ts`: the selects and their bounded relations.
- `query-cursor.ts`, `query-bounds.ts`, `query-payouts.ts`, `query-metadata.ts`.

9 files, 2,499 lines. Imports the domain layer, and nothing above it.

---

**Part of a 6-PR split of #739.** That branch is 69 files and 34,694 lines, over the review-tooling limits, so nothing could review it as one change. It is split here by layer, bottom-up.

Verified before opening:
- The six branches together reproduce `feat/transaction-report-core` exactly. `git diff --stat origin/feat/transaction-report-core <tip>` is empty.
- `npx tsc --noEmit` reports 0 errors on each of the six branches in order, so every step of the stack compiles on its own.
- No file content was changed, reworded, or moved between layers beyond assigning each file to the layer that owns it.