### PR TITLE
feat(reports): add the report service and CSV export

### DIFF
--- a/src/routes/api/reports/schemas.ts
+++ b/src/routes/api/reports/schemas.ts
@@ -1,0 +1,276 @@
+import { HotWalletType, Network, OnChainState, PaymentSourceType } from '@/generated/prisma/client';
+import { z } from '@masumi/payment-core/zod';
+
+export const REPORT_MAX_RANGE_DAYS = 3_660;
+export const REPORT_DEFAULT_PAGE_SIZE = 50;
+export const REPORT_MAX_PAGE_SIZE = 100;
+
+const reportRoleSchema = z.enum(['Buyer', 'Seller']);
+export const reportStateFilterSchema = z.union([z.nativeEnum(OnChainState), z.literal('Pending')]);
+const revenueModeSchema = z.enum(['Billable', 'CashReceived', 'RequestedGross']);
+const dateBasisSchema = z.enum(['CreatedAt', 'FundsLockedAt', 'RevenueRecognizedAt']);
+const bucketSchema = z.enum(['Auto', 'Day', 'Week', 'Month']);
+
+const timeZoneSchema = z
+	.string()
+	.min(1)
+	.max(100)
+	.default('Etc/UTC')
+	.refine((timeZone) => {
+		try {
+			new Intl.DateTimeFormat('en-US', { timeZone }).format();
+			return true;
+		} catch {
+			return false;
+		}
+	}, 'Invalid IANA time zone');
+
+const suppliedFiatRateSchema = z.object({
+	unit: z.string().max(200),
+	rate: z
+		.string()
+		.regex(/^(?:0|[1-9]\d*)(?:\.\d+)?$/, 'Fiat rate must be a positive decimal string')
+		.refine((value) => value !== '0' && !/^0\.0+$/.test(value), 'Fiat rate must be greater than zero'),
+	from: z.coerce.date().optional(),
+	to: z.coerce.date().optional(),
+});
+
+export const reportFilterSchema = z
+	.object({
+		paymentSourceId: z.string().min(1).max(250),
+		managedWalletIds: z.array(z.string().min(1).max(250)).max(100).optional(),
+		externalAddresses: z.array(z.string().min(1).max(250)).max(100).optional(),
+		roles: z.array(reportRoleSchema).min(1).max(2).default(['Buyer', 'Seller']),
+		states: z.array(reportStateFilterSchema).max(11).optional(),
+		from: z.coerce.date(),
+		to: z.coerce.date(),
+		dateBasis: dateBasisSchema.default('RevenueRecognizedAt'),
+		revenueMode: revenueModeSchema.default('Billable'),
+		timeZone: timeZoneSchema,
+		fiat: z
+			.object({
+				currency: z.enum(['usd', 'eur', 'gbp', 'jpy', 'chf', 'aed']),
+				mode: z.enum(['BucketAverage', 'AccountingDate']).default('BucketAverage'),
+				suppliedRates: z.array(suppliedFiatRateSchema).max(100).optional(),
+			})
+			.optional(),
+	})
+	.superRefine((input, ctx) => {
+		if (input.to.getTime() <= input.from.getTime()) {
+			ctx.addIssue({ code: 'custom', path: ['to'], message: 'to must be after from' });
+			return;
+		}
+		const rangeMilliseconds = input.to.getTime() - input.from.getTime();
+		if (rangeMilliseconds > REPORT_MAX_RANGE_DAYS * 24 * 60 * 60 * 1000) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['to'],
+				message: `Report range must not exceed ${REPORT_MAX_RANGE_DAYS} days`,
+			});
+		}
+		for (const rate of input.fiat?.suppliedRates ?? []) {
+			if (rate.from != null && rate.to != null && rate.to.getTime() <= rate.from.getTime()) {
+				ctx.addIssue({ code: 'custom', path: ['fiat', 'suppliedRates'], message: 'Rate to must be after rate from' });
+			}
+		}
+	});
+
+export const reportTransactionsInputSchema = reportFilterSchema.and(
+	z.object({
+		cursor: z.string().max(4_000).optional(),
+		limit: z.coerce.number().int().min(1).max(REPORT_MAX_PAGE_SIZE).default(REPORT_DEFAULT_PAGE_SIZE),
+	}),
+);
+
+export const reportSummaryInputSchema = reportFilterSchema.and(z.object({ bucket: bucketSchema.default('Auto') }));
+
+export const serializedReportAmountSchema = z.object({
+	unit: z.string(),
+	rawAmount: z.string().regex(/^-?\d+$/),
+	decimalAmount: z.string().nullable(),
+	decimals: z.number().int().min(0).nullable(),
+	symbol: z.string().nullable(),
+});
+
+const reportProtocolFeeSchema = z.object({
+	configuredRatePermille: z.number().int().min(0).max(1000),
+	appliedRatePermille: z.number().int().min(0).max(1000).nullable(),
+	amounts: z.array(serializedReportAmountSchema).nullable(),
+	provenance: z.enum(['calculated', 'projected', 'exact_zero', 'not_applicable', 'insufficient_data']),
+	basis: z.enum(['stored_requested_plus_collateral', 'contract_version']).nullable(),
+	completeness: z.enum(['exact', 'reconstructed', 'not_applicable', 'insufficient_data']),
+});
+
+const reportSellerMetricsSchema = z.object({
+	grossRevenue: z.array(serializedReportAmountSchema).nullable(),
+	protocolFee: reportProtocolFeeSchema,
+	cardanoFees: z.array(serializedReportAmountSchema),
+	cardanoFeeTiming: z.enum(['stored_cumulative', 'accounting_allocation']),
+	netRevenue: z.array(serializedReportAmountSchema).nullable(),
+	payoutCompleteness: z.enum(['complete', 'partial']),
+});
+
+const reportBuyerMetricsSchema = z.object({
+	grossSpend: z.array(serializedReportAmountSchema).nullable(),
+	returnedFunds: z.array(serializedReportAmountSchema).nullable(),
+	cardanoFees: z.array(serializedReportAmountSchema),
+	cardanoFeeTiming: z.enum(['stored_cumulative', 'accounting_allocation']),
+	netSpend: z.array(serializedReportAmountSchema).nullable(),
+	payoutCompleteness: z.enum(['complete', 'partial']),
+});
+
+const reportManagedWalletSchema = z.object({
+	id: z.string(),
+	walletAddress: z.string(),
+	walletVkey: z.string(),
+	collectionAddress: z.string().nullable(),
+	deletedAt: z.date().nullable(),
+});
+
+const cardanoFeeReconciliationSchema = z.object({
+	buyerCardanoFees: serializedReportAmountSchema,
+	sellerCardanoFees: serializedReportAmountSchema,
+	adminCardanoFees: serializedReportAmountSchema.nullable(),
+	totalCardanoFees: serializedReportAmountSchema.nullable(),
+	completeness: z.enum(['complete', 'partial', 'inconsistent']),
+	isAggregationOwner: z.boolean(),
+});
+
+export const reportTransactionRowSchema = z.object({
+	id: z.string(),
+	role: reportRoleSchema,
+	requestType: z.enum(['PaymentRequest', 'PurchaseRequest']),
+	createdAt: z.date(),
+	blockchainIdentifier: z.string(),
+	agentIdentifier: z.string().nullable(),
+	agentName: z.string().nullable(),
+	onChainState: z.nativeEnum(OnChainState).nullable(),
+	metadata: z.string().nullable(),
+	managedWallet: reportManagedWalletSchema.nullable(),
+	counterpartyAddress: z.string().nullable(),
+	buyerReturnAddress: z.string().nullable(),
+	sellerReturnAddress: z.string().nullable(),
+	timestamps: z.object({
+		createdAt: z.date(),
+		fundsLockedAt: z.date().nullable(),
+		sellerRevenueRecognizedAt: z.date().nullable(),
+		buyerGrossSpendAt: z.date().nullable(),
+		buyerReturnedAt: z.date().nullable(),
+	}),
+	seller: reportSellerMetricsSchema.nullable(),
+	buyer: reportBuyerMetricsSchema.nullable(),
+	actorCardanoFeeAllocation: z.object({
+		strategy: z.enum(['accounting_allocation', 'lifetime_cohort']),
+		completeness: z.enum(['complete', 'partial']),
+		attachedAt: z.date().nullable(),
+	}),
+	feeAllocationScope: z.enum(['single_request', 'shared_or_unknown']),
+	feeComponentScope: z.enum(['complete', 'partial']),
+	cardanoFeeReconciliation: cardanoFeeReconciliationSchema,
+});
+
+export const reportWarningSchema = z.object({
+	code: z.string(),
+	message: z.string(),
+	rowId: z.string().nullable(),
+});
+
+const reportPaymentSourceSchema = z.object({
+	id: z.string(),
+	network: z.nativeEnum(Network),
+	paymentSourceType: z.nativeEnum(PaymentSourceType),
+	feeRatePermille: z.number().int().min(0).max(1000),
+	smartContractAddress: z.string(),
+	deletedAt: z.date().nullable(),
+});
+
+const normalizedFiltersSchema = z.object({
+	paymentSourceId: z.string(),
+	managedWalletIds: z.array(z.string()).nullable(),
+	externalAddresses: z.array(z.string()),
+	roles: z.array(reportRoleSchema),
+	states: z.array(reportStateFilterSchema),
+	from: z.date(),
+	to: z.date(),
+	dateBasis: dateBasisSchema,
+	revenueMode: revenueModeSchema,
+	timeZone: z.string(),
+});
+
+const reportMetadataSchema = z.object({
+	generatedAt: z.date(),
+	asOf: z.date(),
+	paymentSource: reportPaymentSourceSchema,
+	filters: normalizedFiltersSchema,
+	warnings: z.array(reportWarningSchema),
+});
+
+export const reportTransactionsOutputSchema = z.object({
+	rows: z.array(reportTransactionRowSchema),
+	page: z.object({
+		nextCursor: z.string().nullable(),
+		hasMore: z.boolean(),
+	}),
+	metadata: reportMetadataSchema,
+});
+
+const reportAggregateMetricSchema = z.object({
+	amounts: z.array(serializedReportAmountSchema),
+	completeness: z.enum(['complete', 'partial']),
+});
+
+const reportAggregateSchema = z.object({
+	transactionCount: z.number().int().min(0),
+	transactionCountCompleteness: z.enum(['complete', 'partial']),
+	sellerGrossRevenue: reportAggregateMetricSchema,
+	protocolFees: reportAggregateMetricSchema,
+	sellerCardanoFees: reportAggregateMetricSchema,
+	actorCardanoFees: reportAggregateMetricSchema,
+	sellerNetRevenue: reportAggregateMetricSchema,
+	buyerGrossSpend: reportAggregateMetricSchema,
+	returnedFunds: reportAggregateMetricSchema,
+	buyerCardanoFees: reportAggregateMetricSchema,
+	buyerNetSpend: reportAggregateMetricSchema,
+	adminCardanoFees: reportAggregateMetricSchema,
+	totalCardanoFees: reportAggregateMetricSchema,
+});
+
+export const reportSummaryOutputSchema = z.object({
+	totals: reportAggregateSchema,
+	wallets: z.array(
+		z.object({
+			managedWallet: reportManagedWalletSchema.nullable(),
+			role: reportRoleSchema,
+			metrics: reportAggregateSchema,
+		}),
+	),
+	history: z.array(
+		z.object({
+			bucketStart: z.date(),
+			bucketEnd: z.date(),
+			metrics: reportAggregateSchema,
+		}),
+	),
+	bucket: z.enum(['Day', 'Week', 'Month']),
+	metadata: reportMetadataSchema,
+});
+
+export const reportFacetsOutputSchema = z.object({
+	paymentSources: z.array(reportPaymentSourceSchema),
+	managedWallets: z.array(
+		z.object({
+			id: z.string(),
+			paymentSourceId: z.string(),
+			type: z.enum([HotWalletType.Selling, HotWalletType.Purchasing]),
+			walletAddress: z.string(),
+			walletVkey: z.string(),
+			collectionAddress: z.string().nullable(),
+			note: z.string().nullable(),
+			deletedAt: z.date().nullable(),
+		}),
+	),
+});
+
+export type ReportFilterInput = z.infer<typeof reportFilterSchema>;
+export type ReportTransactionsInput = z.infer<typeof reportTransactionsInputSchema>;
+export type ReportSummaryInput = z.infer<typeof reportSummaryInputSchema>;

