### PR TITLE
feat(reports): add the report API endpoints

### DIFF
--- a/src/routes/api/index.ts
+++ b/src/routes/api/index.ts
@@ -174,6 +174,15 @@ import {
 	x402WalletBalanceGet,
 	x402WalletsCountGet,
 } from './x402';
+import {
+	reportExportZipEndpointPost,
+	reportFacetsEndpointGet,
+	reportSummaryEndpointPost,
+	reportTotalsCsvEndpointPost,
+	reportTransactionsCsvEndpointPost,
+	reportTransactionsEndpointPost,
+	reportWalletSummaryCsvEndpointPost,
+} from './reports';
 
 export const apiRouter: Routing = {
 	v1: {
@@ -574,6 +583,29 @@ export const apiRouter: Routing = {
 		},
 		'rail-readiness': {
 			get: railReadinessEndpointGet,
+		},
+		reports: {
+			facets: {
+				get: reportFacetsEndpointGet,
+			},
+			transactions: {
+				post: reportTransactionsEndpointPost,
+			},
+			summary: {
+				post: reportSummaryEndpointPost,
+			},
+			'transactions.csv': {
+				post: reportTransactionsCsvEndpointPost,
+			},
+			'wallet-summary.csv': {
+				post: reportWalletSummaryCsvEndpointPost,
+			},
+			'totals.csv': {
+				post: reportTotalsCsvEndpointPost,
+			},
+			'export.zip': {
+				post: reportExportZipEndpointPost,
+			},
 		},
 	},
 };