--- a/src/services/transaction-report/csv.spec.ts
+++ b/src/services/transaction-report/csv.spec.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { MAINNET_USDCX_UNIT, MAINNET_USDM_UNIT, PREPROD_USDM_UNIT } from '@/utils/asset-units';
+import { aggregateReportRows } from './aggregate';
+import {
+	createTotalsCsv,
+	createTransactionsCsv,
+	createWalletSummaryCsv,
+	ReportCsvSizeLimitError,
+	type ReportCsvMetadata,
+} from './csv';
+import { buildReportRow, type ReportRequestRecord, type ReportRow } from './records';
+
+const FROM = new Date('2026-01-01T00:00:00.000Z');
+const TO = new Date('2026-02-01T00:00:00.000Z');
+const AS_OF = new Date('2026-02-02T00:00:00.000Z');
+
+function record(overrides: Partial<ReportRequestRecord> = {}): ReportRequestRecord {
+	return {
+		id: 'request-1',
+		role: 'Seller',
+		requestType: 'PaymentRequest',
+		createdAt: new Date('2026-01-02T03:04:05.000Z'),
+		blockchainIdentifier: 'chain-1',
+		agentIdentifier: 'agent-1',
+		agentName: 'Agent One',
+		onChainState: 'Withdrawn',
+		metadata: '{"source":"test"}',
+		managedWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-wallet',
+			walletVkey: 'wallet-vkey',
+			collectionAddress: 'addr-collection',
+			deletedAt: null,
+		},
+		counterpartyAddress: 'addr-counterparty',
+		buyerReturnAddress: null,
+		sellerReturnAddress: 'addr-seller-return',
+		paymentSourceType: 'Web3CardanoV1',
+		configuredFeeRatePermille: 50,
+		unlockTime: BigInt(new Date('2026-01-02T00:00:00.000Z').getTime()),
+		collateralReturnLovelace: 2_000_000n,
+		requestedFunds: [
+			{ unit: 'lovelace', amount: 1_234_567n },
+			{ unit: MAINNET_USDM_UNIT, amount: 2_500_000n },
+			{ unit: PREPROD_USDM_UNIT, amount: 500_000n },
+			{ unit: MAINNET_USDCX_UNIT, amount: 3_000_001n },
+			{ unit: 'zz-policy-token', amount: 4n },
+			{ unit: 'aa-policy-token', amount: 9_007_199_254_740_993n },
+		],
+		withdrawnForBuyer: [],
+		withdrawnForSeller: [],
+		buyerPayoutCompleteness: 'complete',
+		sellerPayoutCompleteness: 'complete',
+		buyerCardanoFees: 0n,
+		sellerCardanoFees: 123_456n,
+		transactions: [
+			{
+				id: 'transaction-1',
+				txHash: 'hash-1',
+				status: 'Confirmed',
+				newOnChainState: 'Withdrawn',
+				blockTime: Math.floor(new Date('2026-01-03T00:00:00.000Z').getTime() / 1000),
+				fees: 223_456n,
+				relatedRequestKeys: ['Seller:request-1'],
+				relatedPaymentKeys: ['chain-1'],
+			},
+		],
+		feeAllocationScope: 'single_request',
+		isFeeReconciliationOwner: true,
+		feeComponentScope: 'complete',
+		...overrides,
+	};
+}
+
+function row(overrides: Partial<ReportRequestRecord> = {}): ReportRow {
+	return buildReportRow(record(overrides), 'RequestedGross', AS_OF, {
+		dateBasis: 'CreatedAt',
+		from: FROM,
+		to: TO,
+	});
+}
+
+function metadata(overrides: Partial<ReportCsvMetadata> = {}): ReportCsvMetadata {
+	return {
+		generatedAt: new Date('2026-02-02T01:02:03.000Z'),
+		asOf: AS_OF,
+		paymentSource: {
+			id: 'source-1',
+			network: 'Preprod',
+			paymentSourceType: 'Web3CardanoV1',
+			feeRatePermille: 50,
+			smartContractAddress: 'addr-contract',
+			deletedAt: null,
+		},
+		filters: {
+			paymentSourceId: 'source-1',
+			managedWalletIds: ['wallet-z', 'wallet-a'],
+			externalAddresses: ['addr-z', 'addr-a'],
+			roles: ['Seller', 'Buyer'],
+			states: ['Withdrawn'],
+			from: FROM,
+			to: TO,
+			dateBasis: 'CreatedAt',
+			revenueMode: 'RequestedGross',
+			timeZone: 'Etc/UTC',
+		},
+		requestedBucket: 'Auto',
+		bucket: 'Day',
+		warnings: [
+			{ code: 'Z_WARNING', message: 'z', rowId: null },
+			{ code: 'A_WARNING', message: 'a', rowId: null },
+		],
+		...overrides,
+	};
+}
+
+function parseCsv(buffer: Buffer): string[][] {
+	const text = buffer.toString('utf8');
+	const rows: string[][] = [];
+	let rowValues: string[] = [];
+	let value = '';
+	let inQuotes = false;
+	for (let index = 0; index < text.length; index += 1) {
+		const character = text[index];
+		if (inQuotes) {
+			if (character === '"' && text[index + 1] === '"') {
+				value += '"';
+				index += 1;
+			} else if (character === '"') inQuotes = false;
+			else value += character;
+		} else if (character === '"') inQuotes = true;
+		else if (character === ',') {
+			rowValues.push(value);
+			value = '';
+		} else if (character === '\r' && text[index + 1] === '\n') {
+			rowValues.push(value);
+			rows.push(rowValues);
+			rowValues = [];
+			value = '';
+			index += 1;
+		} else value += character;
+	}
+	return rows;
+}
+
+function csvRecord(buffer: Buffer, rowIndex = 1): Record<string, string> {
+	const rows = parseCsv(buffer);
+	return Object.fromEntries(rows[0].map((header, index) => [header, rows[rowIndex][index]]));
+}
+
+describe('transaction report CSV', () => {
+	it('exports normalized asset decimals and exact unknown atomic amounts', () => {
+		const output = createTransactionsCsv([row()], metadata());
+		const values = csvRecord(output, 2);
+
+		expect(values.record_type).toBe('transaction');
+		expect(values.seller_gross_revenue_ada).toBe('1.234567');
+		expect(values.seller_gross_revenue_usdm).toBe('3.000000');
+		expect(values.seller_gross_revenue_usdcx).toBe('3.000001');
+		expect(values.seller_gross_revenue_other_assets_json).toBe(
+			'{"aa-policy-token":"9007199254740993","zz-policy-token":"4"}',
+		);
+		expect(values.protocol_fee_configured_rate_permille).toBe('50');
+		expect(values.protocol_fee_configured_rate_percent).toBe('5.0');
+		expect(values.protocol_fee_completeness).toBe('reconstructed');
+		expect(values.reconciliation_total_cardano_fee_ada).toBe('0.223456');
+		expect(values.reconciliation_completeness).toBe('partial');
+	});
+
+	it('keeps buyer metrics separate from non-applicable seller metrics', () => {
+		const buyer = row({
+			id: 'purchase-1',
+			role: 'Buyer',
+			requestType: 'PurchaseRequest',
+			buyerCardanoFees: 100_000n,
+			sellerCardanoFees: 0n,
+			transactions: [
+				{
+					...record().transactions[0],
+					id: 'buyer-lock',
+					txHash: 'buyer-lock-hash',
+					newOnChainState: 'FundsLocked',
+					fees: 0n,
+					relatedRequestKeys: ['Buyer:purchase-1'],
+				},
+			],
+		});
+		const values = csvRecord(createTransactionsCsv([buyer], metadata()), 2);
+
+		expect(values.role).toBe('Buyer');
+		expect(values.seller_gross_revenue_ada).toBe('');
+		expect(values.protocol_fee_ada).toBe('');
+		expect(values.buyer_gross_spend_ada).toBe('1.234567');
+		expect(values.buyer_gross_spend_usdm).toBe('3.000000');
+		expect(values.buyer_cardano_fees_ada).toBe('0.100000');
+		expect(values.buyer_cardano_fee_timing).toBe('stored_cumulative');
+		expect(values.buyer_payout_completeness).toBe('complete');
+	});
+
+	it('quotes every field, escapes quotes, and protects only untrusted formula-like text', () => {
+		const dangerous = row({
+			id: '\tcommand',
+			blockchainIdentifier: '\rcommand',
+			agentIdentifier: '+command',
+			agentName: '  =SUM("x",1)',
+			counterpartyAddress: '-command',
+			buyerReturnAddress: '@command',
+			metadata: '\ncommand',
+		});
+		const output = createTransactionsCsv([dangerous], metadata());
+		const values = csvRecord(output, 2);
+
+		expect(values.id).toBe("'\tcommand");
+		expect(values.blockchain_identifier).toBe("'\rcommand");
+		expect(values.agent_identifier).toBe("'+command");
+		expect(values.agent_name).toBe('\'  =SUM("x",1)');
+		expect(values.counterparty_address).toBe("'-command");
+		expect(values.buyer_return_address).toBe("'@command");
+		expect(values.metadata).toBe("'\ncommand");
+		expect(output.toString('utf8')).toContain('"\'  =SUM(""x"",1)"');
+		expect(values.seller_net_revenue_ada.startsWith("'")).toBe(false);
+	});
+
+	it('uses CRLF records and returns identical bytes for identical input', () => {
+		const reportRow = row();
+		const reportMetadata = metadata();
+		const first = createTransactionsCsv([reportRow], reportMetadata);
+		const second = createTransactionsCsv([reportRow], reportMetadata);
+		const withoutRecords = first.toString('utf8').replaceAll('\r\n', '');
+
+		expect(first.equals(second)).toBe(true);
+		expect(first.toString('utf8').endsWith('\r\n')).toBe(true);
+		expect(withoutRecords).not.toMatch(/[\r\n]/u);
+		expect(first.toString('utf8').startsWith('"generated_at","as_of","payment_source_id"')).toBe(true);
+	});
+
+	it('writes context once and leaves all transaction context cells blank', () => {
+		const output = createTransactionsCsv(
+			[row(), row({ id: 'request-2', blockchainIdentifier: 'chain-2' })],
+			metadata(),
+		);
+		const parsedRows = parseCsv(output);
+		const contextValues = csvRecord(output);
+		const firstValues = csvRecord(output, 2);
+		const secondValues = csvRecord(output, 3);
+		const recordTypeIndex = parsedRows[0].indexOf('record_type');
+
+		expect(parsedRows).toHaveLength(4);
+		expect(new Set(parsedRows[0]).size).toBe(parsedRows[0].length);
+		expect(parsedRows.slice(1).filter((values) => values[recordTypeIndex] === 'report_context')).toHaveLength(1);
+		expect(contextValues.generated_at).toBe('2026-02-02T01:02:03.000Z');
+		expect(contextValues.as_of).toBe('2026-02-02T00:00:00.000Z');
+		expect(contextValues.payment_source_id).toBe('source-1');
+		expect(contextValues.payment_source_network).toBe('Preprod');
+		expect(contextValues.payment_source_type).toBe('Web3CardanoV1');
+		expect(contextValues.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
+		expect(contextValues.filter_external_addresses_json).toBe('["addr-a","addr-z"]');
+		expect(contextValues.filter_roles_json).toBe('["Buyer","Seller"]');
+		expect(contextValues.filter_states_json).toBe('["Withdrawn"]');
+		expect(contextValues.filter_from).toBe('2026-01-01T00:00:00.000Z');
+		expect(contextValues.filter_to).toBe('2026-02-01T00:00:00.000Z');
+		expect(contextValues.filter_date_basis).toBe('CreatedAt');
+		expect(contextValues.filter_revenue_mode).toBe('RequestedGross');
+		expect(contextValues.filter_time_zone).toBe('Etc/UTC');
+		expect(contextValues.filter_bucket).toBe('Auto');
+		expect(contextValues.report_bucket).toBe('Day');
+		expect(firstValues.record_type).toBe('transaction');
+		expect(firstValues.payment_source_id).toBe('');
+		expect(firstValues.filter_states_json).toBe('');
+		expect(secondValues.record_type).toBe('transaction');
+		expect(secondValues.payment_source_id).toBe('');
+		expect(secondValues.filter_states_json).toBe('');
+	});
+
+	it('keeps an empty direct export auditable with one context record', () => {
+		const output = createTransactionsCsv([], metadata());
+		const rows = parseCsv(output);
+		const values = csvRecord(output);
+
+		expect(rows).toHaveLength(2);
+		expect(values.record_type).toBe('report_context');
+		expect(values.payment_source_id).toBe('source-1');
+		expect(values.filter_states_json).toBe('["Withdrawn"]');
+		expect(values.filter_bucket).toBe('Auto');
+		expect(values.report_bucket).toBe('Day');
+		expect(values.id).toBe('');
+		expect(values.seller_gross_revenue_ada).toBe('');
+	});
+
+	it('measures multibyte, quote, and formula escaping before allocating the final buffer', () => {
+		const reportRow = row({ agentName: '  =λ"😀,value' });
+		const unrestricted = createTransactionsCsv([reportRow], metadata());
+		const exactBytes = unrestricted.byteLength;
+
+		expect(createTransactionsCsv([reportRow], metadata(), { maxBytes: exactBytes })).toEqual(unrestricted);
+		expect(csvRecord(unrestricted, 2).agent_name).toBe('\'  =λ"😀,value');
+
+		const allocationSpy = jest.spyOn(Buffer, 'allocUnsafe');
+		let thrown: unknown;
+		try {
+			createTransactionsCsv([reportRow], metadata(), { maxBytes: exactBytes - 1 });
+		} catch (error) {
+			thrown = error;
+		}
+		const allocationCalls = allocationSpy.mock.calls.length;
+		allocationSpy.mockRestore();
+
+		expect(allocationCalls).toBe(0);
+		expect(thrown).toBeInstanceOf(ReportCsvSizeLimitError);
+		expect(thrown).toMatchObject({ maxBytes: exactBytes - 1, statusCode: 413 });
+	});
+});
+
+describe('transaction report aggregate CSV', () => {
+	it('includes exact source, filter, financial, and completeness context in totals', () => {
+		const reportRow = row();
+		const result = aggregateReportRows([reportRow], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
+		const output = createTotalsCsv(result, metadata());
+		const values = csvRecord(output);
+
+		expect(values.as_of).toBe('2026-02-02T00:00:00.000Z');
+		expect(values.payment_source_id).toBe('source-1');
+		expect(values.payment_source_fee_rate_percent).toBe('5.0');
+		expect(values.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
+		expect(values.filter_roles_json).toBe('["Buyer","Seller"]');
+		expect(values.warning_codes_json).toBe('["A_WARNING","Z_WARNING"]');
+		expect(values.transaction_count).toBe('1');
+		expect(values.seller_gross_revenue_ada).toBe('1.234567');
+		expect(values.seller_gross_revenue_completeness).toBe('complete');
+		expect(values.actor_cardano_fees_ada).toBe('0.123456');
+		expect(values.actor_cardano_fees_completeness).toBe('partial');
+		expect(values.admin_cardano_fees_ada).toBe('0.000000');
+		expect(values.total_cardano_fees_ada).toBe('0.223456');
+		expect(values.total_cardano_fees_completeness).toBe('complete');
+	});
+
+	it('sorts wallet rows and includes role-specific summary metrics', () => {
+		const first = row({ managedWallet: { ...record().managedWallet!, id: 'wallet-z' } });
+		const second = row({
+			id: 'request-2',
+			blockchainIdentifier: 'chain-2',
+			managedWallet: { ...record().managedWallet!, id: 'wallet-a' },
+		});
+		const result = aggregateReportRows([first, second], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
+		const output = createWalletSummaryCsv(result, metadata());
+		const rows = parseCsv(output);
+		const contextValues = csvRecord(output);
+		const firstValues = csvRecord(output, 2);
+		const secondValues = csvRecord(output, 3);
+		const recordTypeIndex = rows[0].indexOf('record_type');
+
+		expect(rows).toHaveLength(4);
+		expect(rows.slice(1).filter((values) => values[recordTypeIndex] === 'report_context')).toHaveLength(1);
+		expect(contextValues.payment_source_id).toBe('source-1');
+		expect(contextValues.report_bucket).toBe('Day');
+		expect(firstValues.record_type).toBe('wallet_summary');
+		expect(firstValues.payment_source_id).toBe('');
+		expect(firstValues.report_bucket).toBe('');
+		expect(firstValues.managed_wallet_id).toBe('wallet-a');
+		expect(firstValues.role).toBe('Seller');
+		expect(firstValues.seller_gross_revenue_usdm).toBe('3.000000');
+		expect(firstValues.protocol_fees_completeness).toBe('partial');
+		expect(firstValues.actor_cardano_fees_ada).toBe('0.123456');
+		expect(secondValues.record_type).toBe('wallet_summary');
+		expect(secondValues.payment_source_id).toBe('');
+	});
+
+	it('keeps an empty wallet summary auditable with blank wallet and metric fields', () => {
+		const result = aggregateReportRows([], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
+		const output = createWalletSummaryCsv(result, metadata());
+		const rows = parseCsv(output);
+		const values = csvRecord(output);
+
+		expect(rows).toHaveLength(2);
+		expect(values.record_type).toBe('report_context');
+		expect(values.payment_source_id).toBe('source-1');
+		expect(values.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
+		expect(values.report_bucket).toBe('Day');
+		expect(values.managed_wallet_id).toBe('');
+		expect(values.role).toBe('');
+		expect(values.transaction_count).toBe('');
+		expect(values.total_cardano_fees_ada).toBe('');
+		expect(values.total_cardano_fees_completeness).toBe('');
+	});
+});

--- a/src/services/transaction-report/csv.ts
+++ b/src/services/transaction-report/csv.ts
@@ -1,0 +1,533 @@
+import { constants as bufferConstants } from 'node:buffer';
+import type { ReportFilterInput } from '@/routes/api/reports/schemas';
+import { atomicToDecimalString, getReportAssetMetadata } from '@/utils/asset-units';
+import { normalizeAmounts, type AtomicAmount } from './amounts';
+import type {
+	ReportAggregate,
+	ReportAggregateMetric,
+	ReportAggregateResult,
+	ReportBucket,
+	RequestedReportBucket,
+} from './aggregate';
+import type { ReportRow, ReportWarning } from './records';
+
+type CsvCell = Readonly<{ value: string; isUntrusted: boolean }>;
+type AmountColumns = Readonly<{ ada: string; usdm: string; usdcx: string; otherAssets: string }>;
+
+type NormalizedReportFilters = Readonly<{
+	paymentSourceId: ReportFilterInput['paymentSourceId'];
+	managedWalletIds: readonly string[] | null;
+	externalAddresses: readonly string[];
+	roles: ReadonlyArray<ReportFilterInput['roles'][number]>;
+	states: ReadonlyArray<NonNullable<ReportFilterInput['states']>[number]>;
+	from: Date;
+	to: Date;
+	dateBasis: ReportFilterInput['dateBasis'];
+	revenueMode: ReportFilterInput['revenueMode'];
+	timeZone: ReportFilterInput['timeZone'];
+}>;
+
+export type ReportCsvMetadata = Readonly<{
+	generatedAt: Date;
+	asOf: Date;
+	paymentSource: Readonly<{
+		id: string;
+		network: string;
+		paymentSourceType: ReportRow['paymentSourceType'];
+		feeRatePermille: number;
+		smartContractAddress: string;
+		deletedAt: Date | null;
+	}>;
+	filters: NormalizedReportFilters;
+	requestedBucket: RequestedReportBucket;
+	bucket: ReportBucket;
+	warnings?: readonly ReportWarning[];
+}>;
+
+export type ReportCsvOptions = Readonly<{ maxBytes?: number }>;
+
+export const REPORT_CSV_MAX_BYTES = 64 * 1024 * 1024;
+
+export class ReportCsvSizeLimitError extends Error {
+	readonly statusCode = 413;
+
+	constructor(readonly maxBytes: number) {
+		super(`Report CSV exceeds ${maxBytes} bytes. Narrow the report filters.`);
+		this.name = 'ReportCsvSizeLimitError';
+	}
+}
+
+const AMOUNT_SUFFIXES = ['ada', 'usdm', 'usdcx', 'other_assets_json'] as const;
+const AGGREGATE_METRICS = [
+	'sellerGrossRevenue',
+	'protocolFees',
+	'sellerCardanoFees',
+	'sellerNetRevenue',
+	'buyerGrossSpend',
+	'returnedFunds',
+	'buyerCardanoFees',
+	'buyerNetSpend',
+	'actorCardanoFees',
+	'adminCardanoFees',
+	'totalCardanoFees',
+] as const satisfies ReadonlyArray<Exclude<keyof ReportAggregate, 'transactionCount' | 'transactionCountCompleteness'>>;
+
+const AGGREGATE_METRIC_NAMES: Record<(typeof AGGREGATE_METRICS)[number], string> = {
+	sellerGrossRevenue: 'seller_gross_revenue',
+	protocolFees: 'protocol_fees',
+	sellerCardanoFees: 'seller_cardano_fees',
+	sellerNetRevenue: 'seller_net_revenue',
+	buyerGrossSpend: 'buyer_gross_spend',
+	returnedFunds: 'returned_funds',
+	buyerCardanoFees: 'buyer_cardano_fees',
+	buyerNetSpend: 'buyer_net_spend',
+	actorCardanoFees: 'actor_cardano_fees',
+	adminCardanoFees: 'admin_cardano_fees',
+	totalCardanoFees: 'total_cardano_fees',
+};
+
+const CONTEXT_HEADERS = [
+	'generated_at',
+	'as_of',
+	'payment_source_id',
+	'payment_source_network',
+	'payment_source_type',
+	'payment_source_fee_rate_permille',
+	'payment_source_fee_rate_percent',
+	'payment_source_smart_contract_address',
+	'payment_source_deleted_at',
+	'filter_managed_wallet_ids_json',
+	'filter_external_addresses_json',
+	'filter_roles_json',
+	'filter_states_json',
+	'filter_from',
+	'filter_to',
+	'filter_date_basis',
+	'filter_revenue_mode',
+	'filter_time_zone',
+	'filter_bucket',
+	'report_bucket',
+	'warning_codes_json',
+] as const;
+
+function trusted(value: string | number | boolean | null | undefined): CsvCell {
+	return { value: value == null ? '' : String(value), isUntrusted: false };
+}
+
+function untrusted(value: string | null | undefined): CsvCell {
+	return { value: value ?? '', isUntrusted: true };
+}
+
+function dateCell(value: Date | null): CsvCell {
+	return trusted(value?.toISOString());
+}
+
+function stableStringArrayJson(values: readonly string[] | null): string {
+	return JSON.stringify(values == null ? null : [...new Set(values)].sort((left, right) => left.localeCompare(right)));
+}
+
+const CSV_RECORD_SEPARATOR = '\r\n';
+const CSV_RECORD_SEPARATOR_BYTES = Buffer.byteLength(CSV_RECORD_SEPARATOR, 'utf8');
+const CSV_DOUBLE_QUOTE_BYTE = 0x22;
+const CSV_FORMULA_PREFIX_BYTE = 0x27;
+const CSV_FIELD_SEPARATOR_BYTE = 0x2c;
+const CSV_CARRIAGE_RETURN_BYTE = 0x0d;
+const CSV_LINE_FEED_BYTE = 0x0a;
+
+function needsSpreadsheetFormulaProtection(cell: CsvCell): boolean {
+	return cell.isUntrusted && /^(?:[\t\r\n]|\s*[=+\-@])/u.test(cell.value);
+}
+
+function quoteCount(value: string): number {
+	let count = 0;
+	let index = value.indexOf('"');
+	while (index >= 0) {
+		count += 1;
+		index = value.indexOf('"', index + 1);
+	}
+	return count;
+}
+
+function csvCellByteLength(cell: CsvCell): number {
+	return (
+		2 +
+		Buffer.byteLength(cell.value, 'utf8') +
+		quoteCount(cell.value) +
+		(needsSpreadsheetFormulaProtection(cell) ? 1 : 0)
+	);
+}
+
+function csvRowByteLength(row: readonly CsvCell[]): number {
+	return (
+		row.reduce((total, cell) => total + csvCellByteLength(cell), 0) +
+		Math.max(0, row.length - 1) +
+		CSV_RECORD_SEPARATOR_BYTES
+	);
+}
+
+function writeCsvCell(output: Buffer, startOffset: number, cell: CsvCell): number {
+	let offset = startOffset;
+	output[offset] = CSV_DOUBLE_QUOTE_BYTE;
+	offset += 1;
+	if (needsSpreadsheetFormulaProtection(cell)) {
+		output[offset] = CSV_FORMULA_PREFIX_BYTE;
+		offset += 1;
+	}
+	let segmentStart = 0;
+	let quoteIndex = cell.value.indexOf('"');
+	while (quoteIndex >= 0) {
+		offset += output.write(cell.value.slice(segmentStart, quoteIndex), offset, 'utf8');
+		output[offset] = CSV_DOUBLE_QUOTE_BYTE;
+		output[offset + 1] = CSV_DOUBLE_QUOTE_BYTE;
+		offset += 2;
+		segmentStart = quoteIndex + 1;
+		quoteIndex = cell.value.indexOf('"', segmentStart);
+	}
+	offset += output.write(cell.value.slice(segmentStart), offset, 'utf8');
+	output[offset] = CSV_DOUBLE_QUOTE_BYTE;
+	return offset + 1;
+}
+
+function writeCsvRow(output: Buffer, startOffset: number, row: readonly CsvCell[]): number {
+	let offset = startOffset;
+	for (let index = 0; index < row.length; index += 1) {
+		if (index > 0) {
+			output[offset] = CSV_FIELD_SEPARATOR_BYTE;
+			offset += 1;
+		}
+		offset = writeCsvCell(output, offset, row[index]);
+	}
+	output[offset] = CSV_CARRIAGE_RETURN_BYTE;
+	output[offset + 1] = CSV_LINE_FEED_BYTE;
+	return offset + CSV_RECORD_SEPARATOR_BYTES;
+}
+
+function* csvRows(headers: readonly string[], rows: () => Iterable<readonly CsvCell[]>): Iterable<readonly CsvCell[]> {
+	yield headers.map(trusted);
+	yield* rows();
+}
+
+function csvMaxBytes(options: ReportCsvOptions): number {
+	const maxBytes = options.maxBytes ?? REPORT_CSV_MAX_BYTES;
+	if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0 || maxBytes > bufferConstants.MAX_LENGTH) {
+		throw new RangeError(`CSV maxBytes must be a positive integer no larger than ${bufferConstants.MAX_LENGTH}`);
+	}
+	return maxBytes;
+}
+
+function createCsv(
+	headers: readonly string[],
+	rows: () => Iterable<readonly CsvCell[]>,
+	options: ReportCsvOptions,
+): Buffer {
+	const maxBytes = csvMaxBytes(options);
+	let totalBytes = 0;
+	for (const row of csvRows(headers, rows)) {
+		if (row.length !== headers.length) throw new RangeError('CSV row does not match its header');
+		const rowBytes = csvRowByteLength(row);
+		if (rowBytes > maxBytes - totalBytes) throw new ReportCsvSizeLimitError(maxBytes);
+		totalBytes += rowBytes;
+	}
+
+	const output = Buffer.allocUnsafe(totalBytes);
+	let offset = 0;
+	for (const row of csvRows(headers, rows)) offset = writeCsvRow(output, offset, row);
+	if (offset !== totalBytes) throw new RangeError('CSV byte length changed during encoding');
+	return output;
+}
+
+function splitAmounts(amounts: readonly AtomicAmount[] | null): AmountColumns | null {
+	if (amounts == null) return null;
+	const known = new Map<'ada' | 'usdm' | 'usdcx', bigint>();
+	const other: Record<string, string> = {};
+	for (const amount of normalizeAmounts(amounts)) {
+		const metadata = getReportAssetMetadata(amount.unit);
+		if (metadata == null) other[amount.unit] = amount.amount.toString();
+		else known.set(metadata.key, (known.get(metadata.key) ?? 0n) + amount.amount);
+	}
+	return {
+		ada: atomicToDecimalString(known.get('ada') ?? 0n, 6),
+		usdm: atomicToDecimalString(known.get('usdm') ?? 0n, 6),
+		usdcx: atomicToDecimalString(known.get('usdcx') ?? 0n, 6),
+		otherAssets: JSON.stringify(other),
+	};
+}
+
+function amountHeaders(prefix: string): string[] {
+	return AMOUNT_SUFFIXES.map((suffix) => `${prefix}_${suffix}`);
+}
+
+function amountCells(amounts: readonly AtomicAmount[] | null): CsvCell[] {
+	const columns = splitAmounts(amounts);
+	return columns == null
+		? [trusted(''), trusted(''), trusted(''), trusted('')]
+		: [trusted(columns.ada), trusted(columns.usdm), trusted(columns.usdcx), trusted(columns.otherAssets)];
+}
+
+function aggregateMetricHeaders(prefix: string): string[] {
+	return [...amountHeaders(prefix), `${prefix}_completeness`];
+}
+
+function aggregateMetricCells(metric: ReportAggregateMetric): CsvCell[] {
+	return [...amountCells(metric.amounts), trusted(metric.completeness)];
+}
+
+function aggregateHeaders(): string[] {
+	return [
+		'transaction_count',
+		'transaction_count_completeness',
+		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricHeaders(AGGREGATE_METRIC_NAMES[metric])),
+	];
+}
+
+function aggregateCells(aggregate: ReportAggregate): CsvCell[] {
+	return [
+		trusted(aggregate.transactionCount),
+		trusted(aggregate.transactionCountCompleteness),
+		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricCells(aggregate[metric])),
+	];
+}
+
+function contextCells(metadata: ReportCsvMetadata): CsvCell[] {
+	const filters = metadata.filters;
+	const warningCodes = [...new Set((metadata.warnings ?? []).map((warning) => warning.code))].sort((left, right) =>
+		left.localeCompare(right),
+	);
+	return [
+		dateCell(metadata.generatedAt),
+		dateCell(metadata.asOf),
+		untrusted(metadata.paymentSource.id),
+		trusted(metadata.paymentSource.network),
+		trusted(metadata.paymentSource.paymentSourceType),
+		trusted(metadata.paymentSource.feeRatePermille),
+		trusted(atomicToDecimalString(BigInt(metadata.paymentSource.feeRatePermille), 1)),
+		untrusted(metadata.paymentSource.smartContractAddress),
+		dateCell(metadata.paymentSource.deletedAt),
+		trusted(stableStringArrayJson(filters.managedWalletIds)),
+		trusted(stableStringArrayJson(filters.externalAddresses)),
+		trusted(stableStringArrayJson(filters.roles)),
+		trusted(stableStringArrayJson(filters.states)),
+		dateCell(filters.from),
+		dateCell(filters.to),
+		trusted(filters.dateBasis),
+		trusted(filters.revenueMode),
+		untrusted(filters.timeZone),
+		trusted(metadata.requestedBucket),
+		trusted(metadata.bucket),
+		trusted(JSON.stringify(warningCodes)),
+	];
+}
+
+function rowAmountGroups(row: ReportRow): ReadonlyArray<readonly AtomicAmount[] | null> {
+	return [
+		row.seller?.grossRevenue ?? null,
+		row.seller?.protocolFee.amounts ?? null,
+		row.seller?.cardanoFees ?? null,
+		row.seller?.netRevenue ?? null,
+		row.buyer?.grossSpend ?? null,
+		row.buyer?.returnedFunds ?? null,
+		row.buyer?.cardanoFees ?? null,
+		row.buyer?.netSpend ?? null,
+	];
+}
+
+const TRANSACTION_AMOUNT_PREFIXES = [
+	'seller_gross_revenue',
+	'protocol_fee',
+	'seller_cardano_fees',
+	'seller_net_revenue',
+	'buyer_gross_spend',
+	'buyer_returned_funds',
+	'buyer_cardano_fees',
+	'buyer_net_spend',
+] as const;
+
+const TRANSACTION_HEADERS = [
+	'id',
+	'blockchain_identifier',
+	'role',
+	'request_type',
+	'on_chain_state',
+	'created_at',
+	'funds_locked_at',
+	'seller_revenue_recognized_at',
+	'buyer_gross_spend_at',
+	'buyer_returned_at',
+	'managed_wallet_id',
+	'managed_wallet_address',
+	'managed_wallet_vkey',
+	'managed_wallet_collection_address',
+	'managed_wallet_deleted_at',
+	'agent_identifier',
+	'agent_name',
+	'counterparty_address',
+	'buyer_return_address',
+	'seller_return_address',
+	'metadata',
+	...TRANSACTION_AMOUNT_PREFIXES.flatMap(amountHeaders),
+	'protocol_fee_configured_rate_permille',
+	'protocol_fee_configured_rate_percent',
+	'protocol_fee_applied_rate_permille',
+	'protocol_fee_applied_rate_percent',
+	'protocol_fee_provenance',
+	'protocol_fee_basis',
+	'protocol_fee_completeness',
+	'seller_payout_completeness',
+	'buyer_payout_completeness',
+	'seller_cardano_fee_timing',
+	'buyer_cardano_fee_timing',
+	'actor_cardano_fee_allocation_strategy',
+	'actor_cardano_fee_allocation_completeness',
+	'actor_cardano_fee_allocation_attached_at',
+	'fee_allocation_scope',
+	'fee_component_scope',
+	'reconciliation_buyer_cardano_fee_ada',
+	'reconciliation_seller_cardano_fee_ada',
+	'reconciliation_admin_cardano_fee_ada',
+	'reconciliation_total_cardano_fee_ada',
+	'reconciliation_completeness',
+	'reconciliation_is_aggregation_owner',
+] as const;
+
+function optionalPermillePercent(value: number | null): CsvCell {
+	return value == null ? trusted('') : trusted(atomicToDecimalString(BigInt(value), 1));
+}
+
+function optionalAda(value: bigint | null): CsvCell {
+	return value == null ? trusted('') : trusted(atomicToDecimalString(value, 6));
+}
+
+function transactionCells(row: ReportRow): CsvCell[] {
+	const protocolFee = row.seller?.protocolFee;
+	return [
+		untrusted(row.id),
+		untrusted(row.blockchainIdentifier),
+		trusted(row.role),
+		trusted(row.requestType),
+		trusted(row.onChainState),
+		dateCell(row.createdAt),
+		dateCell(row.timestamps.fundsLockedAt),
+		dateCell(row.timestamps.sellerRevenueRecognizedAt),
+		dateCell(row.timestamps.buyerGrossSpendAt),
+		dateCell(row.timestamps.buyerReturnedAt),
+		untrusted(row.managedWallet?.id),
+		untrusted(row.managedWallet?.walletAddress),
+		untrusted(row.managedWallet?.walletVkey),
+		untrusted(row.managedWallet?.collectionAddress),
+		dateCell(row.managedWallet?.deletedAt ?? null),
+		untrusted(row.agentIdentifier),
+		untrusted(row.agentName),
+		untrusted(row.counterpartyAddress),
+		untrusted(row.buyerReturnAddress),
+		untrusted(row.sellerReturnAddress),
+		untrusted(row.metadata),
+		...rowAmountGroups(row).flatMap(amountCells),
+		trusted(protocolFee?.configuredRatePermille),
+		optionalPermillePercent(protocolFee?.configuredRatePermille ?? null),
+		trusted(protocolFee?.appliedRatePermille),
+		optionalPermillePercent(protocolFee?.appliedRatePermille ?? null),
+		trusted(protocolFee?.provenance),
+		trusted(protocolFee?.basis),
+		trusted(protocolFee?.completeness),
+		trusted(row.seller == null ? '' : row.sellerPayoutCompleteness),
+		trusted(row.buyer == null ? '' : row.buyerPayoutCompleteness),
+		trusted(row.seller?.cardanoFeeTiming),
+		trusted(row.buyer?.cardanoFeeTiming),
+		trusted(row.actorCardanoFeeAllocation.strategy),
+		trusted(row.actorCardanoFeeAllocation.completeness),
+		dateCell(row.actorCardanoFeeAllocation.attachedAt),
+		trusted(row.feeAllocationScope),
+		trusted(row.feeComponentScope),
+		optionalAda(row.cardanoFeeReconciliation.buyerCardanoFees),
+		optionalAda(row.cardanoFeeReconciliation.sellerCardanoFees),
+		optionalAda(row.cardanoFeeReconciliation.adminCardanoFees),
+		optionalAda(row.cardanoFeeReconciliation.totalCardanoFees),
+		trusted(row.cardanoFeeReconciliation.completeness),
+		trusted(row.isFeeReconciliationOwner),
+	];
+}
+
+/**
+ * The file stays rectangular and standalone. One report_context row holds the filters and snapshot. Transaction rows
+ * leave those context cells blank, which keeps large exports bounded without losing audit data.
+ */
+export function createTransactionsCsv(
+	rows: readonly ReportRow[],
+	metadata: ReportCsvMetadata,
+	options: ReportCsvOptions = {},
+): Buffer {
+	const headers = [...CONTEXT_HEADERS, 'record_type', ...TRANSACTION_HEADERS];
+	const blankContextCells = CONTEXT_HEADERS.map(() => trusted(''));
+	function* outputRows(): Iterable<readonly CsvCell[]> {
+		yield [...contextCells(metadata), trusted('report_context'), ...TRANSACTION_HEADERS.map(() => trusted(''))];
+		for (const row of rows) {
+			yield [...blankContextCells, trusted('transaction'), ...transactionCells(row)];
+		}
+	}
+	return createCsv(headers, outputRows, options);
+}
+
+export function createWalletSummaryCsv(
+	result: ReportAggregateResult,
+	metadata: ReportCsvMetadata,
+	options: ReportCsvOptions = {},
+): Buffer {
+	const aggregateColumnHeaders = aggregateHeaders();
+	const walletColumnHeaders = [
+		'managed_wallet_id',
+		'managed_wallet_address',
+		'managed_wallet_vkey',
+		'managed_wallet_collection_address',
+		'managed_wallet_deleted_at',
+		'role',
+	] as const;
+	const headers = [
+		...CONTEXT_HEADERS,
+		'record_type',
+		'history_fee_completeness',
+		...walletColumnHeaders,
+		...aggregateColumnHeaders,
+	];
+	const wallets = [...result.wallets].sort((left, right) => {
+		const walletComparison = (left.managedWallet?.id ?? '').localeCompare(right.managedWallet?.id ?? '');
+		return walletComparison || left.role.localeCompare(right.role);
+	});
+	const blankContextCells = CONTEXT_HEADERS.map(() => trusted(''));
+	function* outputRows(): Iterable<readonly CsvCell[]> {
+		yield [
+			...contextCells(metadata),
+			trusted('report_context'),
+			trusted(result.historyFeeCompleteness),
+			...walletColumnHeaders.map(() => trusted('')),
+			...aggregateColumnHeaders.map(() => trusted('')),
+		];
+		for (const wallet of wallets) {
+			yield [
+				...blankContextCells,
+				trusted('wallet_summary'),
+				trusted(''),
+				untrusted(wallet.managedWallet?.id),
+				untrusted(wallet.managedWallet?.walletAddress),
+				untrusted(wallet.managedWallet?.walletVkey),
+				untrusted(wallet.managedWallet?.collectionAddress),
+				dateCell(wallet.managedWallet?.deletedAt ?? null),
+				trusted(wallet.role),
+				...aggregateCells(wallet.metrics),
+			];
+		}
+	}
+	return createCsv(headers, outputRows, options);
+}
+
+export function createTotalsCsv(
+	result: ReportAggregateResult,
+	metadata: ReportCsvMetadata,
+	options: ReportCsvOptions = {},
+): Buffer {
+	const headers = [...CONTEXT_HEADERS, 'history_fee_completeness', ...aggregateHeaders()];
+	const row = [...contextCells(metadata), trusted(result.historyFeeCompleteness), ...aggregateCells(result.totals)];
+	function* outputRows(): Iterable<readonly CsvCell[]> {
+		yield row;
+	}
+	return createCsv(headers, outputRows, options);
+}

--- a/src/services/transaction-report/export-files.spec.ts
+++ b/src/services/transaction-report/export-files.spec.ts
@@ -1,0 +1,116 @@
+import { access, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+import { unzipSync } from 'fflate';
+import { REPORT_CSV_CONTENT_TYPE, REPORT_ZIP_CONTENT_TYPE, stageReportCsv, stageReportZip } from './export-files';
+
+const csvFiles = {
+	transactions: Buffer.from('id,amount\r\ntransaction-1,1000000\r\n', 'utf8'),
+	walletSummary: Buffer.from('wallet_id,revenue\r\nwallet-1,950000\r\n', 'utf8'),
+	totals: Buffer.from('gross,fees,net\r\n1000000,50000,950000\r\n', 'utf8'),
+};
+
+describe('stageReportCsv', () => {
+	it('stages an exact private CSV file and reports its metadata', async () => {
+		const csv = Buffer.from('name,value\r\nAda,1.000000\r\n', 'utf8');
+		const artifact = await stageReportCsv(csv, 'transactions-20260824');
+
+		try {
+			expect(artifact.filename).toBe('transactions-20260824.csv');
+			expect(artifact.contentType).toBe(REPORT_CSV_CONTENT_TYPE);
+			expect(artifact.contentLength).toBe(csv.byteLength);
+			expect(await readFile(artifact.filePath)).toEqual(csv);
+
+			const directoryStats = await stat(dirname(artifact.filePath));
+			const fileStats = await stat(artifact.filePath);
+			expect(directoryStats.mode & 0o777).toBe(0o700);
+			expect(fileStats.mode & 0o777).toBe(0o600);
+		} finally {
+			await artifact.cleanup();
+		}
+	});
+
+	it('cleans staged data idempotently', async () => {
+		const artifact = await stageReportCsv(Buffer.from('value\r\n1\r\n'), 'totals');
+		const tempDirectory = dirname(artifact.filePath);
+
+		await Promise.all([artifact.cleanup(), artifact.cleanup(), artifact.cleanup()]);
+		await expect(access(tempDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
+		await expect(artifact.cleanup()).resolves.toBeUndefined();
+	});
+});
+
+describe('stageReportZip', () => {
+	it('stages exactly three CSV members without changing their bytes', async () => {
+		const artifact = await stageReportZip(csvFiles, 'financial-report');
+
+		try {
+			const zipBytes = await readFile(artifact.filePath);
+			const members = unzipSync(zipBytes);
+
+			expect(Object.keys(members).sort()).toEqual(['totals.csv', 'transactions.csv', 'wallet-summary.csv']);
+			expect(Buffer.from(members['transactions.csv'])).toEqual(csvFiles.transactions);
+			expect(Buffer.from(members['wallet-summary.csv'])).toEqual(csvFiles.walletSummary);
+			expect(Buffer.from(members['totals.csv'])).toEqual(csvFiles.totals);
+			expect(artifact.filename).toBe('financial-report.zip');
+			expect(artifact.contentType).toBe(REPORT_ZIP_CONTENT_TYPE);
+			expect(artifact.contentLength).toBe(zipBytes.byteLength);
+		} finally {
+			await artifact.cleanup();
+		}
+	});
+
+	it('removes staged temp data when ZIP creation fails', async () => {
+		const isolatedTempRoot = await mkdtemp(join(tmpdir(), 'masumi-export-failure-test-'));
+		const previousTempDirectory = process.env.TMPDIR;
+
+		try {
+			process.env.TMPDIR = isolatedTempRoot;
+			await expect(
+				stageReportZip(
+					{
+						...csvFiles,
+						transactions: null as unknown as Buffer,
+					},
+					'failed-report',
+				),
+			).rejects.toThrow();
+			expect(await readdir(isolatedTempRoot)).toEqual([]);
+		} finally {
+			if (previousTempDirectory == null) {
+				delete process.env.TMPDIR;
+			} else {
+				process.env.TMPDIR = previousTempDirectory;
+			}
+			await rm(isolatedTempRoot, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('report export download base names', () => {
+	it.each([
+		'',
+		'.',
+		'../report',
+		'report.csv',
+		'report name',
+		'_report',
+		'report/child',
+		'report\\child',
+		'a'.repeat(101),
+	])('rejects invalid base name %j before staging', async (downloadBaseName) => {
+		await expect(stageReportCsv(Buffer.alloc(0), downloadBaseName)).rejects.toThrow(TypeError);
+		await expect(stageReportZip(csvFiles, downloadBaseName)).rejects.toThrow(TypeError);
+	});
+
+	it.each(['r', 'Report_2026-08-24', 'transactions'])('accepts valid base name %j', async (downloadBaseName) => {
+		const artifact = await stageReportCsv(Buffer.alloc(0), downloadBaseName);
+
+		try {
+			expect(artifact.filename).toBe(`${downloadBaseName}.csv`);
+		} finally {
+			await artifact.cleanup();
+		}
+	});
+});

--- a/src/services/transaction-report/export-files.ts
+++ b/src/services/transaction-report/export-files.ts
@@ -1,0 +1,154 @@
+import { chmod, mkdtemp, open, rm, stat, type FileHandle } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Zip, ZipDeflate } from 'fflate';
+
+const REPORT_EXPORT_TEMP_PREFIX = 'masumi-report-';
+const DOWNLOAD_BASE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$/;
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+export const REPORT_CSV_CONTENT_TYPE = 'text/csv; charset=utf-8';
+export const REPORT_ZIP_CONTENT_TYPE = 'application/zip';
+
+export type StagedReportArtifact = {
+	filePath: string;
+	filename: string;
+	contentType: typeof REPORT_CSV_CONTENT_TYPE | typeof REPORT_ZIP_CONTENT_TYPE;
+	contentLength: number;
+	cleanup: () => Promise<void>;
+};
+
+export type ReportCsvFiles = {
+	transactions: Buffer;
+	walletSummary: Buffer;
+	totals: Buffer;
+};
+
+type ArtifactWriter = (filePath: string) => Promise<void>;
+
+function validateDownloadBaseName(downloadBaseName: string): void {
+	if (!DOWNLOAD_BASE_NAME_PATTERN.test(downloadBaseName)) {
+		throw new TypeError(
+			'Download base name must contain 1 to 100 ASCII letters, digits, underscores, or hyphens and start with a letter or digit',
+		);
+	}
+}
+
+function createCleanup(tempDirectory: string): () => Promise<void> {
+	let cleanupPromise: Promise<void> | null = null;
+
+	return () => {
+		cleanupPromise ??= rm(tempDirectory, { recursive: true, force: true });
+		return cleanupPromise;
+	};
+}
+
+async function writeBufferExclusive(filePath: string, content: Buffer): Promise<void> {
+	let fileHandle: FileHandle | null = null;
+
+	try {
+		fileHandle = await open(filePath, 'wx', PRIVATE_FILE_MODE);
+		await fileHandle.writeFile(content);
+		await fileHandle.sync();
+	} finally {
+		await fileHandle?.close();
+	}
+}
+
+async function writeZipExclusive(filePath: string, files: ReportCsvFiles): Promise<void> {
+	const fileHandle = await open(filePath, 'wx', PRIVATE_FILE_MODE);
+	let pendingWrite = Promise.resolve();
+	let resolveArchive: (() => void) | null = null;
+	let rejectArchive: ((error: unknown) => void) | null = null;
+	const archiveComplete = new Promise<void>((resolve, reject) => {
+		resolveArchive = resolve;
+		rejectArchive = reject;
+	});
+	const archive = new Zip((error, data, final) => {
+		if (error != null) {
+			rejectArchive?.(error);
+			return;
+		}
+
+		const chunk = Buffer.from(data);
+		pendingWrite = pendingWrite.then(async () => {
+			await fileHandle.writeFile(chunk);
+		});
+
+		if (final) {
+			void pendingWrite.then(
+				() => resolveArchive?.(),
+				(error_) => rejectArchive?.(error_),
+			);
+		}
+	});
+
+	try {
+		for (const [filename, content] of [
+			['transactions.csv', files.transactions],
+			['wallet-summary.csv', files.walletSummary],
+			['totals.csv', files.totals],
+		] as const) {
+			const member = new ZipDeflate(filename);
+			archive.add(member);
+			member.push(content, true);
+		}
+		archive.end();
+		await archiveComplete;
+		await fileHandle.sync();
+	} catch (error) {
+		archive.terminate();
+		await pendingWrite.catch(() => undefined);
+		throw error;
+	} finally {
+		await fileHandle.close();
+	}
+}
+
+async function stageArtifact(
+	downloadBaseName: string,
+	extension: 'csv' | 'zip',
+	contentType: StagedReportArtifact['contentType'],
+	writeArtifact: ArtifactWriter,
+): Promise<StagedReportArtifact> {
+	validateDownloadBaseName(downloadBaseName);
+
+	const tempDirectory = await mkdtemp(join(tmpdir(), REPORT_EXPORT_TEMP_PREFIX));
+	const cleanup = createCleanup(tempDirectory);
+	const filename = `${downloadBaseName}.${extension}`;
+	const filePath = join(tempDirectory, filename);
+
+	try {
+		await chmod(tempDirectory, PRIVATE_DIRECTORY_MODE);
+		await writeArtifact(filePath);
+		await chmod(filePath, PRIVATE_FILE_MODE);
+		const fileStats = await stat(filePath);
+		if (!fileStats.isFile()) {
+			throw new Error('Staged report artifact is not a regular file');
+		}
+
+		return {
+			filePath,
+			filename,
+			contentType,
+			contentLength: fileStats.size,
+			cleanup,
+		};
+	} catch (error) {
+		await cleanup();
+		throw error;
+	}
+}
+
+export async function stageReportCsv(csv: Buffer, downloadBaseName: string): Promise<StagedReportArtifact> {
+	return stageArtifact(downloadBaseName, 'csv', REPORT_CSV_CONTENT_TYPE, async (filePath) => {
+		await writeBufferExclusive(filePath, csv);
+	});
+}
+
+export async function stageReportZip(files: ReportCsvFiles, downloadBaseName: string): Promise<StagedReportArtifact> {
+	return stageArtifact(downloadBaseName, 'zip', REPORT_ZIP_CONTENT_TYPE, async (filePath) => {
+		await writeZipExclusive(filePath, files);
+	});
+}

--- a/src/services/transaction-report/export-service.spec.ts
+++ b/src/services/transaction-report/export-service.spec.ts
@@ -1,0 +1,330 @@
+import { jest } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import type { ReportSummaryInput } from '@/routes/api/reports/schemas';
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+const mockGetCompleteReportData = jest.fn() as AnyMock;
+const mockCreateTransactionsCsv = jest.fn() as AnyMock;
+const mockCreateWalletSummaryCsv = jest.fn() as AnyMock;
+const mockCreateTotalsCsv = jest.fn() as AnyMock;
+const mockStageReportCsv = jest.fn() as AnyMock;
+const mockStageReportZip = jest.fn() as AnyMock;
+const mockLoggerError = jest.fn() as AnyMock;
+const MOCK_CSV_MAX_BYTES = 64;
+
+class MockReportCsvSizeLimitError extends Error {
+	constructor(readonly maxBytes: number) {
+		super(`Report CSV exceeds ${maxBytes} bytes. Narrow the report filters.`);
+	}
+}
+
+jest.unstable_mockModule('./service', () => ({ getCompleteReportData: mockGetCompleteReportData }));
+jest.unstable_mockModule('./csv', () => ({
+	createTransactionsCsv: mockCreateTransactionsCsv,
+	createWalletSummaryCsv: mockCreateWalletSummaryCsv,
+	createTotalsCsv: mockCreateTotalsCsv,
+	REPORT_CSV_MAX_BYTES: MOCK_CSV_MAX_BYTES,
+	ReportCsvSizeLimitError: MockReportCsvSizeLimitError,
+}));
+jest.unstable_mockModule('./export-files', () => ({
+	stageReportCsv: mockStageReportCsv,
+	stageReportZip: mockStageReportZip,
+}));
+jest.unstable_mockModule('@masumi/payment-core/logger', () => ({ logger: { error: mockLoggerError } }));
+
+const { createReportExport } = await import('./export-service');
+
+const input = {
+	paymentSourceId: 'source-1',
+	roles: ['Buyer', 'Seller'],
+	states: [],
+	from: new Date('2026-01-01T00:00:00.000Z'),
+	to: new Date('2026-02-01T00:00:00.000Z'),
+	dateBasis: 'RevenueRecognizedAt',
+	revenueMode: 'Billable',
+	timeZone: 'Etc/UTC',
+	bucket: 'Day',
+} satisfies ReportSummaryInput;
+
+const ctx = { id: 'api-key-1', canRead: true } as AuthContext;
+const transactions = Buffer.from('transactions');
+const walletSummary = Buffer.from('wallet-summary');
+const totals = Buffer.from('totals');
+const report = {
+	rows: [{ id: 'row-1' }],
+	aggregate: { totals: {}, wallets: [], bucket: 'Day' },
+	metadata: { generatedAt: new Date('2026-08-24T12:34:56.789Z') },
+};
+const artifact = {
+	filePath: '/tmp/report.csv',
+	filename: 'report.csv',
+	contentType: 'text/csv; charset=utf-8',
+	contentLength: 10,
+	cleanup: jest.fn(),
+};
+
+describe('createReportExport', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockGetCompleteReportData.mockResolvedValue(report);
+		mockCreateTransactionsCsv.mockReturnValue(transactions);
+		mockCreateWalletSummaryCsv.mockReturnValue(walletSummary);
+		mockCreateTotalsCsv.mockReturnValue(totals);
+		mockStageReportCsv.mockResolvedValue(artifact);
+		mockStageReportZip.mockResolvedValue({ ...artifact, filename: 'report.zip', contentType: 'application/zip' });
+	});
+
+	it.each([
+		['transactions', transactions, mockCreateTransactionsCsv, 'masumi-transactions-20260824T123456Z'],
+		['wallet-summary', walletSummary, mockCreateWalletSummaryCsv, 'masumi-wallet-summary-20260824T123456Z'],
+		['totals', totals, mockCreateTotalsCsv, 'masumi-totals-20260824T123456Z'],
+	] as const)('stages the direct %s CSV from one report snapshot', async (kind, expected, generator, baseName) => {
+		const result = await createReportExport(input, ctx, kind);
+
+		expect(result).toBe(artifact);
+		expect(mockGetCompleteReportData).toHaveBeenCalledWith(input, ctx, undefined);
+		expect(mockGetCompleteReportData).toHaveBeenCalledTimes(1);
+		expect(generator).toHaveBeenCalledWith(
+			kind === 'transactions' ? report.rows : report.aggregate,
+			expect.objectContaining({ requestedBucket: 'Day', bucket: 'Day' }),
+		);
+		expect(mockStageReportCsv).toHaveBeenCalledWith(expected, baseName);
+		expect(mockStageReportZip).not.toHaveBeenCalled();
+	});
+
+	it('stages one ZIP from the same three CSV buffers', async () => {
+		await createReportExport(input, ctx, 'zip');
+
+		expect(mockGetCompleteReportData).toHaveBeenCalledTimes(1);
+		expect(mockCreateTransactionsCsv).toHaveBeenCalledWith(
+			report.rows,
+			expect.objectContaining({
+				requestedBucket: 'Day',
+				bucket: 'Day',
+			}),
+			{
+				maxBytes: MOCK_CSV_MAX_BYTES,
+			},
+		);
+		expect(mockCreateWalletSummaryCsv).toHaveBeenCalledWith(
+			report.aggregate,
+			expect.objectContaining({
+				requestedBucket: 'Day',
+				bucket: 'Day',
+			}),
+			{
+				maxBytes: MOCK_CSV_MAX_BYTES - transactions.byteLength,
+			},
+		);
+		expect(mockCreateTotalsCsv).toHaveBeenCalledWith(
+			report.aggregate,
+			expect.objectContaining({
+				requestedBucket: 'Day',
+				bucket: 'Day',
+			}),
+			{
+				maxBytes: MOCK_CSV_MAX_BYTES - transactions.byteLength - walletSummary.byteLength,
+			},
+		);
+		expect(mockStageReportZip).toHaveBeenCalledWith(
+			{ transactions, walletSummary, totals },
+			'masumi-transaction-report-20260824T123456Z',
+		);
+		expect(mockStageReportCsv).not.toHaveBeenCalled();
+	});
+
+	it('rejects a ZIP when its combined CSV members exceed the byte limit', async () => {
+		const oversizedTransactions = Buffer.alloc(40);
+		const oversizedWalletSummary = Buffer.alloc(20);
+		const oversizedTotals = Buffer.alloc(5);
+		mockCreateTransactionsCsv.mockReturnValue(oversizedTransactions);
+		mockCreateWalletSummaryCsv.mockReturnValue(oversizedWalletSummary);
+		mockCreateTotalsCsv.mockReturnValue(oversizedTotals);
+
+		await expect(createReportExport(input, ctx, 'zip')).rejects.toMatchObject({
+			statusCode: 413,
+			expose: true,
+			message: 'Report CSV exceeds 64 bytes. Narrow the report filters.',
+		});
+		expect(mockCreateTotalsCsv).toHaveBeenCalledWith(
+			report.aggregate,
+			expect.objectContaining({ requestedBucket: 'Day', bucket: 'Day' }),
+			{ maxBytes: 4 },
+		);
+		expect(mockStageReportZip).not.toHaveBeenCalled();
+	});
+
+	it('cleans up a staged ZIP when archive overhead exceeds the byte limit', async () => {
+		const cleanup = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+		mockStageReportZip.mockResolvedValue({
+			...artifact,
+			contentLength: MOCK_CSV_MAX_BYTES + 1,
+			cleanup,
+		});
+
+		await expect(createReportExport(input, ctx, 'zip')).rejects.toMatchObject({
+			statusCode: 413,
+			expose: true,
+			message: 'Report CSV exceeds 64 bytes. Narrow the report filters.',
+		});
+		expect(cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it('maps the CSV byte limit to a public 413 response', async () => {
+		mockCreateTransactionsCsv.mockImplementation(() => {
+			throw new MockReportCsvSizeLimitError(64);
+		});
+
+		await expect(createReportExport(input, ctx, 'transactions')).rejects.toMatchObject({
+			statusCode: 413,
+			expose: true,
+			message: 'Report CSV exceeds 64 bytes. Narrow the report filters.',
+		});
+		expect(mockStageReportCsv).not.toHaveBeenCalled();
+	});
+
+	it('rejects before CSV work when report loading exhausts the export deadline', async () => {
+		const now = jest.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(31_000);
+
+		await expect(createReportExport(input, ctx, 'transactions')).rejects.toMatchObject({
+			statusCode: 504,
+			expose: false,
+			message: 'Report export timed out. Narrow the report filters.',
+		});
+		expect(mockCreateTransactionsCsv).not.toHaveBeenCalled();
+		expect(mockStageReportCsv).not.toHaveBeenCalled();
+		now.mockRestore();
+	});
+
+	it('rejects before report loading when the request is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(createReportExport(input, ctx, 'transactions', controller.signal)).rejects.toMatchObject({
+			statusCode: 504,
+			message: 'Report export timed out. Narrow the report filters.',
+		});
+		expect(mockGetCompleteReportData).not.toHaveBeenCalled();
+		expect(mockCreateTransactionsCsv).not.toHaveBeenCalled();
+	});
+
+	it('stops before CSV work when the request aborts during report loading', async () => {
+		const controller = new AbortController();
+		let resolveReport!: (value: typeof report) => void;
+		mockGetCompleteReportData.mockReturnValue(
+			new Promise<typeof report>((resolve) => {
+				resolveReport = resolve;
+			}),
+		);
+		const result = createReportExport(input, ctx, 'transactions', controller.signal);
+
+		controller.abort();
+		resolveReport(report);
+		await expect(result).rejects.toMatchObject({ statusCode: 504 });
+		expect(mockGetCompleteReportData).toHaveBeenCalledWith(input, ctx, controller.signal);
+		expect(mockCreateTransactionsCsv).not.toHaveBeenCalled();
+	});
+
+	it('returns 504 at the export deadline and tracks report loading until it settles', async () => {
+		jest.useFakeTimers();
+		let resolveReport!: (value: typeof report) => void;
+		const pendingReport = new Promise<typeof report>((resolve) => {
+			resolveReport = resolve;
+		});
+		mockGetCompleteReportData.mockReturnValue(pendingReport);
+		const trackPendingWork = jest.fn<(work: Promise<unknown>) => void>();
+		let outcome: unknown = 'pending';
+		const result = createReportExport(input, ctx, 'transactions', undefined, trackPendingWork);
+		void result.then(
+			(value) => {
+				outcome = value;
+			},
+			(error: unknown) => {
+				outcome = error;
+			},
+		);
+
+		await jest.advanceTimersByTimeAsync(30_000);
+		await Promise.resolve();
+		const outcomeAtDeadline = outcome;
+		resolveReport(report);
+		await result.catch(() => undefined);
+		jest.useRealTimers();
+
+		expect(outcomeAtDeadline).toMatchObject({ statusCode: 504 });
+		expect(trackPendingWork).toHaveBeenCalledWith(pendingReport);
+		expect(mockCreateTransactionsCsv).not.toHaveBeenCalled();
+	});
+
+	it('cleans a staging result that resolves after the export timeout', async () => {
+		jest.useFakeTimers();
+		let resolveArtifact!: (value: typeof artifact) => void;
+		const pendingArtifact = new Promise<typeof artifact>((resolve) => {
+			resolveArtifact = resolve;
+		});
+		mockStageReportCsv.mockReturnValue(pendingArtifact);
+		const result = createReportExport(input, ctx, 'transactions');
+		const rejection = expect(result).rejects.toMatchObject({ statusCode: 504 });
+		await Promise.resolve();
+
+		await jest.advanceTimersByTimeAsync(30_000);
+		await rejection;
+		resolveArtifact(artifact);
+		await jest.runAllTimersAsync();
+		await Promise.resolve();
+		expect(artifact.cleanup).toHaveBeenCalledTimes(1);
+		jest.useRealTimers();
+	});
+
+	it('stops waiting for staging and cleans its late result after a request abort', async () => {
+		let resolveArtifact!: (value: typeof artifact) => void;
+		mockStageReportCsv.mockReturnValue(
+			new Promise<typeof artifact>((resolve) => {
+				resolveArtifact = resolve;
+			}),
+		);
+		const controller = new AbortController();
+		const result = createReportExport(input, ctx, 'transactions', controller.signal);
+		for (let attempt = 0; attempt < 5 && mockStageReportCsv.mock.calls.length === 0; attempt += 1) {
+			await Promise.resolve();
+		}
+		expect(mockStageReportCsv).toHaveBeenCalledTimes(1);
+		controller.abort();
+
+		const settledResult = result.catch((error: unknown) => error);
+		const outcome = await Promise.race([
+			settledResult,
+			new Promise<'still-pending'>((resolve) => setImmediate(() => resolve('still-pending'))),
+		]);
+		resolveArtifact(artifact);
+		await settledResult;
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(outcome).toMatchObject({ statusCode: 504 });
+		expect(artifact.cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it('cleans a staged artifact when staging exhausts the export deadline', async () => {
+		const cleanup = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+		mockStageReportCsv.mockResolvedValue({ ...artifact, cleanup });
+		const now = jest
+			.spyOn(Date, 'now')
+			.mockReturnValueOnce(1_000)
+			.mockReturnValueOnce(1_001)
+			.mockReturnValueOnce(1_002)
+			.mockReturnValueOnce(1_003)
+			.mockReturnValueOnce(1_004)
+			.mockReturnValueOnce(31_000);
+
+		await expect(createReportExport(input, ctx, 'transactions')).rejects.toMatchObject({
+			statusCode: 504,
+			expose: false,
+			message: 'Report export timed out. Narrow the report filters.',
+		});
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		now.mockRestore();
+	});
+});

--- a/src/services/transaction-report/export-service.ts
+++ b/src/services/transaction-report/export-service.ts
@@ -1,0 +1,185 @@
+import createHttpError from 'http-errors';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { logger } from '@masumi/payment-core/logger';
+import type { ReportSummaryInput } from '@/routes/api/reports/schemas';
+import {
+	createTotalsCsv,
+	createTransactionsCsv,
+	createWalletSummaryCsv,
+	REPORT_CSV_MAX_BYTES,
+	ReportCsvSizeLimitError,
+} from './csv';
+import { stageReportCsv, stageReportZip, type StagedReportArtifact } from './export-files';
+import { getCompleteReportData } from './service';
+
+export type ReportExportKind = 'transactions' | 'wallet-summary' | 'totals' | 'zip';
+
+const REPORT_EXPORT_TIMEOUT_MS = 30_000;
+
+function exportTimestamp(value: Date): string {
+	return value
+		.toISOString()
+		.replaceAll('-', '')
+		.replaceAll(':', '')
+		.replace(/\.\d{3}Z$/, 'Z');
+}
+
+function remainingZipCsvBytes(usedBytes: number): number {
+	const remainingBytes = REPORT_CSV_MAX_BYTES - usedBytes;
+	if (remainingBytes <= 0) {
+		throw new ReportCsvSizeLimitError(REPORT_CSV_MAX_BYTES);
+	}
+	return remainingBytes;
+}
+
+function assertExportDeadline(deadline: number, signal?: AbortSignal): void {
+	if (signal?.aborted || Date.now() >= deadline) {
+		throw createHttpError(504, 'Report export timed out. Narrow the report filters.');
+	}
+}
+
+function exportTimeoutError() {
+	return createHttpError(504, 'Report export timed out. Narrow the report filters.');
+}
+
+async function awaitBeforeExportDeadline<T>(
+	operation: Promise<T>,
+	deadline: number,
+	cleanupLateResult?: (value: T) => Promise<void>,
+	signal?: AbortSignal,
+): Promise<T> {
+	const remainingMilliseconds = deadline - Date.now();
+	const cleanLateResult = () => {
+		if (cleanupLateResult == null) return;
+		void operation
+			.then(cleanupLateResult)
+			.catch((lateError: unknown) => logger.error('Late report export cleanup failed', { error: lateError }));
+	};
+	if (signal?.aborted || remainingMilliseconds <= 0) {
+		cleanLateResult();
+		throw exportTimeoutError();
+	}
+	let didTimeout = false;
+	let didAbort = false;
+	let timeout: NodeJS.Timeout | undefined;
+	let handleAbort: (() => void) | undefined;
+	const timeoutResult = new Promise<never>((_resolve, reject) => {
+		timeout = setTimeout(() => {
+			didTimeout = true;
+			reject(exportTimeoutError());
+		}, remainingMilliseconds);
+	});
+	const abortResult = new Promise<never>((_resolve, reject) => {
+		if (signal == null) return;
+		handleAbort = () => {
+			didAbort = true;
+			reject(exportTimeoutError());
+		};
+		signal.addEventListener('abort', handleAbort, { once: true });
+		if (signal.aborted) handleAbort();
+	});
+	try {
+		return await Promise.race([operation, timeoutResult, abortResult]);
+	} catch (error) {
+		if (didTimeout || didAbort) cleanLateResult();
+		throw error;
+	} finally {
+		if (timeout != null) clearTimeout(timeout);
+		if (handleAbort != null) signal?.removeEventListener('abort', handleAbort);
+	}
+}
+
+async function returnStagedArtifactBeforeDeadline(
+	artifact: StagedReportArtifact,
+	deadline: number,
+	signal?: AbortSignal,
+): Promise<StagedReportArtifact> {
+	if (!signal?.aborted && Date.now() < deadline) return artifact;
+	await artifact.cleanup();
+	throw createHttpError(504, 'Report export timed out. Narrow the report filters.');
+}
+
+export async function createReportExport(
+	input: ReportSummaryInput,
+	ctx: AuthContext,
+	kind: ReportExportKind,
+	signal?: AbortSignal,
+	trackPendingWork?: (work: Promise<unknown>) => void,
+): Promise<StagedReportArtifact> {
+	if (signal?.aborted) throw exportTimeoutError();
+	const deadline = Date.now() + REPORT_EXPORT_TIMEOUT_MS;
+	const reportOperation = getCompleteReportData(input, ctx, signal);
+	trackPendingWork?.(reportOperation);
+	const report = await awaitBeforeExportDeadline(reportOperation, deadline, undefined, signal);
+	assertExportDeadline(deadline, signal);
+	const timestamp = exportTimestamp(report.metadata.generatedAt);
+	const csvMetadata = {
+		...report.metadata,
+		requestedBucket: input.bucket,
+		bucket: report.aggregate.bucket,
+	};
+
+	try {
+		if (kind === 'transactions') {
+			const csv = createTransactionsCsv(report.rows, csvMetadata);
+			assertExportDeadline(deadline, signal);
+			const stageOperation = stageReportCsv(csv, `masumi-transactions-${timestamp}`);
+			trackPendingWork?.(stageOperation);
+			const artifact = await awaitBeforeExportDeadline(stageOperation, deadline, (value) => value.cleanup(), signal);
+			return returnStagedArtifactBeforeDeadline(artifact, deadline, signal);
+		}
+		if (kind === 'wallet-summary') {
+			const csv = createWalletSummaryCsv(report.aggregate, csvMetadata);
+			assertExportDeadline(deadline, signal);
+			const stageOperation = stageReportCsv(csv, `masumi-wallet-summary-${timestamp}`);
+			trackPendingWork?.(stageOperation);
+			const artifact = await awaitBeforeExportDeadline(stageOperation, deadline, (value) => value.cleanup(), signal);
+			return returnStagedArtifactBeforeDeadline(artifact, deadline, signal);
+		}
+		if (kind === 'totals') {
+			const csv = createTotalsCsv(report.aggregate, csvMetadata);
+			assertExportDeadline(deadline, signal);
+			const stageOperation = stageReportCsv(csv, `masumi-totals-${timestamp}`);
+			trackPendingWork?.(stageOperation);
+			const artifact = await awaitBeforeExportDeadline(stageOperation, deadline, (value) => value.cleanup(), signal);
+			return returnStagedArtifactBeforeDeadline(artifact, deadline, signal);
+		}
+
+		const transactions = createTransactionsCsv(report.rows, csvMetadata, {
+			maxBytes: REPORT_CSV_MAX_BYTES,
+		});
+		assertExportDeadline(deadline, signal);
+		const walletSummary = createWalletSummaryCsv(report.aggregate, csvMetadata, {
+			maxBytes: remainingZipCsvBytes(transactions.byteLength),
+		});
+		assertExportDeadline(deadline, signal);
+		const totals = createTotalsCsv(report.aggregate, csvMetadata, {
+			maxBytes: remainingZipCsvBytes(transactions.byteLength + walletSummary.byteLength),
+		});
+		assertExportDeadline(deadline, signal);
+		if (transactions.byteLength + walletSummary.byteLength + totals.byteLength > REPORT_CSV_MAX_BYTES) {
+			throw new ReportCsvSizeLimitError(REPORT_CSV_MAX_BYTES);
+		}
+
+		const stageOperation = stageReportZip(
+			{ transactions, walletSummary, totals },
+			`masumi-transaction-report-${timestamp}`,
+		);
+		trackPendingWork?.(stageOperation);
+		const artifact = await awaitBeforeExportDeadline(stageOperation, deadline, (value) => value.cleanup(), signal);
+		if (signal?.aborted || Date.now() >= deadline) {
+			await artifact.cleanup();
+			throw createHttpError(504, 'Report export timed out. Narrow the report filters.');
+		}
+		if (artifact.contentLength > REPORT_CSV_MAX_BYTES) {
+			await artifact.cleanup();
+			throw new ReportCsvSizeLimitError(REPORT_CSV_MAX_BYTES);
+		}
+		return artifact;
+	} catch (error) {
+		if (error instanceof ReportCsvSizeLimitError) {
+			throw createHttpError(413, error.message);
+		}
+		throw error;
+	}
+}

--- a/src/services/transaction-report/service.spec.ts
+++ b/src/services/transaction-report/service.spec.ts
@@ -1,0 +1,711 @@
+import { jest } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import { Network, PaymentSourceType } from '@/generated/prisma/client';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import type { ReportRequestRecord } from './records';
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+const mockResolveSource = jest.fn() as AnyMock;
+const mockResolveWalletIds = jest.fn() as AnyMock;
+const mockListFacets = jest.fn() as AnyMock;
+const mockQueryReportPage = jest.fn() as AnyMock;
+const mockQueryReportFeeComponentClosure = jest.fn() as AnyMock;
+const mockDecodeCursor = jest.fn() as AnyMock;
+const mockEncodeCursor = jest.fn() as AnyMock;
+const mockCreateFilterFingerprint = jest.fn() as AnyMock;
+const mockCreateCursorSnapshot = jest.fn() as AnyMock;
+const mockPrismaTransaction = jest.fn() as AnyMock;
+const mockTransactionQueryRaw = jest.fn() as AnyMock;
+const transactionClient = { transaction: true, $queryRaw: mockTransactionQueryRaw };
+const transactionAsOf = new Date('2026-02-02T12:34:56.000Z');
+
+jest.unstable_mockModule('@masumi/payment-core/db', () => ({
+	prisma: { $transaction: mockPrismaTransaction },
+}));
+
+jest.unstable_mockModule('./access', () => ({
+	resolveAccessibleReportSource: mockResolveSource,
+	resolveAuthorizedManagedWalletIds: mockResolveWalletIds,
+	listAccessibleReportFacets: mockListFacets,
+}));
+
+jest.unstable_mockModule('./query', () => ({
+	queryReportPage: mockQueryReportPage,
+	queryReportFeeComponentClosure: mockQueryReportFeeComponentClosure,
+	decodeReportCursor: mockDecodeCursor,
+	encodeReportCursor: mockEncodeCursor,
+	createReportFilterFingerprint: mockCreateFilterFingerprint,
+	createReportCursorSnapshot: mockCreateCursorSnapshot,
+}));
+
+const { getCompleteReportData, getReportFacets, getSummaryReport, getTransactionsReport, loadAllReportRows } =
+	await import('./service');
+
+const source = {
+	id: 'source-1',
+	createdAt: new Date('2025-01-01T00:00:00.000Z'),
+	network: Network.Preprod,
+	paymentSourceType: PaymentSourceType.Web3CardanoV2,
+	smartContractAddress: 'addr_test1contract',
+	feeRatePermille: 25,
+	deletedAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+const ctx: AuthContext = {
+	id: 'api-key-1',
+	canRead: true,
+	canPay: false,
+	canAdmin: false,
+	networkLimit: [Network.Preprod],
+	caip2NetworkLimit: null,
+	usageLimited: false,
+	walletScopeIds: ['wallet-1'],
+	x402WalletScopeIds: null,
+};
+
+function record(id: string, role: 'Buyer' | 'Seller' = 'Seller'): ReportRequestRecord {
+	return {
+		id,
+		role,
+		requestType: role === 'Seller' ? 'PaymentRequest' : 'PurchaseRequest',
+		createdAt: new Date('2026-01-02T00:00:00.000Z'),
+		blockchainIdentifier: `chain-${id}`,
+		agentIdentifier: null,
+		agentName: null,
+		onChainState: 'Withdrawn',
+		metadata: null,
+		managedWallet: {
+			id: 'wallet-1',
+			walletAddress: 'addr-wallet',
+			walletVkey: 'wallet-vkey',
+			collectionAddress: null,
+			deletedAt: null,
+		},
+		counterpartyAddress: 'addr-counterparty',
+		buyerReturnAddress: null,
+		sellerReturnAddress: null,
+		paymentSourceType: 'Web3CardanoV2',
+		configuredFeeRatePermille: 25,
+		unlockTime: 0n,
+		collateralReturnLovelace: 0n,
+		requestedFunds: [{ unit: 'lovelace', amount: 9_007_199_254_740_993n }],
+		withdrawnForBuyer: [],
+		withdrawnForSeller: [],
+		buyerPayoutCompleteness: 'complete',
+		sellerPayoutCompleteness: 'complete',
+		buyerCardanoFees: 100_000n,
+		sellerCardanoFees: 200_000n,
+		transactions: [
+			{
+				id: `tx-${id}`,
+				txHash: `hash-${id}`,
+				status: 'Confirmed',
+				newOnChainState: 'Withdrawn',
+				blockTime: 1_767_312_000,
+				fees: 400_000n,
+			},
+		],
+		feeAllocationScope: 'single_request',
+		isFeeReconciliationOwner: true,
+		feeComponentScope: 'complete',
+	};
+}
+
+function transactionInput() {
+	return {
+		paymentSourceId: 'source-1',
+		managedWalletIds: ['wallet-1', 'wallet-1'],
+		externalAddresses: ['addr-counterparty', 'addr-counterparty'],
+		roles: ['Seller'] as Array<'Seller'>,
+		states: [],
+		from: new Date('2026-01-01T00:00:00.000Z'),
+		to: new Date('2026-02-01T00:00:00.000Z'),
+		dateBasis: 'CreatedAt' as const,
+		revenueMode: 'Billable' as const,
+		timeZone: 'Etc/UTC',
+		limit: 50,
+	};
+}
+
+function queryFilters() {
+	return {
+		paymentSourceId: 'source-1',
+		paymentSourceType: PaymentSourceType.Web3CardanoV2,
+		configuredFeeRatePermille: 25,
+		authorizedManagedWalletIds: ['wallet-1'],
+		externalAddresses: [],
+		roles: ['Seller'] as Array<'Seller'>,
+		states: [],
+		from: new Date('2026-01-01T00:00:00.000Z'),
+		to: new Date('2026-02-01T00:00:00.000Z'),
+		dateBasis: 'CreatedAt' as const,
+		revenueMode: 'Billable' as const,
+		asOf: new Date('2026-02-02T00:00:00.000Z'),
+	};
+}
+
+describe('transaction report service', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockResolveSource.mockResolvedValue(source);
+		mockResolveWalletIds.mockResolvedValue(['wallet-1']);
+		mockDecodeCursor.mockReturnValue({ positions: { Buyer: null, Seller: null }, snapshot: null });
+		mockCreateFilterFingerprint.mockReturnValue('fingerprint');
+		mockCreateCursorSnapshot.mockImplementation((filters, filterFingerprint) => ({
+			asOf: filters.asOf,
+			paymentSourceId: filters.paymentSourceId,
+			paymentSourceType: filters.paymentSourceType,
+			feeRatePermille: filters.configuredFeeRatePermille,
+			filterFingerprint,
+		}));
+		mockEncodeCursor.mockImplementation((value) => JSON.stringify(value));
+		mockQueryReportFeeComponentClosure.mockImplementation(async (records) => records);
+		mockTransactionQueryRaw.mockResolvedValue([{ asOf: transactionAsOf }]);
+		mockPrismaTransaction.mockImplementation(async (callback) => callback(transactionClient));
+	});
+
+	it('applies effective access filters and returns exact serialized amounts', async () => {
+		mockQueryReportPage.mockResolvedValue({ records: [record('seller-1')], nextCursor: null });
+
+		const result = await getTransactionsReport(transactionInput(), ctx);
+
+		expect(mockQueryReportPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				paymentSourceId: 'source-1',
+				paymentSourceType: PaymentSourceType.Web3CardanoV2,
+				authorizedManagedWalletIds: ['wallet-1'],
+				externalAddresses: ['addr-counterparty'],
+				roles: ['Seller'],
+			}),
+			{ Buyer: null, Seller: null },
+			50,
+			transactionClient,
+			undefined,
+		);
+		expect(result.rows[0].seller?.grossRevenue?.[0]).toMatchObject({
+			rawAmount: '9007199254740993',
+			decimalAmount: '9007199254.740993',
+		});
+		expect(result.metadata.paymentSource.deletedAt).toEqual(source.deletedAt);
+		expect(result.metadata.filters.managedWalletIds).toEqual(['wallet-1']);
+		expect(result.metadata.asOf).toEqual(transactionAsOf);
+		expect(mockResolveSource).toHaveBeenCalledWith(ctx, 'source-1', transactionClient);
+		expect(mockResolveWalletIds).toHaveBeenCalledWith(ctx, 'source-1', ['wallet-1', 'wallet-1'], transactionClient);
+		expect(mockTransactionQueryRaw.mock.calls[0][0].join('')).toContain('transaction_timestamp()');
+		expect(mockTransactionQueryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+			mockResolveSource.mock.invocationCallOrder[0],
+		);
+		expect(mockPrismaTransaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: 'RepeatableRead',
+			timeout: 15_000,
+			maxWait: 5_000,
+		});
+	});
+
+	it('reuses the signed cursor snapshot and rejects changed filters', async () => {
+		const snapshot = {
+			asOf: new Date('2026-01-15T00:00:00.000Z'),
+			paymentSourceId: 'source-1',
+			paymentSourceType: PaymentSourceType.Web3CardanoV1,
+			feeRatePermille: 75,
+			filterFingerprint: 'snapshot-fingerprint',
+		};
+		mockDecodeCursor.mockReturnValue({ positions: { Buyer: null, Seller: null }, snapshot });
+		mockCreateFilterFingerprint.mockReturnValue('snapshot-fingerprint');
+		mockQueryReportPage.mockResolvedValue({ records: [], nextCursor: null });
+
+		const result = await getTransactionsReport({ ...transactionInput(), cursor: 'signed-cursor' }, ctx);
+
+		expect(mockQueryReportPage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				asOf: snapshot.asOf,
+				paymentSourceType: PaymentSourceType.Web3CardanoV1,
+				configuredFeeRatePermille: 75,
+			}),
+			{ Buyer: null, Seller: null },
+			50,
+			transactionClient,
+			undefined,
+		);
+		expect(result.metadata.asOf).toEqual(snapshot.asOf);
+		expect(result.metadata.paymentSource).toMatchObject({
+			paymentSourceType: PaymentSourceType.Web3CardanoV1,
+			feeRatePermille: 75,
+		});
+
+		mockCreateFilterFingerprint.mockReturnValue('changed-fingerprint');
+		await expect(
+			getTransactionsReport({ ...transactionInput(), cursor: 'signed-cursor', states: ['Disputed'] }, ctx),
+		).rejects.toMatchObject({ status: 400 });
+		expect(mockQueryReportPage).toHaveBeenCalledTimes(1);
+	});
+
+	it('binds the next cursor to the report snapshot', async () => {
+		const nextCursor = {
+			Buyer: null,
+			Seller: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'seller-1' },
+		};
+		mockQueryReportPage.mockResolvedValue({ records: [record('seller-1')], nextCursor });
+
+		const result = await getTransactionsReport(transactionInput(), ctx);
+
+		expect(mockEncodeCursor).toHaveBeenCalledWith({
+			positions: nextCursor,
+			snapshot: expect.objectContaining({
+				paymentSourceId: 'source-1',
+				filterFingerprint: 'fingerprint',
+			}),
+		});
+		expect(result.page.hasMore).toBe(true);
+		expect(result.metadata.warnings).toContainEqual(
+			expect.objectContaining({ code: 'PAGINATED_REPORT_MONOTONIC_SNAPSHOT' }),
+		);
+	});
+
+	it('keeps shared fee reconciliation stable across paginated JSON and complete exports', async () => {
+		const relatedRequestKeys = ['Seller:shared-a', 'Seller:shared-b'];
+		const relatedPaymentKeys = ['chain-shared-a', 'chain-shared-b'];
+		const sharedTransaction = {
+			id: 'tx-shared',
+			txHash: 'hash-shared',
+			status: 'Confirmed' as const,
+			newOnChainState: 'Withdrawn' as const,
+			blockTime: 1_767_312_000,
+			fees: 500n,
+			relatedRequestKeys,
+			relatedPaymentKeys,
+			relatedPaymentKeysComplete: true,
+		};
+		const firstRecord = {
+			...record('shared-a'),
+			blockchainIdentifier: 'chain-shared-a',
+			buyerCardanoFees: 0n,
+			sellerCardanoFees: 20n,
+			transactions: [sharedTransaction],
+			feeAllocationScope: 'shared_or_unknown' as const,
+			feeComponentScope: 'partial' as const,
+		};
+		const secondRecord = {
+			...record('shared-b'),
+			blockchainIdentifier: 'chain-shared-b',
+			buyerCardanoFees: 0n,
+			sellerCardanoFees: 30n,
+			transactions: [sharedTransaction],
+			feeAllocationScope: 'shared_or_unknown' as const,
+			feeComponentScope: 'partial' as const,
+		};
+		const nextCursor = {
+			Buyer: null,
+			Seller: { createdAt: firstRecord.createdAt, id: firstRecord.id },
+		};
+		mockQueryReportPage
+			.mockResolvedValueOnce({ records: [firstRecord], nextCursor })
+			.mockResolvedValueOnce({ records: [secondRecord], nextCursor: null })
+			.mockResolvedValueOnce({ records: [firstRecord, secondRecord], nextCursor: null });
+		mockQueryReportFeeComponentClosure.mockResolvedValue([firstRecord, secondRecord]);
+
+		const firstPage = await getTransactionsReport({ ...transactionInput(), limit: 1 }, ctx);
+		mockDecodeCursor.mockReturnValue({
+			positions: nextCursor,
+			snapshot: {
+				asOf: transactionAsOf,
+				paymentSourceId: source.id,
+				paymentSourceType: source.paymentSourceType,
+				feeRatePermille: source.feeRatePermille,
+				filterFingerprint: 'fingerprint',
+			},
+		});
+		const secondPage = await getTransactionsReport({ ...transactionInput(), cursor: 'signed-cursor', limit: 1 }, ctx);
+		const complete = await getCompleteReportData({ ...transactionInput(), bucket: 'Day' }, ctx);
+
+		expect(firstPage.rows[0].cardanoFeeReconciliation).toMatchObject({
+			totalCardanoFees: { rawAmount: '500' },
+			adminCardanoFees: null,
+			completeness: 'partial',
+			isAggregationOwner: true,
+		});
+		expect(secondPage.rows[0].cardanoFeeReconciliation).toMatchObject({
+			totalCardanoFees: null,
+			adminCardanoFees: null,
+			completeness: 'partial',
+			isAggregationOwner: false,
+		});
+		expect(complete.rows.map((row) => row.cardanoFeeReconciliation)).toEqual([
+			expect.objectContaining({ totalCardanoFees: 500n, adminCardanoFees: null, completeness: 'partial' }),
+			expect.objectContaining({ totalCardanoFees: null, adminCardanoFees: null, completeness: 'partial' }),
+		]);
+	});
+
+	it('preserves null metadata when the report includes every accessible wallet', async () => {
+		mockResolveWalletIds.mockResolvedValue(null);
+		mockQueryReportPage.mockResolvedValue({ records: [], nextCursor: null });
+		const { managedWalletIds: _managedWalletIds, ...allWalletInput } = transactionInput();
+
+		const result = await getTransactionsReport(allWalletInput, ctx);
+
+		expect(result.metadata.filters.managedWalletIds).toBeNull();
+	});
+
+	it('revalidates source access on a cursor continuation', async () => {
+		mockDecodeCursor.mockReturnValue({
+			positions: { Buyer: null, Seller: null },
+			snapshot: {
+				asOf: new Date('2026-01-15T00:00:00.000Z'),
+				paymentSourceId: 'source-1',
+				paymentSourceType: PaymentSourceType.Web3CardanoV2,
+				feeRatePermille: 25,
+				filterFingerprint: 'fingerprint',
+			},
+		});
+		mockResolveSource.mockRejectedValue({ status: 404 });
+
+		await expect(getTransactionsReport({ ...transactionInput(), cursor: 'signed-cursor' }, ctx)).rejects.toMatchObject({
+			status: 404,
+		});
+		expect(mockQueryReportPage).not.toHaveBeenCalled();
+	});
+
+	it('maps database transaction timeouts to a gateway timeout', async () => {
+		mockPrismaTransaction.mockRejectedValue({
+			code: 'P2028',
+			message: 'Transaction already closed because it exceeded the configured timeout',
+		});
+
+		await expect(getTransactionsReport(transactionInput(), ctx)).rejects.toMatchObject({ status: 504 });
+	});
+
+	it('stops an aborted paginated report before opening a database transaction', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(getTransactionsReport(transactionInput(), ctx, controller.signal)).rejects.toMatchObject({
+			status: 504,
+		});
+		expect(mockPrismaTransaction).not.toHaveBeenCalled();
+	});
+
+	it('does not hide a non-timeout P2028 transaction failure', async () => {
+		const error = { code: 'P2028', message: 'Transaction API error: invalid transaction invocation' };
+		mockPrismaTransaction.mockRejectedValue(error);
+
+		await expect(getTransactionsReport(transactionInput(), ctx)).rejects.toBe(error);
+	});
+
+	it('rejects fiat settings until report conversion is implemented', async () => {
+		await expect(
+			getTransactionsReport(
+				{
+					...transactionInput(),
+					fiat: { currency: 'usd', mode: 'BucketAverage', suppliedRates: [] },
+				},
+				ctx,
+			),
+		).rejects.toMatchObject({ status: 501 });
+		expect(mockResolveSource).not.toHaveBeenCalled();
+	});
+
+	it('loads all pages and rejects an aggregate above its row limit', async () => {
+		const nextCursor = {
+			Buyer: null,
+			Seller: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'seller-1' },
+		};
+		mockQueryReportPage
+			.mockResolvedValueOnce({ records: [record('seller-1')], nextCursor })
+			.mockResolvedValueOnce({ records: [record('seller-2')], nextCursor: null });
+
+		await expect(
+			loadAllReportRows(
+				{
+					paymentSourceId: 'source-1',
+					paymentSourceType: PaymentSourceType.Web3CardanoV2,
+					configuredFeeRatePermille: 25,
+					authorizedManagedWalletIds: ['wallet-1'],
+					externalAddresses: [],
+					roles: ['Seller'],
+					states: [],
+					from: new Date('2026-01-01T00:00:00.000Z'),
+					to: new Date('2026-02-01T00:00:00.000Z'),
+					dateBasis: 'CreatedAt',
+					revenueMode: 'Billable',
+					asOf: new Date('2026-02-02T00:00:00.000Z'),
+				},
+				{ pageSize: 1, maxRows: 1 },
+			),
+		).rejects.toMatchObject({ status: 413 });
+	});
+
+	it.each([
+		{
+			name: 'metadata bytes',
+			record: { ...record('metadata-limit'), metadata: '12345' },
+			limits: { maxMetadataBytes: 4 },
+		},
+		{
+			name: 'transaction events',
+			record: {
+				...record('event-limit'),
+				transactions: [
+					...record('event-limit').transactions,
+					{ ...record('event-limit').transactions[0], id: 'second-event', txHash: 'second-hash' },
+				],
+			},
+			limits: { maxEvents: 1 },
+		},
+		{
+			name: 'unique asset units',
+			record: {
+				...record('asset-limit'),
+				requestedFunds: [
+					{ unit: 'policy-a', amount: 1n },
+					{ unit: 'policy-b', amount: 1n },
+				],
+			},
+			limits: { maxAssetUnits: 1 },
+		},
+		{
+			name: 'serialized bytes',
+			record: record('serialized-limit'),
+			limits: { maxSerializedBytes: 1 },
+		},
+	])('rejects a complete report above its progressive $name budget', async ({ record: value, limits }) => {
+		mockQueryReportPage.mockResolvedValue({ records: [value], nextCursor: null });
+
+		await expect(loadAllReportRows(queryFilters(), limits)).rejects.toMatchObject({ status: 413 });
+	});
+
+	it('applies progressive metadata budgets across database pages', async () => {
+		const nextCursor = {
+			Buyer: null,
+			Seller: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'metadata-page-1' },
+		};
+		mockQueryReportPage
+			.mockResolvedValueOnce({ records: [{ ...record('metadata-page-1'), metadata: '12345' }], nextCursor })
+			.mockResolvedValueOnce({ records: [{ ...record('metadata-page-2'), metadata: '67890' }], nextCursor: null });
+
+		await expect(loadAllReportRows(queryFilters(), { pageSize: 1, maxMetadataBytes: 8 })).rejects.toMatchObject({
+			status: 413,
+		});
+	});
+
+	it('fails a stalled aggregate cursor instead of looping', async () => {
+		const stalledCursor = {
+			Buyer: null,
+			Seller: { createdAt: new Date('2026-01-02T00:00:00.000Z'), id: 'seller-1' },
+		};
+		mockQueryReportPage.mockResolvedValue({ records: [], nextCursor: stalledCursor });
+
+		await expect(
+			loadAllReportRows(
+				{
+					paymentSourceId: 'source-1',
+					paymentSourceType: PaymentSourceType.Web3CardanoV2,
+					configuredFeeRatePermille: 25,
+					authorizedManagedWalletIds: null,
+					externalAddresses: [],
+					roles: ['Seller'],
+					states: [],
+					from: new Date('2026-01-01T00:00:00.000Z'),
+					to: new Date('2026-02-01T00:00:00.000Z'),
+					dateBasis: 'CreatedAt',
+					revenueMode: 'Billable',
+					asOf: new Date('2026-02-02T00:00:00.000Z'),
+				},
+				{ pageSize: 1 },
+			),
+		).rejects.toThrow('Report pagination did not advance');
+	});
+
+	it('enforces the aggregate deadline after the final database page', async () => {
+		mockQueryReportPage.mockResolvedValue({ records: [], nextCursor: null });
+		const times = [0, 0, 31];
+
+		await expect(
+			loadAllReportRows(
+				{
+					paymentSourceId: 'source-1',
+					paymentSourceType: PaymentSourceType.Web3CardanoV2,
+					configuredFeeRatePermille: 25,
+					authorizedManagedWalletIds: null,
+					externalAddresses: [],
+					roles: ['Seller'],
+					states: [],
+					from: new Date('2026-01-01T00:00:00.000Z'),
+					to: new Date('2026-02-01T00:00:00.000Z'),
+					dateBasis: 'CreatedAt',
+					revenueMode: 'Billable',
+					asOf: new Date('2026-02-02T00:00:00.000Z'),
+				},
+				{ timeoutMilliseconds: 30, now: () => times.shift() ?? 31 },
+			),
+		).rejects.toMatchObject({ status: 504 });
+	});
+
+	it('stops a complete report after its request is aborted between pages', async () => {
+		const controller = new AbortController();
+		mockQueryReportPage.mockImplementation(async () => {
+			controller.abort();
+			return { records: [], nextCursor: null };
+		});
+
+		await expect(loadAllReportRows(queryFilters(), {}, undefined, controller.signal)).rejects.toMatchObject({
+			status: 504,
+		});
+	});
+
+	it('maps archived facet records to the public reporting shape', async () => {
+		mockListFacets.mockResolvedValue({
+			paymentSources: [source],
+			managedWallets: [
+				{
+					id: 'wallet-1',
+					createdAt: new Date(),
+					paymentSourceId: 'source-1',
+					type: 'Selling',
+					walletAddress: 'addr-wallet',
+					walletVkey: 'wallet-vkey',
+					collectionAddress: null,
+					note: null,
+					deletedAt: new Date('2026-01-01T00:00:00.000Z'),
+				},
+			],
+		});
+
+		const result = await getReportFacets(ctx);
+		expect(result.managedWallets[0]).toEqual({
+			id: 'wallet-1',
+			paymentSourceId: 'source-1',
+			type: 'Selling',
+			walletAddress: 'addr-wallet',
+			walletVkey: 'wallet-vkey',
+			collectionAddress: null,
+			note: null,
+			deletedAt: new Date('2026-01-01T00:00:00.000Z'),
+		});
+	});
+
+	it('loads summary pages inside one repeatable-read transaction', async () => {
+		mockQueryReportPage.mockResolvedValue({ records: [], nextCursor: null });
+
+		await getSummaryReport({ ...transactionInput(), bucket: 'Auto' }, ctx);
+
+		expect(mockPrismaTransaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: 'RepeatableRead',
+			timeout: 35_000,
+			maxWait: 5_000,
+		});
+		expect(mockQueryReportPage).toHaveBeenCalledWith(
+			expect.any(Object),
+			{ Buyer: null, Seller: null },
+			100,
+			transactionClient,
+			undefined,
+		);
+	});
+
+	it('returns one complete snapshot for JSON and file exports', async () => {
+		mockQueryReportPage.mockResolvedValue({ records: [record('seller-export')], nextCursor: null });
+
+		const result = await getCompleteReportData({ ...transactionInput(), bucket: 'Day' }, ctx);
+
+		expect(result.rows).toHaveLength(1);
+		expect(result.aggregate.totals.transactionCount).toBe(1);
+		expect(result.metadata).toMatchObject({
+			asOf: transactionAsOf,
+			paymentSource: { id: 'source-1', paymentSourceType: PaymentSourceType.Web3CardanoV2 },
+			filters: { paymentSourceId: 'source-1', managedWalletIds: ['wallet-1'] },
+		});
+		expect(mockPrismaTransaction).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps settled Billable revenue in its earlier unlock bucket', async () => {
+		const unlockAt = new Date('2026-01-01T12:00:00.000Z');
+		mockQueryReportPage.mockResolvedValue({
+			records: [
+				{
+					...record('seller-accrual'),
+					unlockTime: BigInt(unlockAt.getTime()),
+					transactions: [
+						{
+							id: 'tx-result',
+							txHash: 'hash-result',
+							status: 'Confirmed',
+							newOnChainState: 'ResultSubmitted',
+							blockTime: Math.floor(new Date('2025-12-31T12:00:00.000Z').getTime() / 1000),
+							fees: 0n,
+						},
+						{
+							id: 'tx-withdraw',
+							txHash: 'hash-withdraw',
+							status: 'Confirmed',
+							newOnChainState: 'Withdrawn',
+							blockTime: Math.floor(new Date('2026-02-01T12:00:00.000Z').getTime() / 1000),
+							fees: 0n,
+						},
+					],
+				},
+			],
+			nextCursor: null,
+		});
+
+		const result = await getCompleteReportData(
+			{
+				...transactionInput(),
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				to: new Date('2026-01-02T00:00:00.000Z'),
+				dateBasis: 'RevenueRecognizedAt',
+				bucket: 'Day',
+			},
+			ctx,
+		);
+
+		expect(result.rows[0].timestamps.sellerRevenueRecognizedAt).toEqual(unlockAt);
+		expect(result.aggregate.history[0].metrics.sellerGrossRevenue.amounts).toEqual([
+			{ unit: 'lovelace', amount: 9_007_199_254_740_993n },
+		]);
+	});
+
+	it('keeps conflicting actor evidence partial after detail canonicalization and aggregation', async () => {
+		const relatedRequestKeys = ['Seller:seller-conflict-a', 'Seller:seller-conflict-b'];
+		const transaction = {
+			id: 'tx-conflict',
+			txHash: 'hash-conflict',
+			status: 'Confirmed',
+			newOnChainState: 'Withdrawn' as const,
+			blockTime: 1_767_312_000,
+			fees: 100n,
+			relatedRequestKeys,
+			relatedPaymentKeys: ['chain-conflict'],
+			relatedPaymentKeysComplete: true,
+		};
+		mockQueryReportPage.mockResolvedValue({
+			records: [
+				{
+					...record('seller-conflict-a'),
+					blockchainIdentifier: 'chain-conflict',
+					sellerCardanoFees: 20n,
+					transactions: [transaction],
+				},
+				{
+					...record('seller-conflict-b'),
+					blockchainIdentifier: 'chain-conflict',
+					sellerCardanoFees: 25n,
+					transactions: [transaction],
+				},
+			],
+			nextCursor: null,
+		});
+
+		const result = await getCompleteReportData({ ...transactionInput(), bucket: 'Day' }, ctx);
+
+		expect(result.aggregate.totals.totalCardanoFees).toEqual({
+			amounts: [{ unit: 'lovelace', amount: 100n }],
+			completeness: 'complete',
+		});
+		expect(result.aggregate.totals.adminCardanoFees).toEqual({ amounts: [], completeness: 'partial' });
+		expect(result.rows.filter((row) => row.isFeeReconciliationOwner)).toHaveLength(1);
+		expect(result.rows.find((row) => row.isFeeReconciliationOwner)?.actorCardanoFeeAllocation.completeness).toBe(
+			'partial',
+		);
+	});
+});

--- a/src/services/transaction-report/service.ts
+++ b/src/services/transaction-report/service.ts
@@ -1,0 +1,415 @@
+import createHttpError from 'http-errors';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { prisma } from '@masumi/payment-core/db';
+import { HotWalletType, type Prisma } from '@/generated/prisma/client';
+import type { ReportFilterInput, ReportSummaryInput, ReportTransactionsInput } from '@/routes/api/reports/schemas';
+import {
+	listAccessibleReportFacets,
+	resolveAccessibleReportSource,
+	resolveAuthorizedManagedWalletIds,
+	type ReportAccessClient,
+} from './access';
+import {
+	createReportCursorSnapshot,
+	createReportFilterFingerprint,
+	decodeReportCursor,
+	encodeReportCursor,
+	queryReportFeeComponentClosure,
+	queryReportPage,
+	type ReportCursorPositions,
+	type ReportCursorSnapshot,
+	type ReportQueryClient,
+	type ReportQueryFilters,
+} from './query';
+import {
+	buildReportRow,
+	getReportRowWarnings,
+	serializeReportRow,
+	type ReportRow,
+	type ReportWarning,
+} from './records';
+import { aggregateReportRows, serializeReportAggregateResult } from './aggregate';
+import { assignCompleteReportFeeReconciliation } from './aggregate-fees';
+import { createReportLoadBudget, type ReportLoadBudgetLimits } from './load-budget';
+
+const REPORT_AGGREGATE_PAGE_SIZE = 100;
+const REPORT_MAX_AGGREGATE_ROWS = 50_000;
+const REPORT_AGGREGATE_TIMEOUT_MS = 30_000;
+const REPORT_SUMMARY_TRANSACTION_TIMEOUT_MS = REPORT_AGGREGATE_TIMEOUT_MS + 5_000;
+const REPORT_PAGE_TRANSACTION_TIMEOUT_MS = 15_000;
+const REPORT_TRANSACTION_MAX_WAIT_MS = 5_000;
+const REPORT_PAGE_FEE_CONTEXT_MAX_SERIALIZED_BYTES = 32 * 1024 * 1024;
+
+const PAGINATED_SNAPSHOT_WARNING: ReportWarning = {
+	code: 'PAGINATED_REPORT_MONOTONIC_SNAPSHOT',
+	message:
+		'Paginated JSON is monotonic, not a database snapshot. Requests changed after asOf are excluded because historical row values are not stored.',
+	rowId: null,
+};
+
+type ReportSource = Awaited<ReturnType<typeof resolveAccessibleReportSource>>;
+type ReportDatabaseClient = ReportAccessClient & ReportQueryClient;
+
+type AggregateLoadLimits = ReportLoadBudgetLimits & {
+	pageSize?: number;
+	maxRows?: number;
+	timeoutMilliseconds?: number;
+	now?: () => number;
+};
+
+function unique<T>(values: readonly T[]): T[] {
+	return Array.from(new Set(values));
+}
+
+function rejectUnsupportedFiat(input: ReportFilterInput): void {
+	if (input.fiat != null) {
+		throw createHttpError(501, 'Fiat conversion is not available for transaction reports yet');
+	}
+}
+
+function paymentSourceMetadata(source: ReportSource, snapshot?: ReportCursorSnapshot | null) {
+	return {
+		id: source.id,
+		network: source.network,
+		paymentSourceType: snapshot?.paymentSourceType ?? source.paymentSourceType,
+		feeRatePermille: snapshot?.feeRatePermille ?? source.feeRatePermille,
+		smartContractAddress: source.smartContractAddress,
+		deletedAt: source.deletedAt,
+	};
+}
+
+function normalizedFilterMetadata(input: ReportFilterInput, authorizedManagedWalletIds: string[] | null) {
+	return {
+		paymentSourceId: input.paymentSourceId,
+		managedWalletIds: authorizedManagedWalletIds,
+		externalAddresses: unique(input.externalAddresses ?? []),
+		roles: unique(input.roles),
+		states: unique(input.states ?? []),
+		from: input.from,
+		to: input.to,
+		dateBasis: input.dateBasis,
+		revenueMode: input.revenueMode,
+		timeZone: input.timeZone,
+	};
+}
+
+function queryFilters(
+	input: ReportFilterInput,
+	source: ReportSource,
+	authorizedManagedWalletIds: string[] | null,
+	asOf: Date,
+	snapshot?: ReportCursorSnapshot | null,
+): ReportQueryFilters {
+	return {
+		paymentSourceId: source.id,
+		paymentSourceType: snapshot?.paymentSourceType ?? source.paymentSourceType,
+		configuredFeeRatePermille: snapshot?.feeRatePermille ?? source.feeRatePermille,
+		authorizedManagedWalletIds,
+		externalAddresses: unique(input.externalAddresses ?? []),
+		roles: unique(input.roles),
+		states: unique(input.states ?? []),
+		from: input.from,
+		to: input.to,
+		dateBasis: input.dateBasis,
+		revenueMode: input.revenueMode,
+		asOf,
+	};
+}
+
+async function resolveReportRequest(
+	ctx: AuthContext,
+	input: ReportFilterInput,
+	transactionAsOf: Date,
+	snapshot?: ReportCursorSnapshot | null,
+	database?: ReportDatabaseClient,
+) {
+	const [source, authorizedManagedWalletIds] = await Promise.all([
+		resolveAccessibleReportSource(ctx, input.paymentSourceId, database),
+		resolveAuthorizedManagedWalletIds(ctx, input.paymentSourceId, input.managedWalletIds, database),
+	]);
+	const asOf = snapshot?.asOf ?? transactionAsOf;
+	return {
+		source,
+		authorizedManagedWalletIds,
+		asOf,
+		filters: queryFilters(input, source, authorizedManagedWalletIds, asOf, snapshot),
+	};
+}
+
+async function getReportSnapshotTime(database: Pick<Prisma.TransactionClient, '$queryRaw'>): Promise<Date> {
+	const [row] = await database.$queryRaw<Array<{ asOf: Date }>>`
+		SELECT transaction_timestamp() AS "asOf"
+	`;
+	if (!(row?.asOf instanceof Date) || Number.isNaN(row.asOf.getTime())) {
+		throw createHttpError(500, 'Failed to read the report database snapshot time');
+	}
+	return row.asOf;
+}
+
+function reportTimeout(): never {
+	throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+}
+
+function assertReportActive(signal?: AbortSignal, deadline?: number): void {
+	if (signal?.aborted || (deadline != null && Date.now() >= deadline)) reportTimeout();
+}
+
+function isPrismaTimeoutError(error: unknown): boolean {
+	if (typeof error !== 'object' || error == null || !('code' in error)) return false;
+	const code = (error as { code?: unknown }).code;
+	if (code === 'P2024') return true;
+	if (code !== 'P2028' || !('message' in error)) return false;
+	const message = (error as { message?: unknown }).message;
+	return typeof message === 'string' && /(?:timed?\s*out|timeout|expired transaction|given time)/i.test(message);
+}
+
+async function runReportTransaction<T>(
+	work: (transaction: Prisma.TransactionClient) => Promise<T>,
+	timeout: number,
+): Promise<T> {
+	try {
+		return await prisma.$transaction(work, {
+			isolationLevel: 'RepeatableRead',
+			timeout,
+			maxWait: REPORT_TRANSACTION_MAX_WAIT_MS,
+		});
+	} catch (error) {
+		if (isPrismaTimeoutError(error)) reportTimeout();
+		throw error;
+	}
+}
+
+function reportMetadata(
+	input: ReportFilterInput,
+	source: ReportSource,
+	authorizedManagedWalletIds: string[] | null,
+	asOf: Date,
+	warnings: ReportWarning[],
+	snapshot?: ReportCursorSnapshot | null,
+) {
+	return {
+		generatedAt: new Date(),
+		asOf,
+		paymentSource: paymentSourceMetadata(source, snapshot),
+		filters: normalizedFilterMetadata(input, authorizedManagedWalletIds),
+		warnings,
+	};
+}
+
+function summarizeWarnings(warnings: readonly ReportWarning[]): ReportWarning[] {
+	const byCode = new Map<string, ReportWarning>();
+	for (const warning of warnings) {
+		if (!byCode.has(warning.code)) byCode.set(warning.code, { ...warning, rowId: null });
+	}
+	return Array.from(byCode.values());
+}
+
+export async function getReportFacets(ctx: AuthContext, signal?: AbortSignal) {
+	assertReportActive(signal);
+	const facets = await listAccessibleReportFacets(ctx);
+	assertReportActive(signal);
+	return {
+		paymentSources: facets.paymentSources.map((source) => paymentSourceMetadata(source)),
+		managedWallets: facets.managedWallets.map((wallet) => {
+			if (wallet.type !== HotWalletType.Selling && wallet.type !== HotWalletType.Purchasing) {
+				throw createHttpError(500, 'Report facets returned an unsupported managed wallet type');
+			}
+			return {
+				id: wallet.id,
+				paymentSourceId: wallet.paymentSourceId,
+				type: wallet.type,
+				walletAddress: wallet.walletAddress,
+				walletVkey: wallet.walletVkey,
+				collectionAddress: wallet.collectionAddress,
+				note: wallet.note,
+				deletedAt: wallet.deletedAt,
+			};
+		}),
+	};
+}
+
+export async function getTransactionsReport(input: ReportTransactionsInput, ctx: AuthContext, signal?: AbortSignal) {
+	const deadline = Date.now() + REPORT_PAGE_TRANSACTION_TIMEOUT_MS;
+	assertReportActive(signal, deadline);
+	rejectUnsupportedFiat(input);
+	const decodedCursor = decodeReportCursor(input.cursor);
+	if (decodedCursor.snapshot != null && decodedCursor.snapshot.paymentSourceId !== input.paymentSourceId) {
+		throw createHttpError(400, 'Report cursor does not match the requested filters');
+	}
+	const { request, snapshot, page, feeContextRecords } = await runReportTransaction(async (transaction) => {
+		assertReportActive(signal, deadline);
+		const transactionAsOf = await getReportSnapshotTime(transaction);
+		const request = await resolveReportRequest(ctx, input, transactionAsOf, decodedCursor.snapshot, transaction);
+		const filterFingerprint = createReportFilterFingerprint({ ...request.filters, timeZone: input.timeZone });
+		if (decodedCursor.snapshot != null && decodedCursor.snapshot.filterFingerprint !== filterFingerprint) {
+			throw createHttpError(400, 'Report cursor does not match the requested filters');
+		}
+		const snapshot = decodedCursor.snapshot ?? createReportCursorSnapshot(request.filters, filterFingerprint);
+		const page = await queryReportPage(request.filters, decodedCursor.positions, input.limit, transaction, signal);
+		const feeContextRecords =
+			input.cursor != null || page.nextCursor != null
+				? await queryReportFeeComponentClosure(page.records, request.filters, transaction, { signal })
+				: page.records;
+		assertReportActive(signal, deadline);
+		return { request, snapshot, page, feeContextRecords };
+	}, REPORT_PAGE_TRANSACTION_TIMEOUT_MS);
+	assertReportActive(signal, deadline);
+	const { asOf } = request;
+	const metricWindow = { dateBasis: input.dateBasis, from: input.from, to: input.to };
+	const consumeFeeContextBudget = createReportLoadBudget({
+		maxSerializedBytes: REPORT_PAGE_FEE_CONTEXT_MAX_SERIALIZED_BYTES,
+	});
+	const builtFeeContextRows: ReportRow[] = [];
+	for (const record of feeContextRecords) {
+		assertReportActive(signal, deadline);
+		const row = buildReportRow(record, input.revenueMode, asOf, metricWindow);
+		consumeFeeContextBudget(record, row);
+		builtFeeContextRows.push(row);
+	}
+	const feeContextRows = assignCompleteReportFeeReconciliation(
+		builtFeeContextRows,
+		input.dateBasis,
+		input.from,
+		input.to,
+		() => assertReportActive(signal, deadline),
+	);
+	const feeContextRowsByRequest = new Map(feeContextRows.map((row) => [`${row.requestType}:${row.id}`, row] as const));
+	const rows: ReportRow[] = [];
+	for (const record of page.records) {
+		assertReportActive(signal, deadline);
+		const row = feeContextRowsByRequest.get(`${record.requestType}:${record.id}`);
+		if (row == null) throw createHttpError(500, 'Report fee context omitted a requested row');
+		rows.push(row);
+	}
+	assertReportActive(signal, deadline);
+	const warnings = rows.flatMap(getReportRowWarnings);
+	if (input.cursor != null || page.nextCursor != null) warnings.push(PAGINATED_SNAPSHOT_WARNING);
+	return {
+		rows: rows.map(serializeReportRow),
+		page: {
+			nextCursor: page.nextCursor == null ? null : encodeReportCursor({ positions: page.nextCursor, snapshot }),
+			hasMore: page.nextCursor != null,
+		},
+		metadata: reportMetadata(input, request.source, request.authorizedManagedWalletIds, asOf, warnings, snapshot),
+	};
+}
+
+function cursorPositionsKey(cursor: ReportCursorPositions): string {
+	return JSON.stringify({
+		Buyer: cursor.Buyer == null ? null : { createdAt: cursor.Buyer.createdAt.toISOString(), id: cursor.Buyer.id },
+		Seller: cursor.Seller == null ? null : { createdAt: cursor.Seller.createdAt.toISOString(), id: cursor.Seller.id },
+	});
+}
+
+export async function loadAllReportRows(
+	filters: ReportQueryFilters,
+	limits: AggregateLoadLimits = {},
+	database?: ReportQueryClient,
+	signal?: AbortSignal,
+): Promise<ReportRow[]> {
+	const pageSize = limits.pageSize ?? REPORT_AGGREGATE_PAGE_SIZE;
+	const maxRows = limits.maxRows ?? REPORT_MAX_AGGREGATE_ROWS;
+	const timeoutMilliseconds = limits.timeoutMilliseconds ?? REPORT_AGGREGATE_TIMEOUT_MS;
+	const now = limits.now ?? Date.now;
+	const deadline = now() + timeoutMilliseconds;
+	const seenCursors = new Set<string>();
+	const rows: ReportRow[] = [];
+	const consumeBudget = createReportLoadBudget(limits);
+	let cursor: ReportCursorPositions = { Buyer: null, Seller: null };
+
+	while (true) {
+		if (signal?.aborted || now() >= deadline) {
+			throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+		}
+		const page = await queryReportPage(filters, cursor, pageSize, database, signal);
+		if (signal?.aborted || now() >= deadline) {
+			throw createHttpError(504, 'Report calculation timed out. Narrow the report filters.');
+		}
+		if (rows.length + page.records.length > maxRows) {
+			throw createHttpError(413, `Report exceeds ${maxRows} rows. Narrow the report filters.`);
+		}
+		const metricWindow = { dateBasis: filters.dateBasis, from: filters.from, to: filters.to };
+		for (const record of page.records) {
+			if (signal?.aborted || now() >= deadline) reportTimeout();
+			const row = buildReportRow(record, filters.revenueMode, filters.asOf, metricWindow);
+			consumeBudget(record, row);
+			rows.push(row);
+		}
+		if (page.nextCursor == null) {
+			const reconciled = assignCompleteReportFeeReconciliation(
+				rows,
+				filters.dateBasis,
+				filters.from,
+				filters.to,
+				() => {
+					if (signal?.aborted || now() >= deadline) reportTimeout();
+				},
+			);
+			if (signal?.aborted || now() >= deadline) reportTimeout();
+			return reconciled;
+		}
+
+		const encodedCursor = cursorPositionsKey(page.nextCursor);
+		if (seenCursors.has(encodedCursor)) {
+			throw createHttpError(500, 'Report pagination did not advance');
+		}
+		seenCursors.add(encodedCursor);
+		cursor = page.nextCursor;
+	}
+}
+
+async function loadCompleteReportData(input: ReportSummaryInput, ctx: AuthContext, signal?: AbortSignal) {
+	assertReportActive(signal);
+	rejectUnsupportedFiat(input);
+	const deadline = Date.now() + REPORT_AGGREGATE_TIMEOUT_MS;
+	const { request, rows } = await runReportTransaction(async (transaction) => {
+		assertReportActive(signal, deadline);
+		const transactionAsOf = await getReportSnapshotTime(transaction);
+		const request = await resolveReportRequest(ctx, input, transactionAsOf, null, transaction);
+		const remainingMilliseconds = deadline - Date.now();
+		if (remainingMilliseconds <= 0) reportTimeout();
+		const rows = await loadAllReportRows(
+			request.filters,
+			{ timeoutMilliseconds: remainingMilliseconds },
+			transaction,
+			signal,
+		);
+		return { request, rows };
+	}, REPORT_SUMMARY_TRANSACTION_TIMEOUT_MS);
+	assertReportActive(signal, deadline);
+	const aggregate = aggregateReportRows(rows, input.bucket, input.timeZone, input.from, input.to, input.dateBasis, () =>
+		assertReportActive(signal, deadline),
+	);
+	assertReportActive(signal, deadline);
+	const rowWarnings: ReportWarning[] = [];
+	for (const row of rows) {
+		assertReportActive(signal, deadline);
+		rowWarnings.push(...getReportRowWarnings(row));
+	}
+	const warnings = summarizeWarnings([...rowWarnings, ...aggregate.warnings]);
+	assertReportActive(signal, deadline);
+	return {
+		rows,
+		aggregate,
+		metadata: reportMetadata(input, request.source, request.authorizedManagedWalletIds, request.asOf, warnings),
+		deadline,
+	};
+}
+
+export async function getCompleteReportData(input: ReportSummaryInput, ctx: AuthContext, signal?: AbortSignal) {
+	const { deadline: _deadline, ...data } = await loadCompleteReportData(input, ctx, signal);
+	return data;
+}
+
+export async function getSummaryReport(input: ReportSummaryInput, ctx: AuthContext, signal?: AbortSignal) {
+	const { aggregate, metadata, deadline } = await loadCompleteReportData(input, ctx, signal);
+	const serialized = serializeReportAggregateResult(aggregate);
+	assertReportActive(signal, deadline);
+	return {
+		totals: serialized.totals,
+		wallets: serialized.wallets,
+		history: serialized.history,
+		bucket: serialized.bucket,
+		metadata,
+	};
+}