--- a/src/routes/api/reports/docs.spec.ts
+++ b/src/routes/api/reports/docs.spec.ts
@@ -1,0 +1,160 @@
+import { OpenAPIRegistry, OpenApiGeneratorV3, extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from '@masumi/payment-core/zod';
+import { registerReportPaths } from './docs';
+
+extendZodWithOpenApi(z);
+
+const registry = new OpenAPIRegistry();
+const apiKeyAuth = registry.registerComponent('securitySchemes', 'API-Key', {
+	type: 'apiKey',
+	in: 'header',
+	name: 'token',
+});
+registerReportPaths({ registry, apiKeyAuth });
+const document = new OpenApiGeneratorV3(registry.definitions).generateDocument({
+	openapi: '3.0.0',
+	info: { version: '1.0.0', title: 'Reports test API' },
+});
+
+function operation(path: string, method: 'get' | 'post') {
+	const value = document.paths[path]?.[method];
+	if (value == null) throw new Error(`Missing ${method.toUpperCase()} ${path}`);
+	return value;
+}
+
+function requestSchema(path: string) {
+	return requestBody(path).content['application/json']?.schema;
+}
+
+function requestBody(path: string) {
+	const requestBody = operation(path, 'post').requestBody;
+	if (requestBody == null || '$ref' in requestBody) throw new Error(`Missing request body for ${path}`);
+	return requestBody;
+}
+
+function successResponse(path: string, method: 'get' | 'post') {
+	const response = operation(path, method).responses['200'];
+	if (response == null || '$ref' in response) throw new Error(`Missing 200 response for ${method} ${path}`);
+	return response;
+}
+
+function errorResponse(path: string, method: 'get' | 'post', statusCode: string) {
+	const response = operation(path, method).responses[statusCode];
+	if (response == null || '$ref' in response) {
+		throw new Error(`Missing ${statusCode} response for ${method} ${path}`);
+	}
+	return response;
+}
+
+describe('transaction report OpenAPI docs', () => {
+	it('registers every JSON and file export endpoint with read authentication', () => {
+		const endpoints = [
+			['/reports/facets', 'get'],
+			['/reports/transactions', 'post'],
+			['/reports/summary', 'post'],
+			['/reports/transactions.csv', 'post'],
+			['/reports/wallet-summary.csv', 'post'],
+			['/reports/totals.csv', 'post'],
+			['/reports/export.zip', 'post'],
+		] as const;
+
+		for (const [path, method] of endpoints) {
+			expect(operation(path, method)).toMatchObject({
+				tags: ['reports'],
+				security: [{ 'API-Key': [] }],
+			});
+		}
+	});
+
+	it('documents the JSON response envelopes and report request schemas', () => {
+		expect(successResponse('/reports/facets', 'get').content?.['application/json']).toBeDefined();
+		expect(successResponse('/reports/transactions', 'post').content?.['application/json']).toBeDefined();
+		expect(successResponse('/reports/summary', 'post').content?.['application/json']).toBeDefined();
+
+		expect(requestSchema('/reports/transactions')).toMatchObject({
+			allOf: expect.arrayContaining([
+				expect.objectContaining({
+					properties: expect.objectContaining({ paymentSourceId: expect.any(Object) }),
+				}),
+				expect.objectContaining({
+					properties: expect.objectContaining({ cursor: expect.any(Object), limit: expect.any(Object) }),
+				}),
+			]),
+		});
+
+		const summarySchema = requestSchema('/reports/summary');
+		expect(summarySchema).toMatchObject({
+			allOf: expect.arrayContaining([
+				expect.objectContaining({
+					properties: expect.objectContaining({ paymentSourceId: expect.any(Object) }),
+				}),
+				expect.objectContaining({ properties: expect.objectContaining({ bucket: expect.any(Object) }) }),
+			]),
+		});
+		for (const path of [
+			'/reports/transactions.csv',
+			'/reports/wallet-summary.csv',
+			'/reports/totals.csv',
+			'/reports/export.zip',
+		]) {
+			expect(requestSchema(path)).toEqual(summarySchema);
+		}
+	});
+
+	it('requires every POST body and documents the runtime JSON error envelope', () => {
+		for (const path of [
+			'/reports/transactions',
+			'/reports/summary',
+			'/reports/transactions.csv',
+			'/reports/wallet-summary.csv',
+			'/reports/totals.csv',
+			'/reports/export.zip',
+		]) {
+			expect(requestBody(path).required).toBe(true);
+			expect(errorResponse(path, 'post', '400').content?.['application/json']?.schema).toBeDefined();
+		}
+		expect(errorResponse('/reports/facets', 'get', '401').content?.['application/json']?.schema).toBeDefined();
+	});
+
+	it('documents report size limits on facets and paginated transaction rows', () => {
+		expect(errorResponse('/reports/facets', 'get', '413').content?.['application/json']?.schema).toBeDefined();
+		expect(errorResponse('/reports/transactions', 'post', '413').content?.['application/json']?.schema).toBeDefined();
+	});
+
+	it('documents rate and capacity limits with Retry-After headers', () => {
+		for (const [path, method] of [
+			['/reports/facets', 'get'],
+			['/reports/transactions', 'post'],
+			['/reports/summary', 'post'],
+			['/reports/transactions.csv', 'post'],
+			['/reports/wallet-summary.csv', 'post'],
+			['/reports/totals.csv', 'post'],
+			['/reports/export.zip', 'post'],
+		] as const) {
+			for (const statusCode of ['429', '503']) {
+				const response = errorResponse(path, method, statusCode);
+				expect(response.content?.['application/json']?.schema).toBeDefined();
+				expect(response.headers).toMatchObject({
+					'Retry-After': { schema: { type: 'integer', minimum: 1 } },
+				});
+			}
+		}
+	});
+
+	it.each([
+		['/reports/transactions.csv', 'text/csv; charset=utf-8'],
+		['/reports/wallet-summary.csv', 'text/csv; charset=utf-8'],
+		['/reports/totals.csv', 'text/csv; charset=utf-8'],
+		['/reports/export.zip', 'application/zip'],
+	])('documents the binary response and download headers for %s', (path, mediaType) => {
+		const response = successResponse(path, 'post');
+
+		expect(response.content?.[mediaType]).toMatchObject({
+			schema: { type: 'string', format: 'binary' },
+		});
+		expect(response.headers).toMatchObject({
+			'Content-Disposition': { schema: { type: 'string' } },
+			'Content-Length': { schema: { type: 'integer', minimum: 0 } },
+		});
+	});
+});

--- a/src/routes/api/reports/docs.ts
+++ b/src/routes/api/reports/docs.ts
@@ -1,0 +1,281 @@
+// Colocated OpenAPI docs for this route area. When you add or change an
+// endpoint here, update THIS file in the same PR. CI checks generated docs.
+import { z } from '@masumi/payment-core/zod';
+import {
+	reportFacetsOutputSchema,
+	reportSummaryInputSchema,
+	reportSummaryOutputSchema,
+	reportTransactionsInputSchema,
+	reportTransactionsOutputSchema,
+} from '@/routes/api/reports/schemas';
+import { REPORT_CSV_CONTENT_TYPE, REPORT_ZIP_CONTENT_TYPE } from '@/services/transaction-report/export-files';
+import { successResponse, type SwaggerRegistrarContext } from '@/utils/generator/swagger-generator/shared';
+
+const reportFilterExample = {
+	paymentSourceId: 'payment_source_id',
+	managedWalletIds: ['managed_wallet_id'],
+	externalAddresses: ['addr_test1_external'],
+	roles: ['Buyer', 'Seller'],
+	states: ['FundsLocked', 'Withdrawn'],
+	from: '2026-01-01T00:00:00.000Z',
+	to: '2026-02-01T00:00:00.000Z',
+	dateBasis: 'RevenueRecognizedAt',
+	revenueMode: 'Billable',
+	timeZone: 'Etc/UTC',
+};
+
+const paymentSourceExample = {
+	id: 'payment_source_id',
+	network: 'Preprod',
+	paymentSourceType: 'Web3CardanoV2',
+	feeRatePermille: 0,
+	smartContractAddress: 'addr_test1_contract',
+	deletedAt: null,
+};
+
+const managedWalletExample = {
+	id: 'managed_wallet_id',
+	walletAddress: 'addr_test1_wallet',
+	walletVkey: 'wallet_verification_key',
+	collectionAddress: null,
+	deletedAt: null,
+};
+
+const metadataExample = {
+	generatedAt: '2026-02-01T00:00:01.000Z',
+	asOf: '2026-02-01T00:00:00.000Z',
+	paymentSource: paymentSourceExample,
+	filters: {
+		...reportFilterExample,
+		managedWalletIds: ['managed_wallet_id'],
+		externalAddresses: ['addr_test1_external'],
+	},
+	warnings: [],
+};
+
+const zeroAdaExample = {
+	unit: 'lovelace',
+	rawAmount: '0',
+	decimalAmount: '0.000000',
+	decimals: 6,
+	symbol: 'ADA',
+};
+
+const aggregateMetricExample = {
+	amounts: [zeroAdaExample],
+	completeness: 'complete',
+};
+
+const aggregateExample = {
+	transactionCount: 0,
+	transactionCountCompleteness: 'complete',
+	sellerGrossRevenue: aggregateMetricExample,
+	protocolFees: aggregateMetricExample,
+	sellerCardanoFees: aggregateMetricExample,
+	actorCardanoFees: aggregateMetricExample,
+	sellerNetRevenue: aggregateMetricExample,
+	buyerGrossSpend: aggregateMetricExample,
+	returnedFunds: aggregateMetricExample,
+	buyerCardanoFees: aggregateMetricExample,
+	buyerNetSpend: aggregateMetricExample,
+	adminCardanoFees: aggregateMetricExample,
+	totalCardanoFees: aggregateMetricExample,
+};
+
+const reportErrorResponseSchema = z.object({
+	status: z.literal('error'),
+	error: z.object({ message: z.string() }),
+});
+
+function jsonErrorResponse(description: string) {
+	return {
+		description,
+		content: {
+			'application/json': { schema: reportErrorResponseSchema.openapi({}) },
+		},
+	};
+}
+
+function retryableJsonErrorResponse(description: string) {
+	return {
+		...jsonErrorResponse(description),
+		headers: {
+			'Retry-After': {
+				description: 'Minimum seconds before another report request',
+				schema: { type: 'integer' as const, minimum: 1 },
+			},
+		},
+	};
+}
+
+const reportAdmissionErrors = {
+	429: retryableJsonErrorResponse('The API key exceeded its report request rate'),
+	503: retryableJsonErrorResponse('All report processing slots are in use'),
+};
+
+const reportErrors = {
+	...reportAdmissionErrors,
+	400: jsonErrorResponse('The report filters or cursor are invalid'),
+	401: jsonErrorResponse('Unauthorized'),
+	404: jsonErrorResponse('The payment source or requested managed wallet is not accessible'),
+	501: jsonErrorResponse('Fiat conversion is not available yet'),
+	504: jsonErrorResponse('The report calculation timed out; narrow the filters'),
+};
+
+const completeReportErrors = {
+	...reportErrors,
+	413: jsonErrorResponse('The report exceeds its row or file size limit; narrow the filters'),
+};
+
+function jsonRequest(schema: z.ZodTypeAny, example: unknown, description: string) {
+	return {
+		body: {
+			required: true,
+			description,
+			content: {
+				'application/json': {
+					schema: schema.openapi({ example }),
+				},
+			},
+		},
+	};
+}
+
+function binaryResponse(description: string, contentType: string) {
+	return {
+		description,
+		headers: {
+			'Content-Disposition': {
+				description: 'Attachment filename, including an RFC 5987 UTF-8 filename',
+				schema: { type: 'string' as const },
+			},
+			'Content-Length': {
+				description: 'Artifact size in bytes',
+				schema: { type: 'integer' as const, format: 'int64', minimum: 0 },
+			},
+		},
+		content: {
+			[contentType]: {
+				schema: { type: 'string' as const, format: 'binary' },
+			},
+		},
+	};
+}
+
+export function registerReportPaths({ registry, apiKeyAuth }: SwaggerRegistrarContext) {
+	const secured = [{ [apiKeyAuth.name]: [] }];
+	const summaryInputExample = { ...reportFilterExample, bucket: 'Auto' };
+
+	registry.registerPath({
+		method: 'get',
+		path: '/reports/facets',
+		description:
+			'Lists accessible payment sources and their managed buyer and seller wallets. Results include archived records so historical reports can retain their original labels.',
+		summary: 'List transaction report filters. (read access required)',
+		tags: ['reports'],
+		security: secured,
+		responses: {
+			200: successResponse('Accessible report filters', reportFacetsOutputSchema, {
+				paymentSources: [paymentSourceExample],
+				managedWallets: [
+					{
+						...managedWalletExample,
+						paymentSourceId: paymentSourceExample.id,
+						type: 'Selling',
+						note: 'Primary seller wallet',
+					},
+				],
+			}),
+			...reportAdmissionErrors,
+			401: reportErrors[401],
+			413: completeReportErrors[413],
+		},
+	});
+
+	registry.registerPath({
+		method: 'post',
+		path: '/reports/transactions',
+		description:
+			'Returns paginated buyer and seller report rows for one payment source. The cursor preserves the initial asOf boundary and source fee settings, but it does not preserve historical row values. Amounts include raw atomic units and decimal metadata for supported assets.',
+		summary: 'Get transaction report rows. (read access required)',
+		tags: ['reports'],
+		security: secured,
+		request: jsonRequest(
+			reportTransactionsInputSchema,
+			{ ...reportFilterExample, limit: 50 },
+			'Payment source, wallet, role, state, accounting date, revenue, and pagination filters',
+		),
+		responses: {
+			200: successResponse('Transaction report rows', reportTransactionsOutputSchema, {
+				rows: [],
+				page: { nextCursor: null, hasMore: false },
+				metadata: metadataExample,
+			}),
+			...reportErrors,
+			413: completeReportErrors[413],
+		},
+	});
+
+	registry.registerPath({
+		method: 'post',
+		path: '/reports/summary',
+		description:
+			'Returns totals, per-wallet and role totals, and time buckets from one database snapshot. The service calculates applicable V1 protocol fees from the payment source rate. Applicable V2 protocol fees are exact zero.',
+		summary: 'Get transaction report totals and history. (read access required)',
+		tags: ['reports'],
+		security: secured,
+		request: jsonRequest(reportSummaryInputSchema, summaryInputExample, 'Report filters and history bucket size'),
+		responses: {
+			200: successResponse('Transaction report totals and history', reportSummaryOutputSchema, {
+				totals: aggregateExample,
+				wallets: [],
+				history: [],
+				bucket: 'Day',
+				metadata: metadataExample,
+			}),
+			...completeReportErrors,
+		},
+	});
+
+	for (const exportPath of [
+		{
+			path: '/reports/transactions.csv',
+			description: 'Downloads one row per buyer or seller transaction as CSV.',
+			responseDescription: 'Transaction rows CSV',
+			contentType: REPORT_CSV_CONTENT_TYPE,
+		},
+		{
+			path: '/reports/wallet-summary.csv',
+			description: 'Downloads totals grouped by managed wallet and buyer or seller role as CSV.',
+			responseDescription: 'Wallet and role totals CSV',
+			contentType: REPORT_CSV_CONTENT_TYPE,
+		},
+		{
+			path: '/reports/totals.csv',
+			description: 'Downloads payment source totals as CSV.',
+			responseDescription: 'Payment source totals CSV',
+			contentType: REPORT_CSV_CONTENT_TYPE,
+		},
+		{
+			path: '/reports/export.zip',
+			description:
+				'Downloads a ZIP archive containing transactions.csv, wallet-summary.csv, and totals.csv from one database snapshot.',
+			responseDescription: 'Complete transaction report ZIP archive',
+			contentType: REPORT_ZIP_CONTENT_TYPE,
+		},
+	] as const) {
+		registry.registerPath({
+			method: 'post',
+			path: exportPath.path,
+			description: exportPath.description,
+			summary: `${exportPath.responseDescription}. (read access required)`,
+			tags: ['reports'],
+			security: secured,
+			request: jsonRequest(reportSummaryInputSchema, summaryInputExample, 'Report filters and history bucket size'),
+			responses: {
+				200: binaryResponse(exportPath.responseDescription, exportPath.contentType),
+				...completeReportErrors,
+			},
+		});
+	}
+}

--- a/src/routes/api/reports/export-result-handler.spec.ts
+++ b/src/routes/api/reports/export-result-handler.spec.ts
@@ -186,18 +186,25 @@ describe('report export result handler', () => {
 		expect(cleanup).toHaveBeenCalledTimes(1);
 	});
 
-	it('cleans once when opening the staged file fails', async () => {
+	it('answers with an error, not an empty 200, when the staged file cannot be opened', async () => {
 		const { artifact, cleanup } = await createArtifact(Buffer.from('unused'), {
 			filePath: join(testDirectory, 'missing.csv'),
 		});
 		const logger = createLogger();
+		const response = new TestResponse();
 
-		await executeSuccess(artifact, new TestResponse(), logger);
+		await executeSuccess(artifact, response, logger);
 
 		expect(cleanup).toHaveBeenCalledTimes(1);
 		expect(logger.error).toHaveBeenCalledWith('Report export stream failed', {
 			error: expect.objectContaining({ code: 'ENOENT' }),
 		});
+		// A staged 200 with a Content-Length and no body reads as a valid but
+		// empty export, so the download headers must never be set here.
+		expect(response.statusCode).not.toBe(200);
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(response.headers.has('content-length')).toBe(false);
+		expect(response.jsonBody).toMatchObject({ status: 'error' });
 	});
 
 	it('cleans once when the client disconnects during streaming', async () => {

--- a/src/routes/api/reports/export-result-handler.spec.ts
+++ b/src/routes/api/reports/export-result-handler.spec.ts
@@ -1,0 +1,389 @@
+import { jest } from '@jest/globals';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Writable } from 'node:stream';
+import type { Request, Response } from 'express';
+import { testEndpoint } from 'express-zod-api';
+import createHttpError from 'http-errors';
+import { HttpExistsError } from '@masumi/payment-core/http-exists-error';
+import { z } from '@masumi/payment-core/zod';
+import {
+	REPORT_CSV_CONTENT_TYPE,
+	REPORT_ZIP_CONTENT_TYPE,
+	type StagedReportArtifact,
+} from '@/services/transaction-report/export-files';
+import {
+	createAttachmentHeader,
+	readAuthenticatedReportExportEndpointFactory,
+	reportExportArtifactPassThroughSchema,
+	reportExportArtifactSchema,
+	reportExportResultHandler,
+} from './export-result-handler';
+
+type TestLogger = {
+	debug: jest.Mock;
+	info: jest.Mock;
+	warn: jest.Mock;
+	error: jest.Mock;
+};
+
+class TestResponse extends Writable {
+	readonly chunks: Buffer[] = [];
+	readonly headers = new Map<string, string>();
+	jsonBody: unknown;
+	statusCode = 200;
+
+	constructor(private readonly disconnectOnWrite = false) {
+		super();
+	}
+
+	status(code: number): this {
+		this.statusCode = code;
+		return this;
+	}
+
+	set(field: string | Record<string, unknown> | undefined, value?: unknown): this {
+		if (typeof field === 'string') {
+			this.headers.set(field.toLowerCase(), String(value));
+			return this;
+		}
+		for (const [name, headerValue] of Object.entries(field ?? {})) {
+			if (headerValue != null) {
+				this.headers.set(name.toLowerCase(), String(headerValue));
+			}
+		}
+		return this;
+	}
+
+	json(body: unknown): this {
+		this.jsonBody = body;
+		this.end(JSON.stringify(body));
+		return this;
+	}
+
+	get bytes(): Buffer {
+		return Buffer.concat(this.chunks);
+	}
+
+	_write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+		this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		callback();
+		if (this.disconnectOnWrite) {
+			this.destroy();
+		}
+	}
+}
+
+function createLogger(): TestLogger {
+	return {
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	};
+}
+
+async function executeSuccess(
+	artifact: StagedReportArtifact | Record<string, unknown>,
+	response: TestResponse,
+	logger: TestLogger,
+): Promise<void> {
+	await reportExportResultHandler.execute({
+		output: artifact,
+		error: null,
+		input: {},
+		ctx: {},
+		request: { url: '/api/v1/reports/transactions.csv' } as Request,
+		response: response as unknown as Response,
+		logger: logger as never,
+	});
+}
+
+async function executeError(
+	error: Error,
+	response: TestResponse,
+	logger: TestLogger,
+	input: Record<string, unknown> = {},
+): Promise<void> {
+	await reportExportResultHandler.execute({
+		output: null,
+		error,
+		input,
+		ctx: {},
+		request: { url: '/api/v1/reports/transactions.csv' } as Request,
+		response: response as unknown as Response,
+		logger: logger as never,
+	});
+}
+
+describe('report export result handler', () => {
+	let testDirectory: string;
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		testDirectory = await mkdtemp(join(tmpdir(), 'masumi-export-handler-test-'));
+	});
+
+	afterEach(async () => {
+		await rm(testDirectory, { recursive: true, force: true });
+	});
+
+	async function createArtifact(
+		content: Buffer,
+		overrides: Partial<StagedReportArtifact> = {},
+	): Promise<{ artifact: StagedReportArtifact; cleanup: jest.Mock<() => Promise<void>> }> {
+		const filePath = join(testDirectory, 'transactions.csv');
+		await writeFile(filePath, content);
+		const cleanup = jest.fn(async () => undefined);
+		return {
+			artifact: {
+				filePath,
+				filename: 'transactions.csv',
+				contentType: REPORT_CSV_CONTENT_TYPE,
+				contentLength: content.length,
+				cleanup,
+				...overrides,
+			},
+			cleanup,
+		};
+	}
+
+	it('streams exact bytes with download headers, then cleans once', async () => {
+		const content = Buffer.from('id,amount\r\n1,42\r\n');
+		const { artifact, cleanup } = await createArtifact(content);
+		const response = new TestResponse();
+		const logger = createLogger();
+
+		await executeSuccess(artifact, response, logger);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers.get('content-type')).toBe(REPORT_CSV_CONTENT_TYPE);
+		expect(response.headers.get('content-disposition')).toBe(
+			`attachment; filename="transactions.csv"; filename*=UTF-8''transactions.csv`,
+		);
+		expect(response.headers.get('content-length')).toBe(String(content.length));
+		expect(response.headers.get('cache-control')).toBe('no-store');
+		expect(response.bytes).toEqual(content);
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it('declares ZIP downloads with an RFC 5987 filename', async () => {
+		const content = Buffer.from('zip bytes');
+		const { artifact, cleanup } = await createArtifact(content, {
+			filename: 'report 2026.zip',
+			contentType: REPORT_ZIP_CONTENT_TYPE,
+		});
+		const response = new TestResponse();
+
+		await executeSuccess(artifact, response, createLogger());
+
+		expect(response.headers.get('content-type')).toBe(REPORT_ZIP_CONTENT_TYPE);
+		expect(response.headers.get('content-disposition')).toBe(
+			`attachment; filename="report 2026.zip"; filename*=UTF-8''report%202026.zip`,
+		);
+		expect(cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it('cleans once when opening the staged file fails', async () => {
+		const { artifact, cleanup } = await createArtifact(Buffer.from('unused'), {
+			filePath: join(testDirectory, 'missing.csv'),
+		});
+		const logger = createLogger();
+
+		await executeSuccess(artifact, new TestResponse(), logger);
+
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalledWith('Report export stream failed', {
+			error: expect.objectContaining({ code: 'ENOENT' }),
+		});
+	});
+
+	it('cleans once when the client disconnects during streaming', async () => {
+		const { artifact, cleanup } = await createArtifact(Buffer.alloc(128 * 1024, 7));
+		const logger = createLogger();
+
+		await executeSuccess(artifact, new TestResponse(true), logger);
+
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalledWith('Report export stream failed', {
+			error: expect.objectContaining({ code: 'ERR_STREAM_PREMATURE_CLOSE' }),
+		});
+	});
+
+	it('keeps HTTP errors as JSON and does not set attachment headers', async () => {
+		const response = new TestResponse();
+		await executeError(
+			createHttpError(429, 'Report limit reached', { headers: { 'Retry-After': '30' } }),
+			response,
+			createLogger(),
+		);
+
+		expect(response.statusCode).toBe(429);
+		expect(response.jsonBody).toEqual({
+			status: 'error',
+			error: { message: 'Report limit reached' },
+		});
+		expect(response.headers.get('retry-after')).toBe('30');
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(response.headers.has('content-length')).toBe(false);
+	});
+
+	it('redacts sensitive input in the existing server error log path', async () => {
+		const response = new TestResponse();
+		const logger = createLogger();
+		await executeError(new Error('internal failure'), response, logger, {
+			mnemonic: 'secret words',
+			nested: { apiKey: 'secret key', safe: 'visible' },
+		});
+
+		expect(response.statusCode).toBe(500);
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(logger.error).toHaveBeenCalledWith(
+			'Server side error',
+			expect.objectContaining({
+				url: '/api/v1/reports/transactions.csv',
+				payload: {
+					mnemonic: '[REDACTED]',
+					nested: { apiKey: '[REDACTED]', safe: 'visible' },
+				},
+			}),
+		);
+	});
+
+	it('keeps HttpExistsError conflict details in the existing JSON envelope', async () => {
+		const response = new TestResponse();
+		const logger = createLogger();
+
+		await executeError(
+			new HttpExistsError('Report already exists', 'report-1', {
+				id: 'report-1',
+				name: 'Existing report',
+			}),
+			response,
+			logger,
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.jsonBody).toEqual({
+			status: 'error',
+			error: { message: 'Report already exists' },
+			id: 'report-1',
+			object: { id: 'report-1', name: 'Existing report' },
+		});
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it.each(['bad\r\nInjected: value.csv', '../report.csv', 'folder/report.csv', '', '\ud800.csv'])(
+		'rejects unsafe filename %p before response headers',
+		async (filename) => {
+			const content = Buffer.from('unused');
+			const { artifact, cleanup } = await createArtifact(content, { filename });
+			const response = new TestResponse();
+
+			await executeSuccess(artifact, response, createLogger());
+
+			expect(response.statusCode).toBe(500);
+			expect(response.jsonBody).toEqual({
+				status: 'error',
+				error: { message: expect.any(String) },
+			});
+			expect(response.headers.has('content-disposition')).toBe(false);
+			expect(response.headers.has('content-type')).toBe(false);
+			expect(cleanup).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it('logs one cleanup failure after rejecting an invalid staged artifact', async () => {
+		const cleanupError = new Error('cleanup failed');
+		const { artifact, cleanup } = await createArtifact(Buffer.from('unused'), {
+			filename: 'bad\r\nfilename.csv',
+		});
+		cleanup.mockRejectedValue(cleanupError);
+		const response = new TestResponse();
+		const logger = createLogger();
+
+		await executeSuccess(artifact, response, logger);
+
+		expect(response.statusCode).toBe(500);
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(cleanup).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalledWith('Report export cleanup failed', { error: cleanupError });
+	});
+
+	it('cleans once when artifact property access throws during validation', async () => {
+		const cleanup = jest.fn(async () => undefined);
+		const validationError = new Error('filename getter failed');
+		const artifact: Record<string, unknown> = {
+			filePath: join(testDirectory, 'unused.csv'),
+			contentType: REPORT_CSV_CONTENT_TYPE,
+			contentLength: 0,
+			cleanup,
+		};
+		Object.defineProperty(artifact, 'filename', {
+			enumerable: true,
+			get: () => {
+				throw validationError;
+			},
+		});
+		const response = new TestResponse();
+
+		await executeSuccess(artifact, response, createLogger());
+
+		expect(response.statusCode).toBe(500);
+		expect(response.headers.has('content-disposition')).toBe(false);
+		expect(cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it('requires read authentication on the export endpoint factory', async () => {
+		const handler = jest.fn(async () => (await createArtifact(Buffer.from('unused'))).artifact);
+		const endpoint = readAuthenticatedReportExportEndpointFactory.build({
+			method: 'get',
+			input: z.object({}),
+			output: reportExportArtifactPassThroughSchema,
+			handler,
+		});
+		const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+
+		try {
+			const { responseMock } = await testEndpoint({
+				endpoint,
+				requestProps: { method: 'GET', headers: {} },
+			});
+
+			expect(responseMock.statusCode).toBe(401);
+			expect(responseMock._getJSONData()).toEqual({
+				status: 'error',
+				error: { message: 'Unauthorized, no authentication token provided' },
+			});
+			expect(responseMock.getHeader('content-disposition')).toBeUndefined();
+			expect(handler).not.toHaveBeenCalled();
+		} finally {
+			randomSpy.mockRestore();
+		}
+	});
+});
+
+describe('report export header helpers', () => {
+	it('encodes Unicode without allowing raw non-ASCII header bytes', () => {
+		expect(createAttachmentHeader('résumé.csv')).toBe(
+			`attachment; filename="r_sum_.csv"; filename*=UTF-8''r%C3%A9sum%C3%A9.csv`,
+		);
+	});
+
+	it('accepts the two staged artifact content types', () => {
+		for (const contentType of [REPORT_CSV_CONTENT_TYPE, REPORT_ZIP_CONTENT_TYPE]) {
+			expect(
+				reportExportArtifactSchema.safeParse({
+					filePath: '/private/tmp/report',
+					filename: 'report.csv',
+					contentType,
+					contentLength: 0,
+					cleanup: async () => undefined,
+				}).success,
+			).toBe(true);
+		}
+	});
+});

--- a/src/routes/api/reports/export-result-handler.ts
+++ b/src/routes/api/reports/export-result-handler.ts
@@ -1,0 +1,136 @@
+import { createReadStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { authMiddleware } from '@masumi/payment-core/auth-middleware';
+import { endpointErrorResponseSchema, sendEndpointError } from '@masumi/payment-core/endpoint-factory';
+import { z } from '@masumi/payment-core/zod';
+import { EndpointsFactory, ResultHandler } from 'express-zod-api';
+import {
+	REPORT_CSV_CONTENT_TYPE,
+	REPORT_ZIP_CONTENT_TYPE,
+	type StagedReportArtifact,
+} from '@/services/transaction-report/export-files';
+
+const MAX_DOWNLOAD_FILENAME_LENGTH = 255;
+
+const cleanupSchema = z.custom<StagedReportArtifact['cleanup']>(
+	(value) => typeof value === 'function',
+	'Cleanup must be a function',
+);
+
+export const reportExportArtifactSchema = z.object({
+	filePath: z.string().min(1),
+	filename: z
+		.string()
+		.min(1)
+		.max(MAX_DOWNLOAD_FILENAME_LENGTH)
+		.refine(
+			(filename) =>
+				!filename.includes('/') &&
+				!filename.includes('\\') &&
+				[...filename].every((character) => {
+					const codePoint = character.codePointAt(0) ?? 0;
+					return codePoint >= 0x20 && codePoint !== 0x7f && !(codePoint >= 0xd800 && codePoint <= 0xdfff);
+				}),
+			'Invalid download filename',
+		),
+	contentType: z.enum([REPORT_CSV_CONTENT_TYPE, REPORT_ZIP_CONTENT_TYPE]),
+	contentLength: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+	cleanup: cleanupSchema,
+});
+
+export const reportExportArtifactPassThroughSchema = z.custom<StagedReportArtifact>();
+
+function encodeRfc5987Value(value: string): string {
+	return encodeURIComponent(value).replace(
+		/[!'()*]/g,
+		(character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+	);
+}
+
+export function createAttachmentHeader(filename: string): string {
+	const asciiFallback = filename.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '\\$&');
+	return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeRfc5987Value(filename)}`;
+}
+
+const binaryResponseSchema = z.string().meta({ format: 'binary' });
+
+async function cleanupReportArtifact(
+	value: unknown,
+	logger: { error: (message: string, meta: { error: unknown }) => unknown },
+): Promise<void> {
+	let cleanup: unknown;
+	try {
+		cleanup =
+			(typeof value === 'object' && value !== null) || typeof value === 'function'
+				? Reflect.get(value, 'cleanup')
+				: undefined;
+	} catch (cleanupLookupError) {
+		logger.error('Report export cleanup failed', { error: cleanupLookupError });
+		return;
+	}
+
+	if (typeof cleanup !== 'function') {
+		return;
+	}
+
+	try {
+		await Reflect.apply(cleanup, value, []);
+	} catch (cleanupError) {
+		logger.error('Report export cleanup failed', { error: cleanupError });
+	}
+}
+
+export const reportExportResultHandler = new ResultHandler({
+	positive: [
+		{ schema: binaryResponseSchema, mimeType: REPORT_CSV_CONTENT_TYPE },
+		{ schema: binaryResponseSchema, mimeType: REPORT_ZIP_CONTENT_TYPE },
+	],
+	negative: endpointErrorResponseSchema,
+	handler: async ({ error, input, output, request, response, logger }) => {
+		if (error) {
+			sendEndpointError({ error, input, request, response, logger });
+			return;
+		}
+
+		const rejectInvalidArtifact = async (validationError: Error): Promise<void> => {
+			try {
+				sendEndpointError({ error: validationError, input, request, response, logger });
+			} finally {
+				await cleanupReportArtifact(output, logger);
+			}
+		};
+
+		let artifactResult: ReturnType<typeof reportExportArtifactSchema.safeParse>;
+		try {
+			artifactResult = reportExportArtifactSchema.safeParse(output);
+		} catch (validationError) {
+			await rejectInvalidArtifact(
+				validationError instanceof Error ? validationError : new Error('Invalid report export artifact'),
+			);
+			return;
+		}
+		if (!artifactResult.success) {
+			await rejectInvalidArtifact(artifactResult.error);
+			return;
+		}
+		const artifact = artifactResult.data;
+
+		try {
+			response.status(200).set({
+				'Content-Type': artifact.contentType,
+				'Content-Disposition': createAttachmentHeader(artifact.filename),
+				'Content-Length': String(artifact.contentLength),
+				'Cache-Control': 'no-store',
+			});
+			await pipeline(createReadStream(artifact.filePath), response);
+		} catch (streamError) {
+			logger.error('Report export stream failed', { error: streamError });
+		} finally {
+			await cleanupReportArtifact(artifact, logger);
+		}
+	},
+});
+
+export const readAuthenticatedReportExportEndpointFactory = new EndpointsFactory(
+	reportExportResultHandler,
+).addMiddleware(authMiddleware({ canRead: true }));

--- a/src/routes/api/reports/export-result-handler.ts
+++ b/src/routes/api/reports/export-result-handler.ts
@@ -1,4 +1,5 @@
 import { createReadStream } from 'node:fs';
+import { once } from 'node:events';
 import { pipeline } from 'node:stream/promises';
 import { authMiddleware } from '@masumi/payment-core/auth-middleware';
 import { endpointErrorResponseSchema, sendEndpointError } from '@masumi/payment-core/endpoint-factory';
@@ -116,13 +117,33 @@ export const reportExportResultHandler = new ResultHandler({
 		const artifact = artifactResult.data;
 
 		try {
+			// Open the staged file before staging 200 and the download headers. A
+			// stream that fails to open after them left the client with an aborted
+			// empty 200 whose Content-Length did not match the body, which reads as
+			// a valid but empty export. Once headers are sent there is no way back,
+			// so a mid-stream failure still only destroys the response.
+			const fileStream = createReadStream(artifact.filePath);
+			try {
+				await once(fileStream, 'open');
+			} catch (openError) {
+				fileStream.destroy();
+				logger.error('Report export stream failed', { error: openError });
+				sendEndpointError({
+					error: openError instanceof Error ? openError : new Error('Report export could not be read'),
+					input,
+					request,
+					response,
+					logger,
+				});
+				return;
+			}
 			response.status(200).set({
 				'Content-Type': artifact.contentType,
 				'Content-Disposition': createAttachmentHeader(artifact.filename),
 				'Content-Length': String(artifact.contentLength),
 				'Cache-Control': 'no-store',
 			});
-			await pipeline(createReadStream(artifact.filePath), response);
+			await pipeline(fileStream, response);
 		} catch (streamError) {
 			logger.error('Report export stream failed', { error: streamError });
 		} finally {

--- a/src/routes/api/reports/index.spec.ts
+++ b/src/routes/api/reports/index.spec.ts
@@ -1,0 +1,419 @@
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import type { Mock } from 'jest-mock';
+import { testEndpoint } from 'express-zod-api';
+import createHttpError from 'http-errors';
+import { ApiKeyStatus, Network, PaymentSourceType } from '@/generated/prisma/client';
+
+type AnyMock = Mock<(...args: any[]) => any>;
+
+const mockFindApiKey = jest.fn() as AnyMock;
+const mockGetFacets = jest.fn() as AnyMock;
+const mockGetTransactions = jest.fn() as AnyMock;
+const mockGetSummary = jest.fn() as AnyMock;
+const mockCreateReportExport = jest.fn() as AnyMock;
+
+jest.unstable_mockModule('@masumi/payment-core/db', () => ({
+	prisma: { apiKey: { findUnique: mockFindApiKey } },
+}));
+
+jest.unstable_mockModule('@/services/transaction-report/service', () => ({
+	getReportFacets: mockGetFacets,
+	getTransactionsReport: mockGetTransactions,
+	getSummaryReport: mockGetSummary,
+}));
+
+jest.unstable_mockModule('@/services/transaction-report/export-service', () => ({
+	createReportExport: mockCreateReportExport,
+}));
+
+const {
+	reportExportZipEndpointPost,
+	reportFacetsEndpointGet,
+	reportSummaryEndpointPost,
+	reportTotalsCsvEndpointPost,
+	reportTransactionsCsvEndpointPost,
+	reportTransactionsEndpointPost,
+	reportWalletSummaryCsvEndpointPost,
+} = await import('./index');
+
+const generatedAt = new Date('2026-02-02T00:00:00.000Z');
+const source = {
+	id: 'source-1',
+	network: Network.Preprod,
+	paymentSourceType: PaymentSourceType.Web3CardanoV2,
+	feeRatePermille: 0,
+	smartContractAddress: 'addr_test1contract',
+	deletedAt: null,
+};
+
+function apiKey(id = 'api-key-1') {
+	return {
+		id,
+		canRead: true,
+		canPay: false,
+		canAdmin: false,
+		status: ApiKeyStatus.Active,
+		token: null,
+		tokenHash: null,
+		tokenHashSecure: 'pbkdf2-placeholder',
+		usageLimited: false,
+		networkLimit: [Network.Preprod],
+		caip2NetworkLimit: [],
+		walletScopeEnabled: false,
+		WalletScopes: [],
+		X402WalletScopes: [],
+	};
+}
+
+function filters() {
+	return {
+		paymentSourceId: 'source-1',
+		managedWalletIds: [],
+		externalAddresses: [],
+		roles: ['Buyer', 'Seller'],
+		states: [],
+		from: new Date('2026-01-01T00:00:00.000Z'),
+		to: new Date('2026-02-01T00:00:00.000Z'),
+		dateBasis: 'CreatedAt',
+		revenueMode: 'Billable',
+		timeZone: 'Etc/UTC',
+	};
+}
+
+function metadata() {
+	return {
+		generatedAt,
+		asOf: generatedAt,
+		paymentSource: source,
+		filters: filters(),
+		warnings: [],
+	};
+}
+
+const zeroAmount = {
+	unit: 'lovelace',
+	rawAmount: '0',
+	decimalAmount: '0.000000',
+	decimals: 6,
+	symbol: 'ADA',
+};
+
+function aggregate() {
+	const metric = () => ({ amounts: [zeroAmount], completeness: 'complete' });
+	return {
+		transactionCount: 0,
+		transactionCountCompleteness: 'complete',
+		sellerGrossRevenue: metric(),
+		protocolFees: metric(),
+		sellerCardanoFees: metric(),
+		actorCardanoFees: metric(),
+		sellerNetRevenue: metric(),
+		buyerGrossSpend: metric(),
+		returnedFunds: metric(),
+		buyerCardanoFees: metric(),
+		buyerNetSpend: metric(),
+		adminCardanoFees: metric(),
+		totalCardanoFees: metric(),
+	};
+}
+
+function reportBody() {
+	return {
+		paymentSourceId: 'source-1',
+		from: '2026-01-01T00:00:00.000Z',
+		to: '2026-02-01T00:00:00.000Z',
+		dateBasis: 'CreatedAt',
+		revenueMode: 'Billable',
+		timeZone: 'Etc/UTC',
+	};
+}
+
+describe('report JSON endpoints', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockFindApiKey.mockResolvedValue(apiKey());
+		mockGetFacets.mockResolvedValue({
+			paymentSources: [source],
+			managedWallets: [
+				{
+					id: 'wallet-1',
+					paymentSourceId: 'source-1',
+					type: 'Selling',
+					walletAddress: 'addr-wallet',
+					walletVkey: 'wallet-vkey',
+					collectionAddress: null,
+					note: null,
+					deletedAt: null,
+				},
+			],
+		});
+		mockGetTransactions.mockResolvedValue({
+			rows: [],
+			page: { nextCursor: null, hasMore: false },
+			metadata: metadata(),
+		});
+		mockGetSummary.mockResolvedValue({
+			totals: aggregate(),
+			wallets: [],
+			history: [],
+			bucket: 'Week',
+			metadata: metadata(),
+		});
+	});
+
+	it('exposes active and archived report facets through read authentication', async () => {
+		const { responseMock } = await testEndpoint({
+			endpoint: reportFacetsEndpointGet,
+			requestProps: { method: 'GET', headers: { token: 'valid' } },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(200);
+		expect(responseMock.getHeader('cache-control')).toBe('private, no-store');
+		expect(responseMock.getHeader('vary')).toBe('token');
+		expect(mockGetFacets).toHaveBeenCalledWith(expect.objectContaining({ canRead: true }), expect.any(AbortSignal));
+		expect(responseMock._getJSONData().data.paymentSources[0]).toMatchObject({
+			id: 'source-1',
+			paymentSourceType: PaymentSourceType.Web3CardanoV2,
+		});
+	});
+
+	it('parses transaction report dates and applies schema defaults', async () => {
+		const { responseMock } = await testEndpoint({
+			endpoint: reportTransactionsEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'valid', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(200);
+		expect(mockGetTransactions).toHaveBeenCalledWith(
+			expect.objectContaining({
+				paymentSourceId: 'source-1',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				roles: ['Buyer', 'Seller'],
+				limit: 50,
+			}),
+			expect.objectContaining({ canRead: true }),
+			expect.any(AbortSignal),
+		);
+	});
+
+	it('returns the exact summary shape including admin Cardano fees', async () => {
+		const { responseMock } = await testEndpoint({
+			endpoint: reportSummaryEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'valid', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(200);
+		expect(mockGetSummary).toHaveBeenCalledWith(
+			expect.objectContaining({ paymentSourceId: 'source-1' }),
+			expect.objectContaining({ canRead: true }),
+			expect.any(AbortSignal),
+		);
+		expect(responseMock._getJSONData().data.totals.adminCardanoFees).toEqual({
+			amounts: [zeroAmount],
+			completeness: 'complete',
+		});
+	});
+
+	it('rejects an invalid range before report work starts', async () => {
+		const { responseMock } = await testEndpoint({
+			endpoint: reportTransactionsEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'valid', 'content-type': 'application/json' },
+				body: { ...reportBody(), to: '2025-12-01T00:00:00.000Z' },
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(400);
+		expect(mockGetTransactions).not.toHaveBeenCalled();
+	});
+
+	it('rate limits report data requests per API key', async () => {
+		mockFindApiKey.mockResolvedValue(apiKey('api-key-report-rate'));
+
+		for (let attempt = 0; attempt < 30; attempt += 1) {
+			const { responseMock } = await testEndpoint({
+				endpoint: reportTransactionsEndpointPost,
+				requestProps: {
+					method: 'POST',
+					headers: { token: 'rate-limited', 'content-type': 'application/json' },
+					body: reportBody(),
+				},
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			expect(responseMock.statusCode).toBe(200);
+		}
+
+		const { responseMock } = await testEndpoint({
+			endpoint: reportSummaryEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'rate-limited', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(429);
+		expect(responseMock.getHeader('retry-after')).toBeDefined();
+		expect(mockGetTransactions).toHaveBeenCalledTimes(30);
+		expect(mockGetSummary).not.toHaveBeenCalled();
+	});
+
+	it('caps concurrent report work for admin API keys', async () => {
+		mockFindApiKey.mockResolvedValue({ ...apiKey('api-key-report-admin'), canAdmin: true });
+		const summary = {
+			totals: aggregate(),
+			wallets: [],
+			history: [],
+			bucket: 'Week',
+			metadata: metadata(),
+		};
+		let resolveSummary!: (value: typeof summary) => void;
+		const pendingSummary = new Promise<typeof summary>((resolve) => {
+			resolveSummary = resolve;
+		});
+		let resolveStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			resolveStarted = resolve;
+		});
+		mockGetSummary.mockImplementation(() => {
+			if (mockGetSummary.mock.calls.length === 4) resolveStarted();
+			return mockGetSummary.mock.calls.length <= 4 ? pendingSummary : Promise.resolve(summary);
+		});
+		const request = () =>
+			testEndpoint({
+				endpoint: reportSummaryEndpointPost,
+				requestProps: {
+					method: 'POST',
+					headers: { token: 'admin', 'content-type': 'application/json' },
+					body: reportBody(),
+				},
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+		const active = Array.from({ length: 4 }, request);
+		await started;
+		expect(mockGetSummary).toHaveBeenCalledTimes(4);
+
+		try {
+			const blocked = await request();
+			expect(blocked.responseMock.statusCode).toBe(503);
+			expect(blocked.responseMock.getHeader('retry-after')).toBe('1');
+			expect(mockGetSummary).toHaveBeenCalledTimes(4);
+		} finally {
+			resolveSummary(summary);
+			await Promise.all(active);
+		}
+	});
+});
+
+describe('report export endpoints', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockFindApiKey.mockResolvedValue(apiKey());
+		mockCreateReportExport.mockRejectedValue(createHttpError(503, 'staging unavailable'));
+	});
+
+	it.each([
+		['transactions', reportTransactionsCsvEndpointPost],
+		['wallet-summary', reportWalletSummaryCsvEndpointPost],
+		['totals', reportTotalsCsvEndpointPost],
+		['zip', reportExportZipEndpointPost],
+	] as const)('creates the %s export from the parsed report filters', async (kind, endpoint) => {
+		const { responseMock } = await testEndpoint({
+			endpoint,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'valid', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(503);
+		expect(mockCreateReportExport).toHaveBeenCalledWith(
+			expect.objectContaining({
+				paymentSourceId: 'source-1',
+				from: new Date('2026-01-01T00:00:00.000Z'),
+				roles: ['Buyer', 'Seller'],
+			}),
+			expect.objectContaining({ canRead: true }),
+			kind,
+			expect.any(AbortSignal),
+			expect.any(Function),
+		);
+	});
+
+	it('cleans an invalid staged artifact after endpoint output pass-through', async () => {
+		const cleanup = jest.fn(async () => undefined);
+		mockCreateReportExport.mockResolvedValue({
+			filePath: '/private/tmp/staged-report.csv',
+			filename: 'bad\r\nInjected.csv',
+			contentType: 'text/csv; charset=utf-8',
+			contentLength: 12,
+			cleanup,
+		});
+
+		const { responseMock } = await testEndpoint({
+			endpoint: reportTransactionsCsvEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'valid', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(500);
+		expect(responseMock._getJSONData()).toEqual({
+			status: 'error',
+			error: { message: expect.any(String) },
+		});
+		expect(responseMock.getHeader('content-disposition')).toBeUndefined();
+		expect(cleanup).toHaveBeenCalledTimes(1);
+	});
+
+	it('rate limits report exports per API key', async () => {
+		mockFindApiKey.mockResolvedValue(apiKey('api-key-export-rate'));
+
+		for (let attempt = 0; attempt < 5; attempt += 1) {
+			const { responseMock } = await testEndpoint({
+				endpoint: reportTotalsCsvEndpointPost,
+				requestProps: {
+					method: 'POST',
+					headers: { token: 'export-rate-limited', 'content-type': 'application/json' },
+					body: reportBody(),
+				},
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			expect(responseMock.statusCode).toBe(503);
+		}
+
+		const { responseMock } = await testEndpoint({
+			endpoint: reportExportZipEndpointPost,
+			requestProps: {
+				method: 'POST',
+				headers: { token: 'export-rate-limited', 'content-type': 'application/json' },
+				body: reportBody(),
+			},
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+
+		expect(responseMock.statusCode).toBe(429);
+		expect(responseMock.getHeader('retry-after')).toBeDefined();
+		expect(mockCreateReportExport).toHaveBeenCalledTimes(5);
+	});
+});

--- a/src/routes/api/reports/index.ts
+++ b/src/routes/api/reports/index.ts
@@ -1,0 +1,83 @@
+import { readAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
+import { z } from '@masumi/payment-core/zod';
+import { createReportExport } from '@/services/transaction-report/export-service';
+import { getReportFacets, getSummaryReport, getTransactionsReport } from '@/services/transaction-report/service';
+import { createAuthenticatedRateLimitMiddleware } from '@/utils/middleware/rate-limit';
+import {
+	readAuthenticatedReportExportEndpointFactory,
+	reportExportArtifactPassThroughSchema,
+} from './export-result-handler';
+import {
+	reportFacetsOutputSchema,
+	reportSummaryInputSchema,
+	reportSummaryOutputSchema,
+	reportTransactionsInputSchema,
+	reportTransactionsOutputSchema,
+} from './schemas';
+import { privateReportResponseMiddleware, reportAbortMiddleware, reportConcurrencyMiddleware } from './request-control';
+
+const reportFacetsInputSchema = z.object({});
+const reportDataRateLimitMiddleware = createAuthenticatedRateLimitMiddleware({
+	maxRequests: 30,
+	windowMs: 60_000,
+});
+const reportExportRateLimitMiddleware = createAuthenticatedRateLimitMiddleware({
+	maxRequests: 5,
+	windowMs: 60_000,
+});
+const reportEndpointFactory = readAuthenticatedEndpointFactory
+	.addMiddleware(privateReportResponseMiddleware)
+	.addMiddleware(reportDataRateLimitMiddleware)
+	.addMiddleware(reportAbortMiddleware)
+	.addMiddleware(reportConcurrencyMiddleware);
+const reportExportEndpointFactory = readAuthenticatedReportExportEndpointFactory
+	.addMiddleware(reportExportRateLimitMiddleware)
+	.addMiddleware(reportAbortMiddleware)
+	.addMiddleware(reportConcurrencyMiddleware);
+
+export const reportFacetsEndpointGet = reportEndpointFactory.build({
+	method: 'get',
+	input: reportFacetsInputSchema,
+	output: reportFacetsOutputSchema,
+	handler: async ({ ctx }) => ctx.runReportOperation(() => getReportFacets(ctx, ctx.reportAbortSignal)),
+});
+
+export const reportTransactionsEndpointPost = reportEndpointFactory.build({
+	method: 'post',
+	input: reportTransactionsInputSchema,
+	output: reportTransactionsOutputSchema,
+	handler: async ({ input, ctx }) =>
+		ctx.runReportOperation(() => getTransactionsReport(input, ctx, ctx.reportAbortSignal)),
+});
+
+export const reportSummaryEndpointPost = reportEndpointFactory.build({
+	method: 'post',
+	input: reportSummaryInputSchema,
+	output: reportSummaryOutputSchema,
+	handler: async ({ input, ctx }) => ctx.runReportOperation(() => getSummaryReport(input, ctx, ctx.reportAbortSignal)),
+});
+
+function buildReportExportEndpoint(kind: 'transactions' | 'wallet-summary' | 'totals' | 'zip') {
+	return reportExportEndpointFactory.build({
+		method: 'post',
+		input: reportSummaryInputSchema,
+		output: reportExportArtifactPassThroughSchema,
+		handler: async ({ input, ctx }) =>
+			ctx.runReportOperation((trackPendingWork) =>
+				createReportExport(input, ctx, kind, ctx.reportAbortSignal, trackPendingWork),
+			),
+	});
+}
+
+export const reportTransactionsCsvEndpointPost = buildReportExportEndpoint('transactions');
+export const reportWalletSummaryCsvEndpointPost = buildReportExportEndpoint('wallet-summary');
+export const reportTotalsCsvEndpointPost = buildReportExportEndpoint('totals');
+export const reportExportZipEndpointPost = buildReportExportEndpoint('zip');
+
+export {
+	reportFacetsOutputSchema,
+	reportSummaryInputSchema,
+	reportSummaryOutputSchema,
+	reportTransactionsInputSchema,
+	reportTransactionsOutputSchema,
+};

--- a/src/routes/api/reports/index.ts
+++ b/src/routes/api/reports/index.ts
@@ -31,6 +31,10 @@ const reportEndpointFactory = readAuthenticatedEndpointFactory
 	.addMiddleware(reportAbortMiddleware)
 	.addMiddleware(reportConcurrencyMiddleware);
 const reportExportEndpointFactory = readAuthenticatedReportExportEndpointFactory
+	// Export errors are JSON like the data endpoints and depend on the token, so
+	// they need the same Cache-Control and Vary. The success path sets its own
+	// no-store, but only after this middleware has already covered the failures.
+	.addMiddleware(privateReportResponseMiddleware)
 	.addMiddleware(reportExportRateLimitMiddleware)
 	.addMiddleware(reportAbortMiddleware)
 	.addMiddleware(reportConcurrencyMiddleware);

--- a/src/routes/api/reports/request-control.spec.ts
+++ b/src/routes/api/reports/request-control.spec.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { z } from '@masumi/payment-core/zod';
+import { Network } from '@/generated/prisma/client';
+import { defaultEndpointsFactory, Middleware, testEndpoint, testMiddleware } from 'express-zod-api';
+import {
+	privateReportResponseMiddleware,
+	reportAbortMiddleware,
+	reportConcurrencyMiddleware,
+	REPORT_RESPONSE_TIMEOUT_MS,
+} from './request-control';
+
+const authContext: AuthContext = {
+	id: 'api-key-1',
+	canRead: true,
+	canPay: false,
+	canAdmin: false,
+	networkLimit: [Network.Preprod],
+	caip2NetworkLimit: [],
+	usageLimited: false,
+	walletScopeIds: null,
+	x402WalletScopeIds: null,
+};
+
+describe('report request control', () => {
+	it('preserves existing Vary fields when it adds the token field', async () => {
+		const existingVaryMiddleware = new Middleware<Record<string, never>, AuthContext, string>({
+			handler: async ({ response }) => {
+				response.setHeader('Vary', 'Origin');
+				return authContext;
+			},
+		});
+		const endpoint = defaultEndpointsFactory
+			.addMiddleware(existingVaryMiddleware)
+			.addMiddleware(privateReportResponseMiddleware)
+			.build({
+				method: 'get',
+				input: z.object({}),
+				output: z.object({ ok: z.boolean() }),
+				handler: async () => ({ ok: true }),
+			});
+
+		const { responseMock } = await testEndpoint({
+			endpoint,
+			requestProps: { method: 'GET' },
+		});
+
+		expect(responseMock.getHeader('vary')).toBe('Origin, token');
+	});
+
+	it('aborts report work when the request is aborted', async () => {
+		const { output, requestMock } = await testMiddleware({
+			middleware: reportAbortMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+		});
+		const signal = output.reportAbortSignal as AbortSignal;
+
+		expect(signal.aborted).toBe(false);
+		requestMock.emit('aborted');
+		expect(signal.aborted).toBe(true);
+	});
+
+	it('does not abort completed report work when the response closes normally', async () => {
+		const { output, responseMock } = await testMiddleware({
+			middleware: reportAbortMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		const signal = output.reportAbortSignal as AbortSignal;
+		Object.defineProperty(responseMock, 'writableEnded', { configurable: true, value: true });
+
+		responseMock.emit('close');
+		expect(signal.aborted).toBe(false);
+	});
+
+	it('aborts unfinished report work when the response closes early', async () => {
+		const { output, responseMock } = await testMiddleware({
+			middleware: reportAbortMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		const signal = output.reportAbortSignal as AbortSignal;
+
+		responseMock.emit('close');
+		expect(signal.aborted).toBe(true);
+	});
+
+	it('caps concurrent reports for admin API keys and releases completed slots', async () => {
+		const adminContext = { ...authContext, canAdmin: true };
+		const active = await Promise.all(
+			Array.from({ length: 4 }, () =>
+				testMiddleware({
+					middleware: reportConcurrencyMiddleware,
+					ctx: adminContext,
+					requestProps: { method: 'POST', body: {} },
+					responseOptions: { eventEmitter: EventEmitter },
+				}),
+			),
+		);
+		expect(active.map(({ responseMock }) => responseMock.statusCode)).toEqual([200, 200, 200, 200]);
+
+		const blocked = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: adminContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(blocked.responseMock.statusCode).toBe(503);
+		expect(blocked.responseMock.getHeader('retry-after')).toBe('1');
+
+		type RunReportOperation = <T>(
+			operation: (trackPendingWork: (work: Promise<unknown>) => void) => Promise<T>,
+		) => Promise<T>;
+		const runReportOperation = active[0].output.runReportOperation as RunReportOperation | undefined;
+		if (runReportOperation == null) {
+			for (const { responseMock } of active) responseMock.emit('finish');
+		}
+		expect(runReportOperation).toEqual(expect.any(Function));
+		let resolvePendingWork!: () => void;
+		const pendingWork = new Promise<void>((resolve) => {
+			resolvePendingWork = resolve;
+		});
+		const responseOperation = runReportOperation?.(async (trackPendingWork) => {
+			trackPendingWork(pendingWork);
+			throw new Error('Report response deadline reached');
+		});
+		active[0].responseMock.emit('close');
+		await expect(responseOperation).rejects.toThrow('Report response deadline reached');
+
+		const blockedAfterClose = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: adminContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(blockedAfterClose.responseMock.statusCode).toBe(503);
+
+		resolvePendingWork();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		const admitted = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: adminContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(admitted.responseMock.statusCode).toBe(200);
+
+		for (const { responseMock } of active.slice(1)) responseMock.emit('finish');
+		admitted.responseMock.emit('finish');
+	});
+
+	it('holds resolved report slots until their responses finish', async () => {
+		const active = await Promise.all(
+			Array.from({ length: 4 }, () =>
+				testMiddleware({
+					middleware: reportConcurrencyMiddleware,
+					ctx: authContext,
+					requestProps: { method: 'POST', body: {} },
+					responseOptions: { eventEmitter: EventEmitter },
+				}),
+			),
+		);
+		await Promise.all(
+			active.map(({ output }) => {
+				const runReportOperation = output.runReportOperation as
+					| ((operation: () => Promise<string>) => Promise<string>)
+					| undefined;
+				return runReportOperation?.(async () => 'staged-artifact');
+			}),
+		);
+
+		const blocked = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(blocked.responseMock.statusCode).toBe(503);
+
+		active[0].responseMock.emit('finish');
+		const admitted = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(admitted.responseMock.statusCode).toBe(200);
+
+		for (const { responseMock } of active.slice(1)) responseMock.emit('finish');
+		admitted.responseMock.emit('finish');
+	});
+
+	it('expires unfinished responses and releases their report slots', async () => {
+		jest.useFakeTimers();
+		const active = await Promise.all(
+			Array.from({ length: 4 }, () =>
+				testMiddleware({
+					middleware: reportConcurrencyMiddleware,
+					ctx: authContext,
+					requestProps: { method: 'POST', body: {} },
+					responseOptions: { eventEmitter: EventEmitter },
+				}),
+			),
+		);
+		try {
+			const destroySpies = active.map(({ responseMock }) => jest.spyOn(responseMock, 'destroy'));
+			await Promise.all(
+				active.map(({ output }) => {
+					const runReportOperation = output.runReportOperation as
+						| ((operation: () => Promise<string>) => Promise<string>)
+						| undefined;
+					return runReportOperation?.(async () => 'staged-artifact');
+				}),
+			);
+
+			await jest.advanceTimersByTimeAsync(REPORT_RESPONSE_TIMEOUT_MS);
+			expect(destroySpies.every((destroy) => destroy.mock.calls.length === 1)).toBe(true);
+
+			const admitted = await testMiddleware({
+				middleware: reportConcurrencyMiddleware,
+				ctx: authContext,
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			expect(admitted.responseMock.statusCode).toBe(200);
+			admitted.responseMock.emit('finish');
+		} finally {
+			for (const { responseMock } of active) responseMock.emit('finish');
+			jest.useRealTimers();
+		}
+	});
+});

--- a/src/routes/api/reports/request-control.spec.ts
+++ b/src/routes/api/reports/request-control.spec.ts
@@ -8,6 +8,7 @@ import {
 	privateReportResponseMiddleware,
 	reportAbortMiddleware,
 	reportConcurrencyMiddleware,
+	REPORT_CONCURRENCY_LIMIT,
 	REPORT_RESPONSE_TIMEOUT_MS,
 } from './request-control';
 
@@ -230,6 +231,56 @@ describe('report request control', () => {
 			admitted.responseMock.emit('finish');
 		} finally {
 			for (const { responseMock } of active) responseMock.emit('finish');
+			jest.useRealTimers();
+		}
+	});
+
+	/**
+	 * A client that disconnects before the handler starts releases the slot, and
+	 * the handler then takes it back. That second acquisition used to inherit no
+	 * timer and no response listeners, because releasing had removed both, so an
+	 * operation that never settled kept the slot for the lifetime of the process.
+	 */
+	it('re-arms the deadline when a released slot is taken back', async () => {
+		jest.useFakeTimers();
+		const stalled = await testMiddleware({
+			middleware: reportConcurrencyMiddleware,
+			ctx: authContext,
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		try {
+			// The client goes away before the handler runs, which frees the slot.
+			stalled.responseMock.emit('close');
+
+			const runReportOperation = stalled.output.runReportOperation as (
+				operation: () => Promise<string>,
+			) => Promise<string>;
+			// The handler takes the slot back, then never settles.
+			void runReportOperation(() => new Promise<string>(() => {}));
+			await Promise.resolve();
+
+			// Only the re-armed deadline can free this slot now.
+			await jest.advanceTimersByTimeAsync(REPORT_RESPONSE_TIMEOUT_MS);
+
+			// Every slot must be available again. Without the re-armed deadline the
+			// stalled request still holds one and the last of these is refused.
+			const admitted = [];
+			for (let index = 0; index < REPORT_CONCURRENCY_LIMIT; index += 1) {
+				admitted.push(
+					await testMiddleware({
+						middleware: reportConcurrencyMiddleware,
+						ctx: authContext,
+						requestProps: { method: 'POST', body: {} },
+						responseOptions: { eventEmitter: EventEmitter },
+					}),
+				);
+			}
+			expect(admitted.map(({ responseMock }) => responseMock.statusCode)).toEqual(
+				Array.from({ length: REPORT_CONCURRENCY_LIMIT }, () => 200),
+			);
+			for (const { responseMock } of admitted) responseMock.emit('finish');
+		} finally {
 			jest.useRealTimers();
 		}
 	});

--- a/src/routes/api/reports/request-control.ts
+++ b/src/routes/api/reports/request-control.ts
@@ -4,7 +4,7 @@ import { Middleware } from 'express-zod-api';
 import createHttpError from 'http-errors';
 
 const reportControlInputSchema = z.object({});
-const REPORT_CONCURRENCY_LIMIT = 4;
+export const REPORT_CONCURRENCY_LIMIT = 4;
 export const REPORT_RESPONSE_TIMEOUT_MS = 5 * 60_000;
 let activeReportRequests = 0;
 
@@ -86,14 +86,23 @@ export const reportConcurrencyMiddleware = new Middleware<
 			clearResponseDeadline();
 			releaseWhenComplete();
 		};
+		const armResponseDeadline = () => {
+			responseDeadline = setTimeout(() => {
+				hasResponseCompleted = true;
+				response.destroy();
+				// `release()`, not `releaseWhenComplete()`. The deadline is the only
+				// bound on how long one request can hold a slot, and an operation
+				// that never settles leaves `hasOperationSettled` false for ever, so
+				// the conditional release can never fire. The response is destroyed
+				// above, so nothing is still being delivered to a client. Work that
+				// settles later re-enters `release()` and returns on `hasReleased`.
+				release();
+			}, REPORT_RESPONSE_TIMEOUT_MS);
+			responseDeadline.unref();
+		};
 		response.once('finish', handleResponseCompleted);
 		response.once('close', handleResponseCompleted);
-		responseDeadline = setTimeout(() => {
-			hasResponseCompleted = true;
-			response.destroy();
-			releaseWhenComplete();
-		}, REPORT_RESPONSE_TIMEOUT_MS);
-		responseDeadline.unref();
+		armResponseDeadline();
 		const runReportOperation = async <T>(
 			operation: (trackPendingWork: (work: Promise<unknown>) => void) => Promise<T>,
 		): Promise<T> => {
@@ -106,6 +115,12 @@ export const reportConcurrencyMiddleware = new Middleware<
 				}
 				activeReportRequests += 1;
 				hasReleased = false;
+				// `release()` cleared the deadline and removed both response
+				// listeners, and the response has already completed, so nothing is
+				// left to free this slot. Without a fresh timer an operation that
+				// never settles holds it for the lifetime of the process and the
+				// effective concurrency limit drops by one for good.
+				armResponseDeadline();
 			}
 			const trackPendingWork = (work: Promise<unknown>) => {
 				const settlement = work.then(

--- a/src/routes/api/reports/request-control.ts
+++ b/src/routes/api/reports/request-control.ts
@@ -1,0 +1,146 @@
+import type { AuthContext } from '@masumi/payment-core/auth';
+import { z } from '@masumi/payment-core/zod';
+import { Middleware } from 'express-zod-api';
+import createHttpError from 'http-errors';
+
+const reportControlInputSchema = z.object({});
+const REPORT_CONCURRENCY_LIMIT = 4;
+export const REPORT_RESPONSE_TIMEOUT_MS = 5 * 60_000;
+let activeReportRequests = 0;
+
+export type ReportRequestContext = {
+	reportAbortSignal: AbortSignal;
+};
+
+export type ReportConcurrencyContext = {
+	runReportOperation: <T>(operation: (trackPendingWork: (work: Promise<unknown>) => void) => Promise<T>) => Promise<T>;
+};
+
+export const reportAbortMiddleware = new Middleware<
+	AuthContext,
+	ReportRequestContext,
+	string,
+	typeof reportControlInputSchema
+>({
+	input: reportControlInputSchema,
+	handler: async ({ request, response }) => {
+		const controller = new AbortController();
+		const abortRequest = () => controller.abort();
+		const clearListeners = () => {
+			request.off('aborted', abortRequest);
+			response.off('close', handleResponseClose);
+			response.off('finish', clearListeners);
+		};
+		const handleResponseClose = () => {
+			if (!response.writableEnded) abortRequest();
+			clearListeners();
+		};
+
+		request.once('aborted', abortRequest);
+		response.once('close', handleResponseClose);
+		response.once('finish', clearListeners);
+		if (request.aborted) abortRequest();
+
+		return { reportAbortSignal: controller.signal };
+	},
+});
+
+export const reportConcurrencyMiddleware = new Middleware<
+	AuthContext & ReportRequestContext,
+	ReportConcurrencyContext,
+	string,
+	typeof reportControlInputSchema
+>({
+	input: reportControlInputSchema,
+	handler: async ({ response }) => {
+		if (activeReportRequests >= REPORT_CONCURRENCY_LIMIT) {
+			response.setHeader('Retry-After', '1');
+			throw createHttpError(503, 'Report capacity reached. Retry later.');
+		}
+
+		activeReportRequests += 1;
+		let hasStarted = false;
+		let hasReleased = false;
+		let hasResponseCompleted = false;
+		let hasOperationSettled = false;
+		const pendingWork = new Set<Promise<void>>();
+		let responseDeadline: NodeJS.Timeout | null = null;
+		const clearResponseDeadline = () => {
+			if (responseDeadline == null) return;
+			clearTimeout(responseDeadline);
+			responseDeadline = null;
+		};
+		const release = () => {
+			if (hasReleased) return;
+			hasReleased = true;
+			activeReportRequests -= 1;
+			clearResponseDeadline();
+			response.off('finish', handleResponseCompleted);
+			response.off('close', handleResponseCompleted);
+		};
+		const releaseWhenComplete = () => {
+			if (!hasStarted || (hasResponseCompleted && hasOperationSettled && pendingWork.size === 0)) release();
+		};
+		const handleResponseCompleted = () => {
+			hasResponseCompleted = true;
+			clearResponseDeadline();
+			releaseWhenComplete();
+		};
+		response.once('finish', handleResponseCompleted);
+		response.once('close', handleResponseCompleted);
+		responseDeadline = setTimeout(() => {
+			hasResponseCompleted = true;
+			response.destroy();
+			releaseWhenComplete();
+		}, REPORT_RESPONSE_TIMEOUT_MS);
+		responseDeadline.unref();
+		const runReportOperation = async <T>(
+			operation: (trackPendingWork: (work: Promise<unknown>) => void) => Promise<T>,
+		): Promise<T> => {
+			if (hasStarted) throw createHttpError(500, 'Report operation already started');
+			hasStarted = true;
+			if (hasReleased) {
+				if (activeReportRequests >= REPORT_CONCURRENCY_LIMIT) {
+					response.setHeader('Retry-After', '1');
+					throw createHttpError(503, 'Report capacity reached. Retry later.');
+				}
+				activeReportRequests += 1;
+				hasReleased = false;
+			}
+			const trackPendingWork = (work: Promise<unknown>) => {
+				const settlement = work.then(
+					() => undefined,
+					() => undefined,
+				);
+				pendingWork.add(settlement);
+				void settlement.finally(() => {
+					pendingWork.delete(settlement);
+					releaseWhenComplete();
+				});
+			};
+
+			try {
+				return await operation(trackPendingWork);
+			} finally {
+				hasOperationSettled = true;
+				releaseWhenComplete();
+			}
+		};
+
+		return { runReportOperation };
+	},
+});
+
+export const privateReportResponseMiddleware = new Middleware<
+	AuthContext,
+	AuthContext,
+	string,
+	typeof reportControlInputSchema
+>({
+	input: reportControlInputSchema,
+	handler: async ({ ctx, response }) => {
+		response.setHeader('Cache-Control', 'private, no-store');
+		response.vary('token');
+		return ctx;
+	},
+});

--- a/src/routes/api/reports/schemas.spec.ts
+++ b/src/routes/api/reports/schemas.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from '@jest/globals';
+import { HotWalletType } from '@/generated/prisma/client';
+import { reportFacetsOutputSchema, reportFilterSchema, reportTransactionsInputSchema } from './schemas';
+
+const validFilter = {
+	paymentSourceId: 'source-1',
+	from: '2026-01-01T00:00:00.000Z',
+	to: '2026-02-01T00:00:00.000Z',
+};
+
+describe('reportFilterSchema', () => {
+	it('applies safe report defaults', () => {
+		const result = reportFilterSchema.parse(validFilter);
+		expect(result).toMatchObject({
+			roles: ['Buyer', 'Seller'],
+			dateBasis: 'RevenueRecognizedAt',
+			revenueMode: 'Billable',
+			timeZone: 'Etc/UTC',
+		});
+		expect(result.from).toEqual(new Date(validFilter.from));
+		expect(result.to).toEqual(new Date(validFilter.to));
+	});
+
+	it('rejects an inverted range', () => {
+		expect(() => reportFilterSchema.parse({ ...validFilter, from: validFilter.to, to: validFilter.from })).toThrow(
+			'to must be after from',
+		);
+	});
+
+	it('rejects an invalid IANA time zone', () => {
+		expect(() => reportFilterSchema.parse({ ...validFilter, timeZone: 'Mars/Olympus' })).toThrow(
+			'Invalid IANA time zone',
+		);
+	});
+
+	it('rejects a report range longer than ten years', () => {
+		expect(() => reportFilterSchema.parse({ ...validFilter, from: '2010-01-01T00:00:00.000Z' })).toThrow(
+			'Report range must not exceed 3660 days',
+		);
+	});
+
+	it('accepts exact caller-supplied fiat rates', () => {
+		const result = reportFilterSchema.parse({
+			...validFilter,
+			fiat: {
+				currency: 'usd',
+				suppliedRates: [{ unit: 'lovelace', rate: '0.621234567890123456' }],
+			},
+		});
+		expect(result.fiat?.suppliedRates?.[0].rate).toBe('0.621234567890123456');
+	});
+});
+
+describe('reportTransactionsInputSchema', () => {
+	it('defaults to 50 rows and caps pages at 100', () => {
+		expect(reportTransactionsInputSchema.parse(validFilter).limit).toBe(50);
+		expect(() => reportTransactionsInputSchema.parse({ ...validFilter, limit: 101 })).toThrow();
+	});
+});
+
+describe('reportFacetsOutputSchema', () => {
+	const wallet = {
+		id: 'wallet-1',
+		paymentSourceId: 'source-1',
+		walletAddress: 'addr_test1wallet',
+		walletVkey: 'wallet-vkey',
+		collectionAddress: null,
+		note: null,
+		deletedAt: null,
+	};
+
+	it('allows only managed buyer and seller wallet types', () => {
+		expect(
+			reportFacetsOutputSchema.safeParse({
+				paymentSources: [],
+				managedWallets: [{ ...wallet, type: HotWalletType.Selling }],
+			}).success,
+		).toBe(true);
+		expect(
+			reportFacetsOutputSchema.safeParse({
+				paymentSources: [],
+				managedWallets: [{ ...wallet, type: HotWalletType.Funding }],
+			}).success,
+		).toBe(false);
+	});
+});

--- a/src/utils/generator/swagger-generator/index.ts
+++ b/src/utils/generator/swagger-generator/index.ts
@@ -17,6 +17,7 @@ import { registerHydraPaths } from '@/routes/api/hydra/docs';
 import { registerRailReadinessPaths } from '@/routes/api/rail-readiness/docs';
 import { registerTxSyncQuarantinePaths } from '@/routes/api/tx-sync-quarantine/docs';
 import { registerRequestRepairPaths } from '@/routes/api/request-repair/docs';
+import { registerReportPaths } from '@/routes/api/reports/docs';
 
 extendZodWithOpenApi(z);
 
@@ -44,6 +45,7 @@ export function generateOpenAPI() {
 	registerRailReadinessPaths({ registry, apiKeyAuth });
 	registerTxSyncQuarantinePaths({ registry, apiKeyAuth });
 	registerRequestRepairPaths({ registry, apiKeyAuth });
+	registerReportPaths({ registry, apiKeyAuth });
 
 	return new OpenApiGeneratorV3(registry.definitions).generateDocument({
 		openapi: '3.0.0',

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -37249,6 +37249,6825 @@
                     }
                 }
             }
+        },
+        "/reports/facets": {
+            "get": {
+                "description": "Lists accessible payment sources and their managed buyer and seller wallets. Results include archived records so historical reports can retain their original labels.",
+                "summary": "List transaction report filters. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Accessible report filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "success"
+                                            ]
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "paymentSources": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "network": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "Preprod",
+                                                                    "Mainnet"
+                                                                ]
+                                                            },
+                                                            "paymentSourceType": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "Web3CardanoV1",
+                                                                    "Web3CardanoV2"
+                                                                ]
+                                                            },
+                                                            "feeRatePermille": {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 1000
+                                                            },
+                                                            "smartContractAddress": {
+                                                                "type": "string"
+                                                            },
+                                                            "deletedAt": {
+                                                                "type": "string",
+                                                                "nullable": true,
+                                                                "format": "date-time"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "id",
+                                                            "network",
+                                                            "paymentSourceType",
+                                                            "feeRatePermille",
+                                                            "smartContractAddress",
+                                                            "deletedAt"
+                                                        ]
+                                                    }
+                                                },
+                                                "managedWallets": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "paymentSourceId": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "Selling",
+                                                                    "Purchasing"
+                                                                ]
+                                                            },
+                                                            "walletAddress": {
+                                                                "type": "string"
+                                                            },
+                                                            "walletVkey": {
+                                                                "type": "string"
+                                                            },
+                                                            "collectionAddress": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "note": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "deletedAt": {
+                                                                "type": "string",
+                                                                "nullable": true,
+                                                                "format": "date-time"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "id",
+                                                            "paymentSourceId",
+                                                            "type",
+                                                            "walletAddress",
+                                                            "walletVkey",
+                                                            "collectionAddress",
+                                                            "note",
+                                                            "deletedAt"
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "required": [
+                                                "paymentSources",
+                                                "managedWallets"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "data"
+                                    ],
+                                    "example": {
+                                        "status": "success",
+                                        "data": {
+                                            "paymentSources": [
+                                                {
+                                                    "id": "payment_source_id",
+                                                    "network": "Preprod",
+                                                    "paymentSourceType": "Web3CardanoV2",
+                                                    "feeRatePermille": 0,
+                                                    "smartContractAddress": "addr_test1_contract",
+                                                    "deletedAt": null
+                                                }
+                                            ],
+                                            "managedWallets": [
+                                                {
+                                                    "id": "managed_wallet_id",
+                                                    "walletAddress": "addr_test1_wallet",
+                                                    "walletVkey": "wallet_verification_key",
+                                                    "collectionAddress": null,
+                                                    "deletedAt": null,
+                                                    "paymentSourceId": "payment_source_id",
+                                                    "type": "Selling",
+                                                    "note": "Primary seller wallet"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/transactions": {
+            "post": {
+                "description": "Returns paginated buyer and seller report rows for one payment source. The cursor preserves the initial asOf boundary and source fee settings, but it does not preserve historical row values. Amounts include raw atomic units and decimal metadata for supported assets.",
+                "summary": "Get transaction report rows. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Payment source, wallet, role, state, accounting date, revenue, and pagination filters",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "cursor": {
+                                                "type": "string",
+                                                "maxLength": 4000
+                                            },
+                                            "limit": {
+                                                "type": "integer",
+                                                "minimum": 1,
+                                                "maximum": 100,
+                                                "default": 50
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "limit": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transaction report rows",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "success"
+                                            ]
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "Buyer",
+                                                                    "Seller"
+                                                                ]
+                                                            },
+                                                            "requestType": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "PaymentRequest",
+                                                                    "PurchaseRequest"
+                                                                ]
+                                                            },
+                                                            "createdAt": {
+                                                                "type": "string",
+                                                                "format": "date-time"
+                                                            },
+                                                            "blockchainIdentifier": {
+                                                                "type": "string"
+                                                            },
+                                                            "agentIdentifier": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "agentName": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "onChainState": {
+                                                                "type": "string",
+                                                                "nullable": true,
+                                                                "enum": [
+                                                                    "FundsLocked",
+                                                                    "FundsOrDatumInvalid",
+                                                                    "ResultSubmitted",
+                                                                    "RefundRequested",
+                                                                    "Disputed",
+                                                                    "WithdrawAuthorized",
+                                                                    "RefundAuthorized",
+                                                                    "Withdrawn",
+                                                                    "RefundWithdrawn",
+                                                                    "DisputedWithdrawn",
+                                                                    null
+                                                                ]
+                                                            },
+                                                            "metadata": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "managedWallet": {
+                                                                "type": "object",
+                                                                "nullable": true,
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "walletAddress": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "walletVkey": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "collectionAddress": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
+                                                                    "deletedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id",
+                                                                    "walletAddress",
+                                                                    "walletVkey",
+                                                                    "collectionAddress",
+                                                                    "deletedAt"
+                                                                ]
+                                                            },
+                                                            "counterpartyAddress": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "buyerReturnAddress": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "sellerReturnAddress": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
+                                                            "timestamps": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "createdAt": {
+                                                                        "type": "string",
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "fundsLockedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "sellerRevenueRecognizedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "buyerGrossSpendAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    },
+                                                                    "buyerReturnedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "createdAt",
+                                                                    "fundsLockedAt",
+                                                                    "sellerRevenueRecognizedAt",
+                                                                    "buyerGrossSpendAt",
+                                                                    "buyerReturnedAt"
+                                                                ]
+                                                            },
+                                                            "seller": {
+                                                                "type": "object",
+                                                                "nullable": true,
+                                                                "properties": {
+                                                                    "grossRevenue": {
+                                                                        "type": "array",
+                                                                        "nullable": true,
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "protocolFee": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "configuredRatePermille": {
+                                                                                "type": "integer",
+                                                                                "minimum": 0,
+                                                                                "maximum": 1000
+                                                                            },
+                                                                            "appliedRatePermille": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0,
+                                                                                "maximum": 1000
+                                                                            },
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "nullable": true,
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "provenance": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "calculated",
+                                                                                    "projected",
+                                                                                    "exact_zero",
+                                                                                    "not_applicable",
+                                                                                    "insufficient_data"
+                                                                                ]
+                                                                            },
+                                                                            "basis": {
+                                                                                "type": "string",
+                                                                                "nullable": true,
+                                                                                "enum": [
+                                                                                    "stored_requested_plus_collateral",
+                                                                                    "contract_version",
+                                                                                    null
+                                                                                ]
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "exact",
+                                                                                    "reconstructed",
+                                                                                    "not_applicable",
+                                                                                    "insufficient_data"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "configuredRatePermille",
+                                                                            "appliedRatePermille",
+                                                                            "amounts",
+                                                                            "provenance",
+                                                                            "basis",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "cardanoFees": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "cardanoFeeTiming": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "stored_cumulative",
+                                                                            "accounting_allocation"
+                                                                        ]
+                                                                    },
+                                                                    "netRevenue": {
+                                                                        "type": "array",
+                                                                        "nullable": true,
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "payoutCompleteness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "grossRevenue",
+                                                                    "protocolFee",
+                                                                    "cardanoFees",
+                                                                    "cardanoFeeTiming",
+                                                                    "netRevenue",
+                                                                    "payoutCompleteness"
+                                                                ]
+                                                            },
+                                                            "buyer": {
+                                                                "type": "object",
+                                                                "nullable": true,
+                                                                "properties": {
+                                                                    "grossSpend": {
+                                                                        "type": "array",
+                                                                        "nullable": true,
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "returnedFunds": {
+                                                                        "type": "array",
+                                                                        "nullable": true,
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "cardanoFees": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "cardanoFeeTiming": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "stored_cumulative",
+                                                                            "accounting_allocation"
+                                                                        ]
+                                                                    },
+                                                                    "netSpend": {
+                                                                        "type": "array",
+                                                                        "nullable": true,
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "unit": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rawAmount": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^-?\\d+$"
+                                                                                },
+                                                                                "decimalAmount": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "decimals": {
+                                                                                    "type": "integer",
+                                                                                    "nullable": true,
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "symbol": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "unit",
+                                                                                "rawAmount",
+                                                                                "decimalAmount",
+                                                                                "decimals",
+                                                                                "symbol"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "payoutCompleteness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "grossSpend",
+                                                                    "returnedFunds",
+                                                                    "cardanoFees",
+                                                                    "cardanoFeeTiming",
+                                                                    "netSpend",
+                                                                    "payoutCompleteness"
+                                                                ]
+                                                            },
+                                                            "actorCardanoFeeAllocation": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "strategy": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "accounting_allocation",
+                                                                            "lifetime_cohort"
+                                                                        ]
+                                                                    },
+                                                                    "completeness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial"
+                                                                        ]
+                                                                    },
+                                                                    "attachedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "strategy",
+                                                                    "completeness",
+                                                                    "attachedAt"
+                                                                ]
+                                                            },
+                                                            "feeAllocationScope": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "single_request",
+                                                                    "shared_or_unknown"
+                                                                ]
+                                                            },
+                                                            "feeComponentScope": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "complete",
+                                                                    "partial"
+                                                                ]
+                                                            },
+                                                            "cardanoFeeReconciliation": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "buyerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    },
+                                                                    "sellerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    },
+                                                                    "adminCardanoFees": {
+                                                                        "type": "object",
+                                                                        "nullable": true,
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    },
+                                                                    "totalCardanoFees": {
+                                                                        "type": "object",
+                                                                        "nullable": true,
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    },
+                                                                    "completeness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial",
+                                                                            "inconsistent"
+                                                                        ]
+                                                                    },
+                                                                    "isAggregationOwner": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "buyerCardanoFees",
+                                                                    "sellerCardanoFees",
+                                                                    "adminCardanoFees",
+                                                                    "totalCardanoFees",
+                                                                    "completeness",
+                                                                    "isAggregationOwner"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "id",
+                                                            "role",
+                                                            "requestType",
+                                                            "createdAt",
+                                                            "blockchainIdentifier",
+                                                            "agentIdentifier",
+                                                            "agentName",
+                                                            "onChainState",
+                                                            "metadata",
+                                                            "managedWallet",
+                                                            "counterpartyAddress",
+                                                            "buyerReturnAddress",
+                                                            "sellerReturnAddress",
+                                                            "timestamps",
+                                                            "seller",
+                                                            "buyer",
+                                                            "actorCardanoFeeAllocation",
+                                                            "feeAllocationScope",
+                                                            "feeComponentScope",
+                                                            "cardanoFeeReconciliation"
+                                                        ]
+                                                    }
+                                                },
+                                                "page": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "nextCursor": {
+                                                            "type": "string",
+                                                            "nullable": true
+                                                        },
+                                                        "hasMore": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "nextCursor",
+                                                        "hasMore"
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "generatedAt": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        },
+                                                        "asOf": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        },
+                                                        "paymentSource": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "network": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Preprod",
+                                                                        "Mainnet"
+                                                                    ]
+                                                                },
+                                                                "paymentSourceType": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Web3CardanoV1",
+                                                                        "Web3CardanoV2"
+                                                                    ]
+                                                                },
+                                                                "feeRatePermille": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0,
+                                                                    "maximum": 1000
+                                                                },
+                                                                "smartContractAddress": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deletedAt": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id",
+                                                                "network",
+                                                                "paymentSourceType",
+                                                                "feeRatePermille",
+                                                                "smartContractAddress",
+                                                                "deletedAt"
+                                                            ]
+                                                        },
+                                                        "filters": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "paymentSourceId": {
+                                                                    "type": "string"
+                                                                },
+                                                                "managedWalletIds": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "externalAddresses": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "roles": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "Buyer",
+                                                                            "Seller"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "states": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "FundsLocked",
+                                                                                    "FundsOrDatumInvalid",
+                                                                                    "ResultSubmitted",
+                                                                                    "RefundRequested",
+                                                                                    "Disputed",
+                                                                                    "WithdrawAuthorized",
+                                                                                    "RefundAuthorized",
+                                                                                    "Withdrawn",
+                                                                                    "RefundWithdrawn",
+                                                                                    "DisputedWithdrawn"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "Pending"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "format": "date-time"
+                                                                },
+                                                                "dateBasis": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "CreatedAt",
+                                                                        "FundsLockedAt",
+                                                                        "RevenueRecognizedAt"
+                                                                    ]
+                                                                },
+                                                                "revenueMode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Billable",
+                                                                        "CashReceived",
+                                                                        "RequestedGross"
+                                                                    ]
+                                                                },
+                                                                "timeZone": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "paymentSourceId",
+                                                                "managedWalletIds",
+                                                                "externalAddresses",
+                                                                "roles",
+                                                                "states",
+                                                                "from",
+                                                                "to",
+                                                                "dateBasis",
+                                                                "revenueMode",
+                                                                "timeZone"
+                                                            ]
+                                                        },
+                                                        "warnings": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "code": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "message": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "rowId": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "code",
+                                                                    "message",
+                                                                    "rowId"
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "generatedAt",
+                                                        "asOf",
+                                                        "paymentSource",
+                                                        "filters",
+                                                        "warnings"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "rows",
+                                                "page",
+                                                "metadata"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "data"
+                                    ],
+                                    "example": {
+                                        "status": "success",
+                                        "data": {
+                                            "rows": [],
+                                            "page": {
+                                                "nextCursor": null,
+                                                "hasMore": false
+                                            },
+                                            "metadata": {
+                                                "generatedAt": "2026-02-01T00:00:01.000Z",
+                                                "asOf": "2026-02-01T00:00:00.000Z",
+                                                "paymentSource": {
+                                                    "id": "payment_source_id",
+                                                    "network": "Preprod",
+                                                    "paymentSourceType": "Web3CardanoV2",
+                                                    "feeRatePermille": 0,
+                                                    "smartContractAddress": "addr_test1_contract",
+                                                    "deletedAt": null
+                                                },
+                                                "filters": {
+                                                    "paymentSourceId": "payment_source_id",
+                                                    "managedWalletIds": [
+                                                        "managed_wallet_id"
+                                                    ],
+                                                    "externalAddresses": [
+                                                        "addr_test1_external"
+                                                    ],
+                                                    "roles": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ],
+                                                    "states": [
+                                                        "FundsLocked",
+                                                        "Withdrawn"
+                                                    ],
+                                                    "from": "2026-01-01T00:00:00.000Z",
+                                                    "to": "2026-02-01T00:00:00.000Z",
+                                                    "dateBasis": "RevenueRecognizedAt",
+                                                    "revenueMode": "Billable",
+                                                    "timeZone": "Etc/UTC"
+                                                },
+                                                "warnings": []
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/summary": {
+            "post": {
+                "description": "Returns totals, per-wallet and role totals, and time buckets from one database snapshot. The service calculates applicable V1 protocol fees from the payment source rate. Applicable V2 protocol fees are exact zero.",
+                "summary": "Get transaction report totals and history. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Report filters and history bucket size",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bucket": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Auto",
+                                                    "Day",
+                                                    "Week",
+                                                    "Month"
+                                                ],
+                                                "default": "Auto"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "bucket": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transaction report totals and history",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "success"
+                                            ]
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "totals": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "transactionCount": {
+                                                            "type": "integer",
+                                                            "minimum": 0
+                                                        },
+                                                        "transactionCountCompleteness": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "complete",
+                                                                "partial"
+                                                            ]
+                                                        },
+                                                        "sellerGrossRevenue": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "protocolFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "sellerCardanoFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "actorCardanoFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "sellerNetRevenue": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "buyerGrossSpend": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "returnedFunds": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "buyerCardanoFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "buyerNetSpend": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "adminCardanoFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        },
+                                                        "totalCardanoFees": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "amounts": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rawAmount": {
+                                                                                "type": "string",
+                                                                                "pattern": "^-?\\d+$"
+                                                                            },
+                                                                            "decimalAmount": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            },
+                                                                            "decimals": {
+                                                                                "type": "integer",
+                                                                                "nullable": true,
+                                                                                "minimum": 0
+                                                                            },
+                                                                            "symbol": {
+                                                                                "type": "string",
+                                                                                "nullable": true
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rawAmount",
+                                                                            "decimalAmount",
+                                                                            "decimals",
+                                                                            "symbol"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "completeness": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "complete",
+                                                                        "partial"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "amounts",
+                                                                "completeness"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "transactionCount",
+                                                        "transactionCountCompleteness",
+                                                        "sellerGrossRevenue",
+                                                        "protocolFees",
+                                                        "sellerCardanoFees",
+                                                        "actorCardanoFees",
+                                                        "sellerNetRevenue",
+                                                        "buyerGrossSpend",
+                                                        "returnedFunds",
+                                                        "buyerCardanoFees",
+                                                        "buyerNetSpend",
+                                                        "adminCardanoFees",
+                                                        "totalCardanoFees"
+                                                    ]
+                                                },
+                                                "wallets": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "managedWallet": {
+                                                                "type": "object",
+                                                                "nullable": true,
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "walletAddress": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "walletVkey": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "collectionAddress": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
+                                                                    "deletedAt": {
+                                                                        "type": "string",
+                                                                        "nullable": true,
+                                                                        "format": "date-time"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id",
+                                                                    "walletAddress",
+                                                                    "walletVkey",
+                                                                    "collectionAddress",
+                                                                    "deletedAt"
+                                                                ]
+                                                            },
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "Buyer",
+                                                                    "Seller"
+                                                                ]
+                                                            },
+                                                            "metrics": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "transactionCount": {
+                                                                        "type": "integer",
+                                                                        "minimum": 0
+                                                                    },
+                                                                    "transactionCountCompleteness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial"
+                                                                        ]
+                                                                    },
+                                                                    "sellerGrossRevenue": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "protocolFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "sellerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "actorCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "sellerNetRevenue": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerGrossSpend": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "returnedFunds": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerNetSpend": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "adminCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "totalCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "transactionCount",
+                                                                    "transactionCountCompleteness",
+                                                                    "sellerGrossRevenue",
+                                                                    "protocolFees",
+                                                                    "sellerCardanoFees",
+                                                                    "actorCardanoFees",
+                                                                    "sellerNetRevenue",
+                                                                    "buyerGrossSpend",
+                                                                    "returnedFunds",
+                                                                    "buyerCardanoFees",
+                                                                    "buyerNetSpend",
+                                                                    "adminCardanoFees",
+                                                                    "totalCardanoFees"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "managedWallet",
+                                                            "role",
+                                                            "metrics"
+                                                        ]
+                                                    }
+                                                },
+                                                "history": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "bucketStart": {
+                                                                "type": "string",
+                                                                "format": "date-time"
+                                                            },
+                                                            "bucketEnd": {
+                                                                "type": "string",
+                                                                "format": "date-time"
+                                                            },
+                                                            "metrics": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "transactionCount": {
+                                                                        "type": "integer",
+                                                                        "minimum": 0
+                                                                    },
+                                                                    "transactionCountCompleteness": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "complete",
+                                                                            "partial"
+                                                                        ]
+                                                                    },
+                                                                    "sellerGrossRevenue": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "protocolFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "sellerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "actorCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "sellerNetRevenue": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerGrossSpend": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "returnedFunds": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "buyerNetSpend": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "adminCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    },
+                                                                    "totalCardanoFees": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "amounts": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "unit": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "rawAmount": {
+                                                                                            "type": "string",
+                                                                                            "pattern": "^-?\\d+$"
+                                                                                        },
+                                                                                        "decimalAmount": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "decimals": {
+                                                                                            "type": "integer",
+                                                                                            "nullable": true,
+                                                                                            "minimum": 0
+                                                                                        },
+                                                                                        "symbol": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "unit",
+                                                                                        "rawAmount",
+                                                                                        "decimalAmount",
+                                                                                        "decimals",
+                                                                                        "symbol"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "completeness": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "complete",
+                                                                                    "partial"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "amounts",
+                                                                            "completeness"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "transactionCount",
+                                                                    "transactionCountCompleteness",
+                                                                    "sellerGrossRevenue",
+                                                                    "protocolFees",
+                                                                    "sellerCardanoFees",
+                                                                    "actorCardanoFees",
+                                                                    "sellerNetRevenue",
+                                                                    "buyerGrossSpend",
+                                                                    "returnedFunds",
+                                                                    "buyerCardanoFees",
+                                                                    "buyerNetSpend",
+                                                                    "adminCardanoFees",
+                                                                    "totalCardanoFees"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "bucketStart",
+                                                            "bucketEnd",
+                                                            "metrics"
+                                                        ]
+                                                    }
+                                                },
+                                                "bucket": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Day",
+                                                        "Week",
+                                                        "Month"
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "generatedAt": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        },
+                                                        "asOf": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        },
+                                                        "paymentSource": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "network": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Preprod",
+                                                                        "Mainnet"
+                                                                    ]
+                                                                },
+                                                                "paymentSourceType": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Web3CardanoV1",
+                                                                        "Web3CardanoV2"
+                                                                    ]
+                                                                },
+                                                                "feeRatePermille": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0,
+                                                                    "maximum": 1000
+                                                                },
+                                                                "smartContractAddress": {
+                                                                    "type": "string"
+                                                                },
+                                                                "deletedAt": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id",
+                                                                "network",
+                                                                "paymentSourceType",
+                                                                "feeRatePermille",
+                                                                "smartContractAddress",
+                                                                "deletedAt"
+                                                            ]
+                                                        },
+                                                        "filters": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "paymentSourceId": {
+                                                                    "type": "string"
+                                                                },
+                                                                "managedWalletIds": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "externalAddresses": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "roles": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "Buyer",
+                                                                            "Seller"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "states": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "FundsLocked",
+                                                                                    "FundsOrDatumInvalid",
+                                                                                    "ResultSubmitted",
+                                                                                    "RefundRequested",
+                                                                                    "Disputed",
+                                                                                    "WithdrawAuthorized",
+                                                                                    "RefundAuthorized",
+                                                                                    "Withdrawn",
+                                                                                    "RefundWithdrawn",
+                                                                                    "DisputedWithdrawn"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "Pending"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "format": "date-time"
+                                                                },
+                                                                "dateBasis": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "CreatedAt",
+                                                                        "FundsLockedAt",
+                                                                        "RevenueRecognizedAt"
+                                                                    ]
+                                                                },
+                                                                "revenueMode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "Billable",
+                                                                        "CashReceived",
+                                                                        "RequestedGross"
+                                                                    ]
+                                                                },
+                                                                "timeZone": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "paymentSourceId",
+                                                                "managedWalletIds",
+                                                                "externalAddresses",
+                                                                "roles",
+                                                                "states",
+                                                                "from",
+                                                                "to",
+                                                                "dateBasis",
+                                                                "revenueMode",
+                                                                "timeZone"
+                                                            ]
+                                                        },
+                                                        "warnings": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "code": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "message": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "rowId": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "code",
+                                                                    "message",
+                                                                    "rowId"
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "generatedAt",
+                                                        "asOf",
+                                                        "paymentSource",
+                                                        "filters",
+                                                        "warnings"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "totals",
+                                                "wallets",
+                                                "history",
+                                                "bucket",
+                                                "metadata"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "data"
+                                    ],
+                                    "example": {
+                                        "status": "success",
+                                        "data": {
+                                            "totals": {
+                                                "transactionCount": 0,
+                                                "transactionCountCompleteness": "complete",
+                                                "sellerGrossRevenue": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "protocolFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "sellerCardanoFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "actorCardanoFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "sellerNetRevenue": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "buyerGrossSpend": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "returnedFunds": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "buyerCardanoFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "buyerNetSpend": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "adminCardanoFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                },
+                                                "totalCardanoFees": {
+                                                    "amounts": [
+                                                        {
+                                                            "unit": "lovelace",
+                                                            "rawAmount": "0",
+                                                            "decimalAmount": "0.000000",
+                                                            "decimals": 6,
+                                                            "symbol": "ADA"
+                                                        }
+                                                    ],
+                                                    "completeness": "complete"
+                                                }
+                                            },
+                                            "wallets": [],
+                                            "history": [],
+                                            "bucket": "Day",
+                                            "metadata": {
+                                                "generatedAt": "2026-02-01T00:00:01.000Z",
+                                                "asOf": "2026-02-01T00:00:00.000Z",
+                                                "paymentSource": {
+                                                    "id": "payment_source_id",
+                                                    "network": "Preprod",
+                                                    "paymentSourceType": "Web3CardanoV2",
+                                                    "feeRatePermille": 0,
+                                                    "smartContractAddress": "addr_test1_contract",
+                                                    "deletedAt": null
+                                                },
+                                                "filters": {
+                                                    "paymentSourceId": "payment_source_id",
+                                                    "managedWalletIds": [
+                                                        "managed_wallet_id"
+                                                    ],
+                                                    "externalAddresses": [
+                                                        "addr_test1_external"
+                                                    ],
+                                                    "roles": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ],
+                                                    "states": [
+                                                        "FundsLocked",
+                                                        "Withdrawn"
+                                                    ],
+                                                    "from": "2026-01-01T00:00:00.000Z",
+                                                    "to": "2026-02-01T00:00:00.000Z",
+                                                    "dateBasis": "RevenueRecognizedAt",
+                                                    "revenueMode": "Billable",
+                                                    "timeZone": "Etc/UTC"
+                                                },
+                                                "warnings": []
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/transactions.csv": {
+            "post": {
+                "description": "Downloads one row per buyer or seller transaction as CSV.",
+                "summary": "Transaction rows CSV. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Report filters and history bucket size",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bucket": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Auto",
+                                                    "Day",
+                                                    "Week",
+                                                    "Month"
+                                                ],
+                                                "default": "Auto"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "bucket": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transaction rows CSV",
+                        "headers": {
+                            "Content-Disposition": {
+                                "description": "Attachment filename, including an RFC 5987 UTF-8 filename",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "Content-Length": {
+                                "description": "Artifact size in bytes",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "minimum": 0
+                                }
+                            }
+                        },
+                        "content": {
+                            "text/csv; charset=utf-8": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/wallet-summary.csv": {
+            "post": {
+                "description": "Downloads totals grouped by managed wallet and buyer or seller role as CSV.",
+                "summary": "Wallet and role totals CSV. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Report filters and history bucket size",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bucket": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Auto",
+                                                    "Day",
+                                                    "Week",
+                                                    "Month"
+                                                ],
+                                                "default": "Auto"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "bucket": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Wallet and role totals CSV",
+                        "headers": {
+                            "Content-Disposition": {
+                                "description": "Attachment filename, including an RFC 5987 UTF-8 filename",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "Content-Length": {
+                                "description": "Artifact size in bytes",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "minimum": 0
+                                }
+                            }
+                        },
+                        "content": {
+                            "text/csv; charset=utf-8": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/totals.csv": {
+            "post": {
+                "description": "Downloads payment source totals as CSV.",
+                "summary": "Payment source totals CSV. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Report filters and history bucket size",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bucket": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Auto",
+                                                    "Day",
+                                                    "Week",
+                                                    "Month"
+                                                ],
+                                                "default": "Auto"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "bucket": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Payment source totals CSV",
+                        "headers": {
+                            "Content-Disposition": {
+                                "description": "Attachment filename, including an RFC 5987 UTF-8 filename",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "Content-Length": {
+                                "description": "Artifact size in bytes",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "minimum": 0
+                                }
+                            }
+                        },
+                        "content": {
+                            "text/csv; charset=utf-8": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/reports/export.zip": {
+            "post": {
+                "description": "Downloads a ZIP archive containing transactions.csv, wallet-summary.csv, and totals.csv from one database snapshot.",
+                "summary": "Complete transaction report ZIP archive. (read access required)",
+                "tags": [
+                    "reports"
+                ],
+                "security": [
+                    {
+                        "API-Key": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "description": "Report filters and history bucket size",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "paymentSourceId": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 250
+                                            },
+                                            "managedWalletIds": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "externalAddresses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "minLength": 1,
+                                                    "maxLength": 250
+                                                },
+                                                "maxItems": 100
+                                            },
+                                            "roles": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "Buyer",
+                                                        "Seller"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                                "default": [
+                                                    "Buyer",
+                                                    "Seller"
+                                                ]
+                                            },
+                                            "states": {
+                                                "type": "array",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "FundsLocked",
+                                                                "FundsOrDatumInvalid",
+                                                                "ResultSubmitted",
+                                                                "RefundRequested",
+                                                                "Disputed",
+                                                                "WithdrawAuthorized",
+                                                                "RefundAuthorized",
+                                                                "Withdrawn",
+                                                                "RefundWithdrawn",
+                                                                "DisputedWithdrawn"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "Pending"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "maxItems": 11
+                                            },
+                                            "from": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "to": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "format": "date-time"
+                                            },
+                                            "dateBasis": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "CreatedAt",
+                                                    "FundsLockedAt",
+                                                    "RevenueRecognizedAt"
+                                                ],
+                                                "default": "RevenueRecognizedAt"
+                                            },
+                                            "revenueMode": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Billable",
+                                                    "CashReceived",
+                                                    "RequestedGross"
+                                                ],
+                                                "default": "Billable"
+                                            },
+                                            "timeZone": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 100,
+                                                "default": "Etc/UTC"
+                                            },
+                                            "fiat": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "currency": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "usd",
+                                                            "eur",
+                                                            "gbp",
+                                                            "jpy",
+                                                            "chf",
+                                                            "aed"
+                                                        ]
+                                                    },
+                                                    "mode": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "BucketAverage",
+                                                            "AccountingDate"
+                                                        ],
+                                                        "default": "BucketAverage"
+                                                    },
+                                                    "suppliedRates": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "unit": {
+                                                                    "type": "string",
+                                                                    "maxLength": 200
+                                                                },
+                                                                "rate": {
+                                                                    "type": "string",
+                                                                    "pattern": "^(?:0|[1-9]\\d*)(?:\\.\\d+)?$"
+                                                                },
+                                                                "from": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                },
+                                                                "to": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "format": "date-time"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "unit",
+                                                                "rate"
+                                                            ]
+                                                        },
+                                                        "maxItems": 100
+                                                    }
+                                                },
+                                                "required": [
+                                                    "currency"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "paymentSourceId",
+                                            "from",
+                                            "to"
+                                        ]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bucket": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "Auto",
+                                                    "Day",
+                                                    "Week",
+                                                    "Month"
+                                                ],
+                                                "default": "Auto"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "example": {
+                                    "paymentSourceId": "payment_source_id",
+                                    "managedWalletIds": [
+                                        "managed_wallet_id"
+                                    ],
+                                    "externalAddresses": [
+                                        "addr_test1_external"
+                                    ],
+                                    "roles": [
+                                        "Buyer",
+                                        "Seller"
+                                    ],
+                                    "states": [
+                                        "FundsLocked",
+                                        "Withdrawn"
+                                    ],
+                                    "from": "2026-01-01T00:00:00.000Z",
+                                    "to": "2026-02-01T00:00:00.000Z",
+                                    "dateBasis": "RevenueRecognizedAt",
+                                    "revenueMode": "Billable",
+                                    "timeZone": "Etc/UTC",
+                                    "bucket": "Auto"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Complete transaction report ZIP archive",
+                        "headers": {
+                            "Content-Disposition": {
+                                "description": "Attachment filename, including an RFC 5987 UTF-8 filename",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "Content-Length": {
+                                "description": "Artifact size in bytes",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64",
+                                    "minimum": 0
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/zip": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The report filters or cursor are invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The payment source or requested managed wallet is not accessible",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "The report exceeds its row or file size limit; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "The API key exceeded its report request rate",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Fiat conversion is not available yet",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "All report processing slots are in use",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "Minimum seconds before another report request",
+                                "schema": {
+                                    "type": "integer",
+                                    "minimum": 1
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "504": {
+                        "description": "The report calculation timed out; narrow the filters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "error"
+                                            ]
+                                        },
+                                        "error": {
+                                            "type": "object",
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "message"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The HTTP surface, and the two places it is registered.

- `src/routes/api/reports/`: summary, transactions, facets, the three CSV endpoints and the ZIP export, with their schemas and OpenAPI docs.
- `request-control.ts` and `export-result-handler.ts`.
- `src/routes/api/index.ts` and the swagger generator index, which register the above.

12 files, 2,246 lines. This is the last layer with hand-written code; the generated artifacts follow in the next PR.

---

**Part of a 6-PR split of #739.** That branch is 69 files and 34,694 lines, over the review-tooling limits, so nothing could review it as one change. It is split here by layer, bottom-up.

Verified before opening:
- The six branches together reproduce `feat/transaction-report-core` exactly. `git diff --stat origin/feat/transaction-report-core <tip>` is empty.
- `npx tsc --noEmit` reports 0 errors on each of the six branches in order, so every step of the stack compiles on its own.
- No file content was changed, reworded, or moved between layers beyond assigning each file to the layer that owns it.