--- a/src/services/transaction-report/service.ts
+++ b/src/services/transaction-report/service.ts
@@ -37,6 +37,11 @@ const REPORT_MAX_AGGREGATE_ROWS = 50_000;
 const REPORT_AGGREGATE_TIMEOUT_MS = 30_000;
 const REPORT_SUMMARY_TRANSACTION_TIMEOUT_MS = REPORT_AGGREGATE_TIMEOUT_MS + 5_000;
 const REPORT_PAGE_TRANSACTION_TIMEOUT_MS = 15_000;
+// The request deadline has to outlast the database transaction. With both set
+// to the same value a query that used its whole budget left nothing for row
+// building and fee reconciliation, so the request raised 504 after the database
+// work had already succeeded. The summary path keeps the same kind of slack.
+const REPORT_PAGE_DEADLINE_MS = REPORT_PAGE_TRANSACTION_TIMEOUT_MS + 5_000;
 const REPORT_TRANSACTION_MAX_WAIT_MS = 5_000;
 const REPORT_PAGE_FEE_CONTEXT_MAX_SERIALIZED_BYTES = 32 * 1024 * 1024;
 
@@ -229,7 +234,7 @@ export async function getReportFacets(ctx: AuthContext, signal?: AbortSignal) {
 }
 
 export async function getTransactionsReport(input: ReportTransactionsInput, ctx: AuthContext, signal?: AbortSignal) {
-	const deadline = Date.now() + REPORT_PAGE_TRANSACTION_TIMEOUT_MS;
+	const deadline = Date.now() + REPORT_PAGE_DEADLINE_MS;
 	assertReportActive(signal, deadline);
 	rejectUnsupportedFiat(input);
 	const decodedCursor = decodeReportCursor(input.cursor);


### PR DESCRIPTION
Turns the aggregated figures into files.

- `service.ts`: orchestrates query then aggregate. It sits here rather than in the domain layer because it depends on the query layer.
- `csv.ts`: the three CSV shapes, one column per asset.
- `export-service.ts`, `export-files.ts`: the ZIP bundle.
- `load-budget.ts`, `checkpoint.ts`: the bounds that keep a large export from running unbounded.

10 files, 2,935 lines.

---

**Part of a 6-PR split of #739.** That branch is 69 files and 34,694 lines, over the review-tooling limits, so nothing could review it as one change. It is split here by layer, bottom-up.

Verified before opening:
- The six branches together reproduce `feat/transaction-report-core` exactly. `git diff --stat origin/feat/transaction-report-core <tip>` is empty.
- `npx tsc --noEmit` reports 0 errors on each of the six branches in order, so every step of the stack compiles on its own.
- No file content was changed, reworded, or moved between layers beyond assigning each file to the layer that owns it.