### PR TITLE
fix(registry): stop declaring collateral the input cannot cover

### DIFF
--- a/packages/payment-core/package.json
+++ b/packages/payment-core/package.json
@@ -10,6 +10,7 @@
 		"./auth-middleware": "./src/auth-middleware.ts",
 		"./blockchain-error-interpreter": "./src/blockchain-error-interpreter.ts",
 		"./blockchain-identifier": "./src/blockchain-identifier.ts",
+		"./collateral": "./src/collateral.ts",
 		"./config": "./src/config.ts",
 		"./db": "./src/db.ts",
 		"./db-retry": "./src/db-retry.ts",

--- a/packages/payment-core/src/collateral.spec.ts
+++ b/packages/payment-core/src/collateral.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { MIN_TOTAL_COLLATERAL_LOVELACE, deriveTotalCollateral, extractCollateralProtocolParams } from './collateral';
+
+const BUDGET = [{ mem: 14_000_000, steps: 10_000_000_000 }];
+
+/**
+ * `deriveTotalCollateral` degrades to the floor when it cannot read the protocol
+ * parameters, which is safe but throws away the scaling that is the whole point
+ * of deriving. The degradation is invisible in a passing suite, so the shape
+ * PRODUCTION passes has to be asserted directly.
+ *
+ * Production hands it mesh's `Protocol`, whose field is `collateralPercent`
+ * (@meshsdk/common `index.d.ts:214`) with numeric prices. Every other test in the
+ * repo uses the `collateralPercentage` alias with string prices, so without these
+ * a mesh rename would silently pin every build back to the 3 ADA floor.
+ */
+describe('extractCollateralProtocolParams', () => {
+	it("reads mesh's own Protocol shape, the one production passes", () => {
+		expect(extractCollateralProtocolParams({ priceMem: 0.0577, priceStep: 0.0000721, collateralPercent: 150 })).toEqual(
+			{ priceMem: 0.0577, priceStep: 0.0000721, collateralPercentage: 150 },
+		);
+	});
+
+	it('reads the raw blockfrost snake_case shape', () => {
+		expect(
+			extractCollateralProtocolParams({ price_mem: '0.0577', price_step: '0.0000721', collateral_percent: 150 }),
+		).toEqual({ priceMem: '0.0577', priceStep: '0.0000721', collateralPercentage: 150 });
+	});
+
+	it('returns null when a required field is absent', () => {
+		expect(extractCollateralProtocolParams({ priceMem: 0.0577, priceStep: 0.0000721 })).toBeNull();
+	});
+});
+
+describe('deriveTotalCollateral', () => {
+	/**
+	 * The regression this guards: with mesh's key names the derivation must scale
+	 * above the floor. If it returns exactly the floor here, the extractor stopped
+	 * recognising the shape and every build is back to a flat 3 ADA.
+	 */
+	it("scales above the floor on mesh's Protocol shape", () => {
+		const total = deriveTotalCollateral(
+			BUDGET,
+			{ priceMem: 0.0577, priceStep: 0.0000721, collateralPercent: 150 },
+			10_000_000n,
+		);
+
+		expect(BigInt(total)).toBe(3_439_800n);
+		expect(BigInt(total)).toBeGreaterThan(MIN_TOTAL_COLLATERAL_LOVELACE);
+	});
+
+	it('falls back to the floor when the parameters cannot be read', () => {
+		expect(deriveTotalCollateral(BUDGET, { priceMem: 0.0577 }, 10_000_000n)).toBe(
+			MIN_TOTAL_COLLATERAL_LOVELACE.toString(),
+		);
+	});
+
+	it('never declares more than the input can return', () => {
+		const total = deriveTotalCollateral(
+			BUDGET,
+			{ priceMem: 0.0577, priceStep: 0.0000721, collateralPercent: 150 },
+			4_200_000n,
+		);
+
+		expect(BigInt(total)).toBe(3_200_000n);
+		expect(BigInt(total)).toBeLessThan(4_200_000n);
+	});
+});

--- a/packages/payment-core/src/collateral.ts
+++ b/packages/payment-core/src/collateral.ts
@@ -1,0 +1,276 @@
+/**
+ * Conway phase-1 collateral math, shared by every builder that declares
+ * `total_collateral`.
+ *
+ * Mesh SDK pinning (ADR 0005): this module touches NO mesh runtime and does
+ * not even import a mesh type. `CollateralUtxoLike` is a structural shape that
+ * both pinned `UTxO` types satisfy, so V1 (`src/`, mesh beta.96) and V2
+ * (`packages/payment-source-v2`, mesh beta.102) can share one implementation
+ * with no risk of collapsing the two mesh lines onto each other. Keep it that
+ * way: if this file ever needs a mesh value import, split it per rail instead.
+ *
+ * Why this is shared rather than a per-builder constant: the declared total is
+ * pinned between two moving bounds. It must sit ABOVE the ledger's requirement
+ * (`collateralPercentage` of the fee, else `InsufficientCollateral`) and
+ * strictly BELOW what the collateral input holds, because mesh always emits a
+ * `collateral_return` of `input - declared` and never min-UTxO-checks it. A
+ * hardcoded constant cannot track either bound.
+ */
+
+/**
+ * Structural shape of the parts of a mesh `UTxO` this module reads.
+ *
+ * Declared locally rather than imported so payment-core stays free of a mesh
+ * dependency. Both pinned `UTxO` types are assignable to it.
+ */
+export type CollateralUtxoLike = {
+	output: { amount: Array<{ unit: string; quantity: string }> };
+};
+
+/**
+ * Internal: parse a decimal value (number or string) into a scaled bigint.
+ * Returns `value * 10^scaleDigits` rounded toward zero. Designed for
+ * Cardano protocol-parameter decimals like price_mem = "0.0577" which are
+ * exact rationals on-chain but arrive at us as decimal strings.
+ *
+ * Precision: we pad to 20 fractional digits which is well beyond any
+ * realistic protocol-parameter precision. Any fractional digits beyond 20
+ * are truncated (NOT rounded), acceptable for a safety-margin computation,
+ * and the caller is expected to apply a multiplier (e.g. 1.5x) for headroom.
+ */
+function decimalToScaled(value: number | string, scaleDigits: number): bigint {
+	const s = typeof value === 'number' ? value.toString() : value;
+	// Handle scientific notation (e.g. "1e-3") by normalizing through Number.
+	// Mesh / blockfrost don't emit scientific notation today but be defensive.
+	const normalized = s.includes('e') || s.includes('E') ? Number(s).toFixed(20) : s;
+
+	const isNegative = normalized.startsWith('-');
+	const unsigned = isNegative ? normalized.slice(1) : normalized;
+	const [whole, frac = ''] = unsigned.split('.');
+
+	const cappedFracDigits = Math.min(scaleDigits, 20);
+	const fracPadded = (frac + '0'.repeat(scaleDigits)).slice(0, cappedFracDigits);
+	const padTail = '0'.repeat(scaleDigits - cappedFracDigits);
+
+	const combined = (whole === '' ? '0' : whole) + fracPadded + padTail;
+	const result = BigInt(combined);
+	return isNegative ? -result : result;
+}
+
+/** Internal: ceil-div for non-negative bigints. */
+function ceilDiv(num: bigint, den: bigint): bigint {
+	if (den <= 0n) throw new Error('ceilDiv: denominator must be positive');
+	if (num <= 0n) return 0n;
+	return (num + den - 1n) / den;
+}
+
+/**
+ * Compute the Conway-era total collateral requirement from per-redeemer
+ * `ex_units` budgets. Formula:
+ *
+ *   redeemerFee     = ceil(budget.mem * priceMem) + ceil(budget.steps * priceStep)
+ *   totalScriptFee  = sum(redeemerFee across all redeemers)
+ *   totalCollateral = ceil(totalScriptFee * collateralPercentage / 100)
+ *
+ * The result is the MINIMUM lovelace the collateral UTxO must hold. Apply a
+ * safety multiplier (e.g. 1.5x) at the caller for headroom.
+ *
+ * KNOWN UNDERCOUNT: the ledger takes `collateralPercentage` of the WHOLE fee,
+ * and the whole fee is the script fee plus the size fee
+ * (`txFeePerByte * size + txFeeFixed`). This reads the script half only. The
+ * size half is bounded by `maxTxSize` (16 KB), so it contributes at most
+ * ~876k lovelace, and `COLLATERAL_SAFETY_NUM` plus
+ * `MIN_TOTAL_COLLATERAL_LOVELACE` absorb it at every budget these builders
+ * produce. Do not treat this as fee-exact.
+ *
+ * Precision: prices arrive as decimal strings ("0.0577") or numbers. We
+ * scale to bigint via `decimalToScaled` with 20 fractional digits, more
+ * than enough for any realistic protocol-parameter precision (current
+ * priceMem / priceStep have <=5 fractional digits). Fractional digits beyond
+ * 20 are truncated. This is a safety-margin computation, not a fee-exact
+ * computation; the caller MUST add headroom on top.
+ *
+ * @param budgets         Per-redeemer ex_units budgets from `evaluateTx`.
+ * @param protocolParams  Shape mirrors mesh's `Protocol` from
+ *                        `BlockfrostProvider.fetchProtocolParameters(...)`.
+ *                        `priceMem`/`priceStep` are decimals (lovelace per
+ *                        unit), `collateralPercentage` is an int (e.g. 150).
+ * @returns               Lovelace floor as a bigint.
+ */
+export function computeCollateralFromExUnits(
+	budgets: Array<{ mem: number; steps: number }>,
+	protocolParams: {
+		priceMem: number | string;
+		priceStep: number | string;
+		collateralPercentage: number;
+	},
+): bigint {
+	if (budgets.length === 0) return 0n;
+
+	// Scale prices to bigints (x10^20) so we can multiply without floats.
+	const PRICE_SCALE_DIGITS = 20;
+	const priceScale = 10n ** BigInt(PRICE_SCALE_DIGITS);
+	const priceMemScaled = decimalToScaled(protocolParams.priceMem, PRICE_SCALE_DIGITS);
+	const priceStepScaled = decimalToScaled(protocolParams.priceStep, PRICE_SCALE_DIGITS);
+
+	let totalScriptFee = 0n;
+	for (const budget of budgets) {
+		const memFee = ceilDiv(BigInt(Math.trunc(budget.mem)) * priceMemScaled, priceScale);
+		const stepFee = ceilDiv(BigInt(Math.trunc(budget.steps)) * priceStepScaled, priceScale);
+		totalScriptFee += memFee + stepFee;
+	}
+
+	const collateralPercentage = BigInt(Math.trunc(protocolParams.collateralPercentage));
+	if (collateralPercentage <= 0n) {
+		throw new Error(
+			`computeCollateralFromExUnits: collateralPercentage must be positive, got ${protocolParams.collateralPercentage}`,
+		);
+	}
+
+	return ceilDiv(totalScriptFee * collateralPercentage, 100n);
+}
+
+/**
+ * Per-spend-leg `ex_units` budgets sum across redeemers; the Conway phase-1
+ * required collateral grows linearly with that sum. 3 ADA covers ~2 SPEND
+ * legs at current preprod prices but is insufficient for 5+ legs, which would
+ * phase-1 reject with `InsufficientCollateral`.
+ *
+ * We compute the floor from the actual evaluated budgets via
+ * `computeCollateralFromExUnits`, then apply this safety multiplier as
+ * headroom against protocol-parameter changes mid-flight (priceMem/priceStep
+ * rarely change but `collateralPercentage` has shifted historically).
+ *
+ * Expressed as bigint numerator/denominator to keep the math integer-only.
+ */
+export const COLLATERAL_SAFETY_NUM = 150n;
+export const COLLATERAL_SAFETY_DEN = 100n;
+
+/**
+ * Floor: even a single-leg tx with tiny budgets must hold this much in
+ * collateral. Matches the V1 single-item builder default and prevents the
+ * derived value from rounding down below mesh's minimum-collateral check.
+ */
+export const MIN_TOTAL_COLLATERAL_LOVELACE = 3_000_000n;
+
+/**
+ * Min-ADA headroom kept aside on the collateral input when clamping declared
+ * total collateral, so the resulting collateral-return output still satisfies
+ * the ledger's min-UTxO rule. 1 ADA comfortably exceeds the min-ADA of a
+ * PURE-ADA output at current `coinsPerUtxoSize`.
+ */
+export const COLLATERAL_RETURN_MIN_LOVELACE = 1_000_000n;
+
+/**
+ * Extra min-ADA headroom per distinct native asset carried by the collateral.
+ *
+ * Mesh's collateral return carries the FULL value of the collateral input,
+ * tokens included (verified against both pinned mesh lines: `addCollateralReturn`
+ * merges `toValue(collateral.txIn.amount)` into the return). Each distinct
+ * asset therefore grows the return output, and the ledger's
+ * `(160 + outputSize) * coinsPerUtxoByte` floor grows with it, while Mesh
+ * never min-ADA-checks the collateral return itself (`sanitizeOutputs` only
+ * walks `meshTxBuilderBody.outputs`).
+ *
+ * A flat 1 ADA floor is therefore only correct for pure-ADA collateral. Sized
+ * generously: ~50 bytes per asset at `coinsPerUtxoSize` 4310 is ~215k lovelace,
+ * so 350k leaves margin without meaningfully reducing declarable collateral.
+ */
+export const COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET = 350_000n;
+
+/** Distinct native (non-lovelace) assets carried by a UTxO. */
+export function nativeAssetCount(utxo: CollateralUtxoLike): number {
+	return utxo.output.amount.filter((asset) => asset.unit !== 'lovelace' && asset.unit !== '').length;
+}
+
+/**
+ * Min-ADA to reserve for the collateral-return output, given how many native
+ * assets the collateral input carries. Pure-ADA collateral keeps the original
+ * 1 ADA floor.
+ */
+export function collateralReturnMinLovelace(assetCount: number): bigint {
+	if (assetCount <= 0) return COLLATERAL_RETURN_MIN_LOVELACE;
+	return COLLATERAL_RETURN_MIN_LOVELACE + BigInt(assetCount) * COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET;
+}
+
+/**
+ * Shape we accept from any of mesh's `Protocol`, the V1 helper's cached
+ * `Protocol`-like object, or a raw blockfrost protocol-params response.
+ * Fields are optional because the loose `unknown` input we receive may carry
+ * either camelCase (`priceMem`) or snake_case (`price_mem`) keys, and either
+ * `collateralPercent` (mesh) or `collateralPercentage` (our helper's name)
+ * or `collateral_percent` (blockfrost raw).
+ */
+type ProtocolParamCandidate = {
+	priceMem?: number | string;
+	price_mem?: number | string;
+	priceStep?: number | string;
+	price_step?: number | string;
+	collateralPercentage?: number;
+	collateralPercent?: number;
+	collateral_percent?: number;
+};
+
+/**
+ * Narrow the loosely-typed protocol-parameters bag (mesh's `Protocol` union the
+ * shared cache's `unknown`) into the exact shape `computeCollateralFromExUnits`
+ * expects. Mesh's V2 `Protocol` type names the field `collateralPercent` while
+ * our helper uses `collateralPercentage`; bridge that here. Returns `null` if
+ * any required field is missing: the caller falls back to the static
+ * `MIN_TOTAL_COLLATERAL_LOVELACE` in that case rather than crashing.
+ */
+export function extractCollateralProtocolParams(
+	protocolParameters: unknown,
+): { priceMem: number | string; priceStep: number | string; collateralPercentage: number } | null {
+	if (protocolParameters == null || typeof protocolParameters !== 'object') return null;
+	const p = protocolParameters as ProtocolParamCandidate;
+	const priceMem = p.priceMem ?? p.price_mem;
+	const priceStep = p.priceStep ?? p.price_step;
+	const collateralPercentage = p.collateralPercentage ?? p.collateralPercent ?? p.collateral_percent;
+	if (priceMem == null || priceStep == null || collateralPercentage == null) return null;
+	if (typeof priceMem !== 'number' && typeof priceMem !== 'string') return null;
+	if (typeof priceStep !== 'number' && typeof priceStep !== 'string') return null;
+	if (typeof collateralPercentage !== 'number') return null;
+	return { priceMem, priceStep, collateralPercentage };
+}
+
+/**
+ * Derive Conway phase-1 total collateral from per-redeemer exUnits budgets.
+ *
+ * Sums the budgets, runs `computeCollateralFromExUnits`, applies the safety
+ * multiplier, and floors at `MIN_TOTAL_COLLATERAL_LOVELACE`. Returned as a
+ * string in the shape `setTotalCollateral(...)` expects.
+ */
+export function deriveTotalCollateral(
+	budgets: Array<{ mem: number; steps: number }>,
+	protocolParameters: unknown,
+	collateralCapLovelace?: bigint,
+	collateralNativeAssetCount: number = 0,
+): string {
+	const params = extractCollateralProtocolParams(protocolParameters);
+	if (params == null) {
+		return MIN_TOTAL_COLLATERAL_LOVELACE.toString();
+	}
+	const raw = computeCollateralFromExUnits(budgets, params);
+	const withSafety = (raw * COLLATERAL_SAFETY_NUM) / COLLATERAL_SAFETY_DEN;
+	let total = withSafety > MIN_TOTAL_COLLATERAL_LOVELACE ? withSafety : MIN_TOTAL_COLLATERAL_LOVELACE;
+	// Never declare more collateral than the single collateral input can cover.
+	// The first build pass uses inflated DEFAULT_EX_UNITS budgets, so the derived
+	// requirement can exceed the (typically 5 ADA) collateral UTxO; mesh then
+	// computes collateralInput - totalCollateral < 0, emits a negative
+	// collateral-return output, and throws at build time, silently forcing
+	// single-item fallback for any batch of ~4+ legs. Cap to the input value
+	// (leaving a min-ADA collateral-return) so the evaluation build succeeds; the
+	// second pass uses real, far smaller budgets that stay well under the cap.
+	// The reserved headroom scales with the collateral's native assets: mesh
+	// copies them into the collateral return, so a token-bearing return needs
+	// more min-ADA than a pure-ADA one.
+	const returnMinLovelace = collateralReturnMinLovelace(collateralNativeAssetCount);
+	if (collateralCapLovelace != null && collateralCapLovelace > returnMinLovelace) {
+		const cap = collateralCapLovelace - returnMinLovelace;
+		if (cap >= MIN_TOTAL_COLLATERAL_LOVELACE && total > cap) {
+			total = cap;
+		}
+	}
+	return total.toString();
+}

--- a/packages/payment-core/src/collateral.ts
+++ b/packages/payment-core/src/collateral.ts
@@ -17,6 +17,8 @@
  * hardcoded constant cannot track either bound.
  */
 
+import { logger } from './logger';
+
 /**
  * Structural shape of the parts of a mesh `UTxO` this module reads.
  *
@@ -249,6 +251,17 @@ export function deriveTotalCollateral(
 ): string {
 	const params = extractCollateralProtocolParams(protocolParameters);
 	if (params == null) {
+		// Degrading to the floor is safe but it silently discards the scaling, which
+		// is the whole reason this helper exists. Log it: the only way to get here
+		// is a protocol-parameters bag missing `priceMem`/`priceStep`/
+		// `collateralPercentage`, which means either a failed fetch or a mesh
+		// rename, and both need an operator to notice.
+		logger.warn(
+			'deriveTotalCollateral: protocol parameters missing price/collateral fields; falling back to the floor',
+			{
+				fallbackLovelace: MIN_TOTAL_COLLATERAL_LOVELACE.toString(),
+			},
+		);
 		return MIN_TOTAL_COLLATERAL_LOVELACE.toString();
 	}
 	const raw = computeCollateralFromExUnits(budgets, params);

--- a/packages/payment-source-v2/src/builders/batch-helpers.ts
+++ b/packages/payment-source-v2/src/builders/batch-helpers.ts
@@ -216,102 +216,6 @@ export function pickBatchCollateral(
 	return pickCollateralUtxo(utxos, requiredLovelace, excludeSpendingInputs);
 }
 
-/**
- * Internal: parse a decimal value (number or string) into a scaled bigint.
- * Returns `value * 10^scaleDigits` rounded toward zero. Designed for
- * Cardano protocol-parameter decimals like price_mem = "0.0577" which are
- * exact rationals on-chain but arrive at us as decimal strings.
- *
- * Precision: we pad to 20 fractional digits which is well beyond any
- * realistic protocol-parameter precision. Any fractional digits beyond 20
- * are truncated (NOT rounded) — acceptable for a safety-margin computation,
- * and the caller is expected to apply a multiplier (e.g. 1.5x) for headroom.
- */
-function decimalToScaled(value: number | string, scaleDigits: number): bigint {
-	const s = typeof value === 'number' ? value.toString() : value;
-	// Handle scientific notation (e.g. "1e-3") by normalizing through Number.
-	// Mesh / blockfrost don't emit scientific notation today but be defensive.
-	const normalized = s.includes('e') || s.includes('E') ? Number(s).toFixed(20) : s;
-
-	const isNegative = normalized.startsWith('-');
-	const unsigned = isNegative ? normalized.slice(1) : normalized;
-	const [whole, frac = ''] = unsigned.split('.');
-
-	const cappedFracDigits = Math.min(scaleDigits, 20);
-	const fracPadded = (frac + '0'.repeat(scaleDigits)).slice(0, cappedFracDigits);
-	const padTail = '0'.repeat(scaleDigits - cappedFracDigits);
-
-	const combined = (whole === '' ? '0' : whole) + fracPadded + padTail;
-	const result = BigInt(combined);
-	return isNegative ? -result : result;
-}
-
-/** Internal: ceil-div for non-negative bigints. */
-function ceilDiv(num: bigint, den: bigint): bigint {
-	if (den <= 0n) throw new Error('ceilDiv: denominator must be positive');
-	if (num <= 0n) return 0n;
-	return (num + den - 1n) / den;
-}
-
-/**
- * Compute the Conway-era total collateral requirement from per-redeemer
- * `ex_units` budgets. Formula:
- *
- *   redeemerFee     = ceil(budget.mem * priceMem) + ceil(budget.steps * priceStep)
- *   totalScriptFee  = sum(redeemerFee across all redeemers)
- *   totalCollateral = ceil(totalScriptFee * collateralPercentage / 100)
- *
- * The result is the MINIMUM lovelace the collateral UTxO must hold. Apply a
- * safety multiplier (e.g. 1.5x) at the caller for headroom against
- * protocol-parameter changes mid-flight.
- *
- * Precision: prices arrive as decimal strings ("0.0577") or numbers. We
- * scale to bigint via `decimalToScaled` with 20 fractional digits — more
- * than enough for any realistic protocol-parameter precision (current
- * priceMem / priceStep have ≤5 fractional digits). Fractional digits beyond
- * 20 are truncated. This is a safety-margin computation, not a fee-exact
- * computation; the caller MUST add headroom on top.
- *
- * @param budgets         Per-redeemer ex_units budgets from `evaluateTx`.
- * @param protocolParams  Shape mirrors mesh's `Protocol` from
- *                        `BlockfrostProvider.fetchProtocolParameters(...)`.
- *                        `priceMem`/`priceStep` are decimals (lovelace per
- *                        unit), `collateralPercentage` is an int (e.g. 150).
- * @returns               Lovelace floor as a bigint.
- */
-export function computeCollateralFromExUnits(
-	budgets: Array<{ mem: number; steps: number }>,
-	protocolParams: {
-		priceMem: number | string;
-		priceStep: number | string;
-		collateralPercentage: number;
-	},
-): bigint {
-	if (budgets.length === 0) return 0n;
-
-	// Scale prices to bigints (×10^20) so we can multiply without floats.
-	const PRICE_SCALE_DIGITS = 20;
-	const priceScale = 10n ** BigInt(PRICE_SCALE_DIGITS);
-	const priceMemScaled = decimalToScaled(protocolParams.priceMem, PRICE_SCALE_DIGITS);
-	const priceStepScaled = decimalToScaled(protocolParams.priceStep, PRICE_SCALE_DIGITS);
-
-	let totalScriptFee = 0n;
-	for (const budget of budgets) {
-		const memFee = ceilDiv(BigInt(Math.trunc(budget.mem)) * priceMemScaled, priceScale);
-		const stepFee = ceilDiv(BigInt(Math.trunc(budget.steps)) * priceStepScaled, priceScale);
-		totalScriptFee += memFee + stepFee;
-	}
-
-	const collateralPercentage = BigInt(Math.trunc(protocolParams.collateralPercentage));
-	if (collateralPercentage <= 0n) {
-		throw new Error(
-			`computeCollateralFromExUnits: collateralPercentage must be positive, got ${protocolParams.collateralPercentage}`,
-		);
-	}
-
-	return ceilDiv(totalScriptFee * collateralPercentage, 100n);
-}
-
 /** Why the predicate rejected a given subset of items, or `'none'` if no subset fit. */
 export type BatchShrinkReason = 'window' | 'utxos' | 'collateral' | 'tx-size' | 'none';
 
@@ -424,150 +328,23 @@ export function assertNoCollateralOverlap(
  */
 export const MAX_SAFE_TX_BYTES = 14_000;
 
-/**
- * Per-spend-leg `ex_units` budgets sum across redeemers; the Conway phase-1
- * required collateral grows linearly with that sum. 3 ADA covers ~2 SPEND
- * legs at current preprod prices but is insufficient for 5+ legs, which would
- * phase-1 reject with `InsufficientCollateral`.
- *
- * We compute the floor from the actual evaluated budgets via
- * `computeCollateralFromExUnits`, then apply this safety multiplier as
- * headroom against protocol-parameter changes mid-flight (priceMem/priceStep
- * rarely change but `collateralPercentage` has shifted historically).
- *
- * Expressed as bigint numerator/denominator to keep the math integer-only.
- */
-export const COLLATERAL_SAFETY_NUM = 150n;
-export const COLLATERAL_SAFETY_DEN = 100n;
-
-/**
- * Floor — even a single-leg tx with tiny budgets must hold this much in
- * collateral. Matches the V1 single-item builder default and prevents the
- * derived value from rounding down below mesh's minimum-collateral check.
- */
-export const MIN_TOTAL_COLLATERAL_LOVELACE = 3_000_000n;
-
-/**
- * Min-ADA headroom kept aside on the collateral input when clamping declared
- * total collateral, so the resulting collateral-return output still satisfies
- * the ledger's min-UTxO rule. 1 ADA comfortably exceeds the min-ADA of a
- * PURE-ADA output at current `coinsPerUtxoSize`.
- */
-export const COLLATERAL_RETURN_MIN_LOVELACE = 1_000_000n;
-
-/**
- * Extra min-ADA headroom per distinct native asset carried by the collateral.
- *
- * Mesh's collateral return carries the FULL value of the collateral input,
- * tokens included (verified against both pinned mesh lines: `addCollateralReturn`
- * merges `toValue(collateral.txIn.amount)` into the return). Each distinct
- * asset therefore grows the return output, and the ledger's
- * `(160 + outputSize) * coinsPerUtxoByte` floor grows with it — while Mesh
- * never min-ADA-checks the collateral return itself (`sanitizeOutputs` only
- * walks `meshTxBuilderBody.outputs`).
- *
- * A flat 1 ADA floor is therefore only correct for pure-ADA collateral. Sized
- * generously: ~50 bytes per asset at `coinsPerUtxoSize` 4310 is ~215k lovelace,
- * so 350k leaves margin without meaningfully reducing declarable collateral.
- */
-export const COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET = 350_000n;
-
-/** Distinct native (non-lovelace) assets carried by a UTxO. */
-export function nativeAssetCount(utxo: UTxO): number {
-	return utxo.output.amount.filter((asset) => asset.unit !== 'lovelace' && asset.unit !== '').length;
-}
-
-/**
- * Min-ADA to reserve for the collateral-return output, given how many native
- * assets the collateral input carries. Pure-ADA collateral keeps the original
- * 1 ADA floor.
- */
-export function collateralReturnMinLovelace(assetCount: number): bigint {
-	if (assetCount <= 0) return COLLATERAL_RETURN_MIN_LOVELACE;
-	return COLLATERAL_RETURN_MIN_LOVELACE + BigInt(assetCount) * COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET;
-}
-
-/**
- * Shape we accept from any of mesh's `Protocol`, the V1 helper's cached
- * `Protocol`-like object, or a raw blockfrost protocol-params response.
- * Fields are optional because the loose `unknown` input we receive may carry
- * either camelCase (`priceMem`) or snake_case (`price_mem`) keys, and either
- * `collateralPercent` (mesh) or `collateralPercentage` (our helper's name)
- * or `collateral_percent` (blockfrost raw).
- */
-type ProtocolParamCandidate = {
-	priceMem?: number | string;
-	price_mem?: number | string;
-	priceStep?: number | string;
-	price_step?: number | string;
-	collateralPercentage?: number;
-	collateralPercent?: number;
-	collateral_percent?: number;
-};
-
-/**
- * Narrow the loosely-typed protocol-parameters bag (mesh's `Protocol` ∪ the
- * shared cache's `unknown`) into the exact shape `computeCollateralFromExUnits`
- * expects. Mesh's V2 `Protocol` type names the field `collateralPercent` while
- * our helper uses `collateralPercentage`; bridge that here. Returns `null` if
- * any required field is missing — the caller falls back to the static
- * `MIN_TOTAL_COLLATERAL_LOVELACE` in that case rather than crashing.
- */
-export function extractCollateralProtocolParams(
-	protocolParameters: unknown,
-): { priceMem: number | string; priceStep: number | string; collateralPercentage: number } | null {
-	if (protocolParameters == null || typeof protocolParameters !== 'object') return null;
-	const p = protocolParameters as ProtocolParamCandidate;
-	const priceMem = p.priceMem ?? p.price_mem;
-	const priceStep = p.priceStep ?? p.price_step;
-	const collateralPercentage = p.collateralPercentage ?? p.collateralPercent ?? p.collateral_percent;
-	if (priceMem == null || priceStep == null || collateralPercentage == null) return null;
-	if (typeof priceMem !== 'number' && typeof priceMem !== 'string') return null;
-	if (typeof priceStep !== 'number' && typeof priceStep !== 'string') return null;
-	if (typeof collateralPercentage !== 'number') return null;
-	return { priceMem, priceStep, collateralPercentage };
-}
-
-/**
- * Derive Conway phase-1 total collateral from per-redeemer exUnits budgets.
- *
- * Sums the budgets, runs `computeCollateralFromExUnits`, applies the safety
- * multiplier, and floors at `MIN_TOTAL_COLLATERAL_LOVELACE`. Returned as a
- * string in the shape `setTotalCollateral(...)` expects.
- */
-export function deriveTotalCollateral(
-	budgets: Array<{ mem: number; steps: number }>,
-	protocolParameters: unknown,
-	collateralCapLovelace?: bigint,
-	collateralNativeAssetCount: number = 0,
-): string {
-	const params = extractCollateralProtocolParams(protocolParameters);
-	if (params == null) {
-		return MIN_TOTAL_COLLATERAL_LOVELACE.toString();
-	}
-	const raw = computeCollateralFromExUnits(budgets, params);
-	const withSafety = (raw * COLLATERAL_SAFETY_NUM) / COLLATERAL_SAFETY_DEN;
-	let total = withSafety > MIN_TOTAL_COLLATERAL_LOVELACE ? withSafety : MIN_TOTAL_COLLATERAL_LOVELACE;
-	// Never declare more collateral than the single collateral input can cover.
-	// The first build pass uses inflated DEFAULT_EX_UNITS budgets, so the derived
-	// requirement can exceed the (typically 5 ADA) collateral UTxO; mesh then
-	// computes collateralInput - totalCollateral < 0, emits a negative
-	// collateral-return output, and throws at build time — silently forcing
-	// single-item fallback for any batch of ~4+ legs. Cap to the input value
-	// (leaving a min-ADA collateral-return) so the evaluation build succeeds; the
-	// second pass uses real, far smaller budgets that stay well under the cap.
-	// The reserved headroom scales with the collateral's native assets: mesh
-	// copies them into the collateral return, so a token-bearing return needs
-	// more min-ADA than a pure-ADA one.
-	const returnMinLovelace = collateralReturnMinLovelace(collateralNativeAssetCount);
-	if (collateralCapLovelace != null && collateralCapLovelace > returnMinLovelace) {
-		const cap = collateralCapLovelace - returnMinLovelace;
-		if (cap >= MIN_TOTAL_COLLATERAL_LOVELACE && total > cap) {
-			total = cap;
-		}
-	}
-	return total.toString();
-}
+// Conway phase-1 collateral math moved to `@masumi/payment-core/collateral` so
+// the V1-pinned registry builders in `src/services/registry/shared.ts` can
+// share one implementation with the V2 batch builders (ADR 0005: the module
+// imports no mesh symbol, so neither mesh line can collapse onto the other).
+// Re-exported here because every batch call site imports it from this file.
+export {
+	COLLATERAL_RETURN_MIN_LOVELACE,
+	COLLATERAL_RETURN_MIN_LOVELACE_PER_ASSET,
+	COLLATERAL_SAFETY_DEN,
+	COLLATERAL_SAFETY_NUM,
+	MIN_TOTAL_COLLATERAL_LOVELACE,
+	collateralReturnMinLovelace,
+	computeCollateralFromExUnits,
+	deriveTotalCollateral,
+	extractCollateralProtocolParams,
+	nativeAssetCount,
+} from '@masumi/payment-core/collateral';
 
 /**
  * Lovelace quantity held by a UTxO (0 if it somehow carries no ADA entry).

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -284,17 +284,13 @@ async function processSingleDeregistration(
 		newTxHash = await wallet.submitTx(signedTx);
 	} catch (error) {
 		logger.error('Error submitting V2 deregister single-item tx', { error, requestId: request.id });
-		await prisma.registryRequest.update({
-			where: { id: request.id },
-			data: {
-				state: RegistrationState.DeregistrationRequested,
-				DeregistrationHotWallet: {
-					update: {
-						lockedAt: null,
-					},
-				},
-			},
-		});
+		// Terminal, not a silent re-queue. See the matching comment in
+		// `update/service.ts`: reverting to DeregistrationRequested retried a
+		// deterministic rejection every tick with `error` left NULL. The batch half
+		// of this file already fails the whole set on a submit rejection, and a
+		// DeregistrationFailed row records the reason and can be retried in place
+		// via the deregister route.
+		await markRequestFailed(request, error);
 		return;
 	}
 

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -2,6 +2,7 @@ import { PaymentSourceType, RegistrationState, TransactionStatus } from '@/gener
 import { prisma } from '@masumi/payment-core/db';
 import { logger } from '@masumi/payment-core/logger';
 import type { LanguageVersion, UTxO } from '@meshsdk/core';
+import { describeAmbiguousRegistrySubmit } from '../submit-failure';
 import { asV2Provider } from '../../provider-cast';
 import { convertNetwork } from '@/utils/converter/network-convert';
 import { lockAndQueryRegistryRequests } from '@/utils/db/lock-and-query-registry-request';
@@ -284,6 +285,16 @@ async function processSingleDeregistration(
 		newTxHash = await wallet.submitTx(signedTx);
 	} catch (error) {
 		logger.error('Error submitting V2 deregister single-item tx', { error, requestId: request.id });
+		const ambiguous = describeAmbiguousRegistrySubmit(signedTx, error);
+		if (ambiguous) {
+			logger.warn('Error submitting V2 deregister single-item tx was AMBIGUOUS; the transaction may be on chain', {
+				error,
+				requestId: request.id,
+				intendedTxHash: ambiguous.intendedTxHash,
+			});
+			await markRequestFailed(request, ambiguous.failure);
+			return;
+		}
 		// Terminal, not a silent re-queue. See the matching comment in
 		// `update/service.ts`: reverting to DeregistrationRequested retried a
 		// deterministic rejection every tick with `error` left NULL. The batch half

--- a/packages/payment-source-v2/src/services/registry/deregister/service.ts
+++ b/packages/payment-source-v2/src/services/registry/deregister/service.ts
@@ -276,9 +276,9 @@ async function processSingleDeregistration(
 	const signedTx = await wallet.signTx(unsignedTx);
 
 	// Submit FIRST, then write DB. See register/service.ts single-item
-	// path for full rationale. On submit failure, no orphan Transaction
-	// row to clean up; just revert state back to DeregistrationRequested
-	// and clear the wallet lock so the next tick can retry.
+	// path for full rationale. On submit failure there is no orphan
+	// Transaction row to clean up, so the catch below only has to stamp the
+	// failure and free the wallet.
 	let newTxHash: string;
 	try {
 		newTxHash = await wallet.submitTx(signedTx);

--- a/packages/payment-source-v2/src/services/registry/submit-failure.spec.ts
+++ b/packages/payment-source-v2/src/services/registry/submit-failure.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.unstable_mockModule('@meshsdk/core', () => ({
+	resolveTxHash: () => 'a'.repeat(64),
+}));
+
+const { describeAmbiguousRegistrySubmit } = await import('./submit-failure');
+
+const SIGNED_TX = '84a300818258';
+
+describe('describeAmbiguousRegistrySubmit', () => {
+	/**
+	 * The node refused the transaction before broadcast, so nothing reached the
+	 * chain. The caller must stamp the original error, not a warning about a
+	 * transaction that never existed.
+	 */
+	it.each(['ScriptWitnessNotValidatingUTXOW', 'BadInputsUTxO', 'ValueNotConservedUTxO', 'InsufficientCollateral'])(
+		'returns null for the definitive rejection %s',
+		(rejection) => {
+			expect(describeAmbiguousRegistrySubmit(SIGNED_TX, new Error(`submit failed: ${rejection}`))).toBeNull();
+		},
+	);
+
+	/**
+	 * A transport failure proves nothing. The burn or mint may have landed, so
+	 * the stored reason has to say so and name the hash to check.
+	 */
+	it('describes a transport failure as ambiguous and names the intended hash', () => {
+		const result = describeAmbiguousRegistrySubmit(SIGNED_TX, new Error('socket hang up'));
+
+		expect(result).not.toBeNull();
+		expect(result!.intendedTxHash).toBe('a'.repeat(64));
+		expect(result!.failure.message).toContain('may still be on chain');
+		expect(result!.failure.message).toContain('a'.repeat(64));
+		expect(result!.failure.message).toContain('socket hang up');
+	});
+
+	/**
+	 * Mesh wraps a Blockfrost rejection as a plain object and buries the ledger
+	 * detail under `data.message`, so a definitive rejection must not be read as
+	 * ambiguous just because it is not an Error instance.
+	 */
+	it('reads a definitive rejection out of the plain object mesh throws', () => {
+		expect(
+			describeAmbiguousRegistrySubmit(SIGNED_TX, { status: 400, data: { message: 'ValidationTagMismatch' } }),
+		).toBeNull();
+	});
+});

--- a/packages/payment-source-v2/src/services/registry/submit-failure.ts
+++ b/packages/payment-source-v2/src/services/registry/submit-failure.ts
@@ -1,0 +1,40 @@
+import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
+import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-classifier';
+import { resolveTxHash } from '@meshsdk/core';
+
+export type AmbiguousRegistrySubmit = {
+	intendedTxHash: string;
+	failure: Error;
+};
+
+/**
+ * Tells a registry submit failure that reached the chain apart from one that
+ * did not, and returns the operator-facing description for the ambiguous case.
+ *
+ * Returns null when the node definitively rejected the transaction before
+ * broadcast. Nothing reached the chain, so the plain failure is the whole
+ * truth and the caller stamps the original error.
+ *
+ * Returns a description when the failure proves nothing: a transport error, a
+ * 5xx, a timeout. The transaction may be on chain. The payment paths hand that
+ * case to funding-reconciliation, but the single-item registry paths submit
+ * before they write, so there is no pending Transaction row to reconcile.
+ * Reverting the request to its `*Requested` state is not the safe answer
+ * either: the next tick rebuilds against chain state that may already have
+ * moved, and that rebuild then fails for a reason that hides the real one. The
+ * caller fails the request terminally and stores this text, which names the
+ * hash an operator has to look up before retrying.
+ */
+export function describeAmbiguousRegistrySubmit(signedTx: string, error: unknown): AmbiguousRegistrySubmit | null {
+	if (isDefinitiveNodeRejection(error)) {
+		return null;
+	}
+	const intendedTxHash = String(resolveTxHash(signedTx));
+	return {
+		intendedTxHash,
+		failure: new Error(
+			`Submission failed without a node rejection, so the transaction may still be on chain. ` +
+				`Check ${intendedTxHash} before retrying. Cause: ${interpretBlockchainError(error)}`,
+		),
+	};
+}

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -41,6 +41,7 @@ import {
 	resetRegistryPrepFailureCount,
 } from '../../wallet-collateral/prep-failure-guard';
 import { unlockHotWalletIfNoPendingTransaction } from '../../wallet-lock-helpers';
+import { describeAmbiguousRegistrySubmit } from '../submit-failure';
 import { asV2Provider } from '../../provider-cast';
 import { buildAgentMetadata, validateRegistrationPricing } from '../register/service';
 
@@ -290,6 +291,16 @@ async function processUpdate(
 		newTxHash = await wallet.submitTx(signedTx);
 	} catch (error) {
 		logger.error('Error submitting V2 update tx', { error, requestId: request.id });
+		const ambiguous = describeAmbiguousRegistrySubmit(signedTx, error);
+		if (ambiguous) {
+			logger.warn('Error submitting V2 update tx was AMBIGUOUS; the transaction may be on chain', {
+				error,
+				requestId: request.id,
+				intendedTxHash: ambiguous.intendedTxHash,
+			});
+			await markRequestFailed(request, ambiguous.failure);
+			return;
+		}
 		// Terminal, not a silent re-queue. This used to revert to UpdateRequested,
 		// which retries every tick forever with `error` left NULL: a deterministic
 		// rejection (collateral, phase-1, script-data-hash) then loops invisibly and

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -283,8 +283,8 @@ async function processUpdate(
 
 	// Submit FIRST, then write DB. Same rationale as
 	// register/deregister single-item: on submit failure there is no
-	// orphan Transaction row to clean up, and we revert state back to
-	// UpdateRequested so the next tick can retry.
+	// orphan Transaction row to clean up, so the catch below only has to
+	// stamp the failure and free the wallet.
 	let newTxHash: string;
 	try {
 		newTxHash = await wallet.submitTx(signedTx);

--- a/packages/payment-source-v2/src/services/registry/update/service.ts
+++ b/packages/payment-source-v2/src/services/registry/update/service.ts
@@ -290,15 +290,15 @@ async function processUpdate(
 		newTxHash = await wallet.submitTx(signedTx);
 	} catch (error) {
 		logger.error('Error submitting V2 update tx', { error, requestId: request.id });
-		await prisma.registryRequest.update({
-			where: { id: request.id },
-			data: {
-				state: RegistrationState.UpdateRequested,
-				DeregistrationHotWallet: {
-					update: { lockedAt: null },
-				},
-			},
-		});
+		// Terminal, not a silent re-queue. This used to revert to UpdateRequested,
+		// which retries every tick forever with `error` left NULL: a deterministic
+		// rejection (collateral, phase-1, script-data-hash) then loops invisibly and
+		// an operator sees a queued row with nothing to read. Both batch paths
+		// already treat a submit rejection as terminal (`register/service.ts` and
+		// the batch half of this file), so match them. UpdateFailed records the
+		// reason, frees the wallet, and stays re-queueable: the update route accepts
+		// UpdateFailed and resets the row in place.
+		await markRequestFailed(request, error);
 		return;
 	}
 

--- a/src/routes/api/registry/deregister/index.spec.ts
+++ b/src/routes/api/registry/deregister/index.spec.ts
@@ -260,6 +260,8 @@ describe('unregisterAgentPost', () => {
 		});
 		expect(mockUpdateRegistryRequest.mock.calls[0]?.[0]?.data).toEqual({
 			state: RegistrationState.DeregistrationRequested,
+			// A re-queued row must not keep the reason a previous attempt failed for.
+			error: null,
 			deregistrationHotWalletId: 'recipient-wallet-id',
 		});
 		expect(responseMock._getJSONData().data.RecipientWallet).toEqual({

--- a/src/routes/api/registry/deregister/index.ts
+++ b/src/routes/api/registry/deregister/index.ts
@@ -168,6 +168,11 @@ export const unregisterAgentPost = payAuthenticatedEndpointFactory.build({
 							},
 							data: {
 								state: RegistrationState.DeregistrationRequested,
+								// Drop the reason from a previous failed attempt. Without this a
+								// re-queued row carries a stale error for as long as it is
+								// Requested/Initiated, which reads as "failing again". The update
+								// route already clears it on the same transition.
+								error: null,
 								deregistrationHotWalletId: managedHolderWallet.id,
 							},
 							include: {

--- a/src/services/registry/shared.spec.ts
+++ b/src/services/registry/shared.spec.ts
@@ -36,6 +36,7 @@ class FakeMeshTxBuilder {
 	addingPlutusMint = false;
 	mintItem: MintLeg | undefined = undefined;
 	mints: MintLeg[] = [];
+	totalCollateral: string | undefined = undefined;
 	serializer = {
 		deserializer: {
 			key: {
@@ -116,7 +117,8 @@ class FakeMeshTxBuilder {
 	txInCollateral() {
 		return this;
 	}
-	setTotalCollateral() {
+	setTotalCollateral(amount: string) {
+		this.totalCollateral = amount;
 		return this;
 	}
 	txOut() {
@@ -154,14 +156,32 @@ const { generateRegistryUpdateTransactionAutomaticFees } = await import('./share
 const POLICY_ID = 'a'.repeat(56);
 const SCRIPT = { version: 'V3' as const, code: 'aabbccdd' };
 
-function utxo(txHash: string, outputIndex: number): UTxO {
+function utxo(txHash: string, outputIndex: number, lovelace = '5000000'): UTxO {
 	return {
 		input: { txHash, outputIndex },
 		output: {
 			address: 'addr_test1placeholder',
-			amount: [{ unit: 'lovelace', quantity: '5000000' }],
+			amount: [{ unit: 'lovelace', quantity: lovelace }],
 		},
 	} as unknown as UTxO;
+}
+
+function buildUpdate(collateralUtxo: UTxO) {
+	return generateRegistryUpdateTransactionAutomaticFees(
+		provider,
+		'preprod',
+		SCRIPT,
+		'addr_test1updater',
+		'addr_test1recipient',
+		'2000000',
+		POLICY_ID,
+		'01' + 'aa'.repeat(28) + '000000',
+		'02' + 'bb'.repeat(28) + '000000',
+		utxo('1111', 0),
+		collateralUtxo,
+		[utxo('dddd', 0)],
+		{ name: 'Agent A', description: 'desc' },
+	);
 }
 
 const provider = {
@@ -213,5 +233,33 @@ describe('generateRegistryUpdateTransactionAutomaticFees', () => {
 			// UpdateAction redeemer alternative is 1.
 			expect(leg.redeemer).toEqual({ data: { alternative: 1, fields: [] }, exUnits: expect.anything() });
 		}
+	});
+});
+
+describe('registry collateral declaration', () => {
+	/**
+	 * The declared total must stay strictly below the collateral input. Equal
+	 * values leave no `collateral_return`, and the ledger rejects that in phase 1,
+	 * before `evaluateTx` ever sees the transaction.
+	 */
+	it('declares less collateral than the smallest accepted input holds', async () => {
+		await expect(buildUpdate(utxo('cccc', 0))).resolves.toBe('beadface');
+
+		const finalBuilder = builtBuilders[builtBuilders.length - 1];
+		expect(finalBuilder.totalCollateral).toBeDefined();
+		expect(BigInt(finalBuilder.totalCollateral!)).toBeLessThan(
+			BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount),
+		);
+	});
+
+	/**
+	 * Not every caller routes its collateral through `pickCollateralUtxo`. The
+	 * single-item register path takes `sortAndLimitUtxos(...)[0]`, which orders by
+	 * asset count and not by value, so it can hand over an input worth less than
+	 * the declared total. That has to fail at build time with a readable reason
+	 * rather than at submit with an unexplained phase-1 rejection.
+	 */
+	it('refuses a collateral input that cannot cover the declared total', async () => {
+		await expect(buildUpdate(utxo('cccc', 0, '2000000'))).rejects.toThrow(/holds 2000000 lovelace/);
 	});
 });

--- a/src/services/registry/shared.spec.ts
+++ b/src/services/registry/shared.spec.ts
@@ -166,6 +166,15 @@ function utxo(txHash: string, outputIndex: number, lovelace = '5000000'): UTxO {
 	} as unknown as UTxO;
 }
 
+const provider = {
+	fetchProtocolParameters: async () => ({
+		priceMem: '0.0577',
+		priceStep: '0.0000721',
+		collateralPercentage: 150,
+	}),
+	evaluateTx: async () => [{ tag: 'MINT', index: 0, budget: { mem: 1_000_000, steps: 500_000_000 } }],
+} as never;
+
 function buildUpdate(collateralUtxo: UTxO) {
 	return generateRegistryUpdateTransactionAutomaticFees(
 		provider,
@@ -183,15 +192,6 @@ function buildUpdate(collateralUtxo: UTxO) {
 		{ name: 'Agent A', description: 'desc' },
 	);
 }
-
-const provider = {
-	fetchProtocolParameters: async () => ({
-		priceMem: '0.0577',
-		priceStep: '0.0000721',
-		collateralPercentage: 150,
-	}),
-	evaluateTx: async () => [{ tag: 'MINT', index: 0, budget: { mem: 1_000_000, steps: 500_000_000 } }],
-} as never;
 
 beforeEach(() => {
 	builtBuilders.length = 0;

--- a/src/services/registry/shared.spec.ts
+++ b/src/services/registry/shared.spec.ts
@@ -175,9 +175,20 @@ const provider = {
 	evaluateTx: async () => [{ tag: 'MINT', index: 0, budget: { mem: 1_000_000, steps: 500_000_000 } }],
 } as never;
 
-function buildUpdate(collateralUtxo: UTxO) {
+function providerWithBudget(budget: { mem: number; steps: number }) {
+	return {
+		fetchProtocolParameters: async () => ({
+			priceMem: '0.0577',
+			priceStep: '0.0000721',
+			collateralPercentage: 150,
+		}),
+		evaluateTx: async () => [{ tag: 'MINT', index: 0, budget }],
+	} as never;
+}
+
+function buildUpdate(collateralUtxo: UTxO, evaluationProvider: unknown = provider) {
 	return generateRegistryUpdateTransactionAutomaticFees(
-		provider,
+		evaluationProvider as never,
 		'preprod',
 		SCRIPT,
 		'addr_test1updater',
@@ -271,5 +282,41 @@ describe('registry collateral declaration', () => {
 	 */
 	it('refuses a collateral input worth exactly the declared total', async () => {
 		await expect(buildUpdate(utxo('cccc', 0, '3000000'))).rejects.toThrow(/holds 3000000 lovelace/);
+	});
+
+	/**
+	 * The point of deriving rather than hardcoding. The ledger takes
+	 * `collateralPercentage` of the fee, so a more expensive budget needs a larger
+	 * declaration. A constant cannot follow that; this value has to rise with the
+	 * budget. (It tracks the script half of the fee only, which is why the safety
+	 * multiplier is applied on top. See `computeCollateralFromExUnits`.)
+	 */
+	it('declares more than the floor when the evaluated budget is expensive', async () => {
+		const expensive = providerWithBudget({ mem: 14_000_000, steps: 10_000_000_000 });
+
+		await expect(buildUpdate(utxo('cccc', 0, '10000000'), expensive)).resolves.toBe('beadface');
+
+		const finalBuilder = builtBuilders[builtBuilders.length - 1];
+		// scriptFee = ceil(14e6 * 0.0577) + ceil(10e9 * 0.0000721) = 1_528_800
+		// required  = 150% of that                                 = 2_293_200
+		// declared  = required * 1.5 safety                        = 3_439_800
+		expect(BigInt(finalBuilder.totalCollateral!)).toBe(3_439_800n);
+	});
+
+	/**
+	 * The other bound. However expensive the budget, the declared total must stay
+	 * below the input, or mesh emits a `collateral_return` that the ledger rejects
+	 * in phase 1. The cap wins over the derived requirement.
+	 */
+	it('caps the declared total below the input even when the budget wants more', async () => {
+		const expensive = providerWithBudget({ mem: 14_000_000, steps: 10_000_000_000 });
+
+		await expect(buildUpdate(utxo('cccc', 0, '4200000'), expensive)).resolves.toBe('beadface');
+
+		const finalBuilder = builtBuilders[builtBuilders.length - 1];
+		// Uncapped the derivation wants 3_439_800; the 4.2 ADA input allows only
+		// 4_200_000 - 1_000_000 of min-UTxO headroom for the return.
+		expect(BigInt(finalBuilder.totalCollateral!)).toBe(3_200_000n);
+		expect(BigInt(finalBuilder.totalCollateral!)).toBeLessThan(4_200_000n);
 	});
 });

--- a/src/services/registry/shared.spec.ts
+++ b/src/services/registry/shared.spec.ts
@@ -262,4 +262,14 @@ describe('registry collateral declaration', () => {
 	it('refuses a collateral input that cannot cover the declared total', async () => {
 		await expect(buildUpdate(utxo('cccc', 0, '2000000'))).rejects.toThrow(/holds 2000000 lovelace/);
 	});
+
+	/**
+	 * An input worth exactly the declared total leaves a zero `collateral_return`,
+	 * which is the failure this whole change exists to stop. The floor therefore
+	 * has to sit strictly above the declared total and carry min-UTxO headroom. It
+	 * must not be tied to an unrelated constant that merely happens to be larger.
+	 */
+	it('refuses a collateral input worth exactly the declared total', async () => {
+		await expect(buildUpdate(utxo('cccc', 0, '3000000'))).rejects.toThrow(/holds 3000000 lovelace/);
+	});
 });

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -37,22 +37,40 @@ const minimumRegistryFundingLovelace = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.c
 const REGISTRY_TOTAL_COLLATERAL_LOVELACE = '3000000';
 
 /**
+ * Headroom the collateral input must keep above the declared total.
+ *
+ * The remainder becomes a `collateral_return` output, so it has to clear the
+ * ledger min-UTxO floor. 1 ADA is the same round figure the rest of this tree
+ * treats as a safe plain-output minimum (see `calculateMinUtxo` in
+ * `src/utils/min-utxo`), and it avoids threading protocol parameters into a
+ * guard that only needs a floor.
+ */
+const REGISTRY_COLLATERAL_RETURN_MARGIN_LOVELACE = 1_000_000n;
+
+/**
  * Smallest collateral input these builders accept.
  *
- * `assertCollateralCoversDeclaredTotal` enforces it. The floor is the same
- * 5 ADA `pickCollateralUtxo` already requires, which leaves 2 ADA of
- * `collateral_return`: clear of the min-UTxO floor with room to spare.
+ * Derived from the declared total, deliberately NOT from
+ * `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount`. The two are close today,
+ * but tying the floor to that constant means lowering it to the declared total
+ * would silently re-admit the zero-remainder transaction this guard exists to
+ * stop.
  *
- * The guard is not redundant. Only some callers route their collateral through
- * `pickCollateralUtxo`. The single-item register paths take
+ * The guard is not redundant with `pickCollateralUtxo`. Only some callers route
+ * their collateral through it. The single-item register paths take
  * `sortAndLimitUtxos(...)[0]`, which orders by asset count and not by value, and
  * the single-item update and deregister paths fall back to that same element
  * when nothing clears the floor. Any of those can hand over an input smaller
  * than the declared total. Without this guard such a build dies at submit with a
  * phase-1 rejection that names no cause, because phase-1 failures never reach
  * `evaluateTx`.
+ *
+ * It never rejects an input that used to build: these builders previously
+ * declared the full 5 ADA, which needed more than 5 ADA of input to leave a
+ * returnable remainder, and this floor is 4 ADA.
  */
-const REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount);
+const REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE =
+	BigInt(REGISTRY_TOTAL_COLLATERAL_LOVELACE) + REGISTRY_COLLATERAL_RETURN_MARGIN_LOVELACE;
 
 function assertCollateralCoversDeclaredTotal(collateralUtxo: UTxO): void {
 	const heldLovelace = getLovelaceFromUtxo(collateralUtxo);
@@ -191,10 +209,10 @@ export async function generateRegistryMintTransaction(
 	// caches the mesh-format Protocol object so we don't repeat
 	// `/epochs/latest/parameters` here. Fall back to a live fetch if the cache
 	// is cold (first tx of the process lifetime).
-	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
-	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	assertCollateralCoversDeclaredTotal(collateralUtxo);
 
+	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
+	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});
@@ -435,10 +453,10 @@ async function generateRegistryUpdateTransaction(
 	if (rpcApiKey) {
 		await syncMeshCostModelsFromChain(rpcApiKey);
 	}
-	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
-	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	assertCollateralCoversDeclaredTotal(collateralUtxo);
 
+	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
+	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});
@@ -532,10 +550,10 @@ async function generateRegistryDeregisterTransaction(
 	// Reuse the cached mesh-format chain params populated by the cost-model
 	// sync (see generateRegistryMintTransaction). Fall back to a live fetch on
 	// cache miss.
-	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
-	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	assertCollateralCoversDeclaredTotal(collateralUtxo);
 
+	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
+	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -10,6 +10,7 @@ import { BlockfrostProvider, IFetcher, LanguageVersion, MeshTxBuilder, Network, 
 import { PaymentSourceType } from '@/generated/prisma/client';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
 import { assertNever } from '@/utils/assert-never';
+import { getLovelaceFromUtxo } from '@/utils/utxo';
 
 export type RegistryMetadata = {
 	[key: string]: string | string[] | RegistryMetadata | RegistryMetadata[] | undefined;
@@ -20,21 +21,51 @@ const minimumRegistryFundingLovelace = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.c
 /**
  * Total collateral these registry transactions declare.
  *
- * Must stay BELOW what the collateral input holds. `pickCollateralUtxo` only
- * accepts a UTxO of at least `DEFAULT_MIN_COLLATERAL_LOVELACE` (5 ADA) and
- * prefers the smallest qualifying one, so it reliably picks the 5 ADA UTxO
- * that `ensureCollateralReady` mints. Declaring the same 5 ADA collapses
- * mesh's `collateral_return` to `Coin 0`, which mesh still emits and the
- * ledger rejects with `BabbageOutputTooSmallUTxO` — a phase-1 failure, so
- * `evaluateTx` never sees it and the tx only dies at submit.
+ * Must stay below what the collateral input holds. The ledger returns the
+ * difference as a `collateral_return` output, and rejects the transaction when
+ * that output falls under the min-UTxO floor. Declaring the full
+ * `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount` (5 ADA) against the 5 ADA
+ * UTxO the funding path mints leaves nothing to return, which is what these
+ * builders used to do.
  *
- * 3 ADA covers the requirement with room to spare: at preprod prices the
- * inflated default budgets (mem 7e6, steps 3e9) come to ~620k lovelace of
- * script fee, and Conway asks for `collateralPercentage` (150%) of that, so
- * ~930k. It also matches every sibling call site in this V1 tree and the
- * `MIN_TOTAL_COLLATERAL_LOVELACE` floor the V2 builders derive from.
+ * 3 ADA still covers the requirement: at preprod prices the inflated default
+ * budgets (mem 7e6, steps 3e9) come to roughly 620k lovelace of script fee, and
+ * Conway asks for `collateralPercentage` (150%) of that, so roughly 930k. It
+ * matches the sibling deregister call site and the `MIN_TOTAL_COLLATERAL_LOVELACE`
+ * floor the V2 builders derive from.
  */
 const REGISTRY_TOTAL_COLLATERAL_LOVELACE = '3000000';
+
+/**
+ * Smallest collateral input these builders accept.
+ *
+ * `assertCollateralCoversDeclaredTotal` enforces it. The floor is the same
+ * 5 ADA `pickCollateralUtxo` already requires, which leaves 2 ADA of
+ * `collateral_return`: clear of the min-UTxO floor with room to spare.
+ *
+ * The guard is not redundant. Only some callers route their collateral through
+ * `pickCollateralUtxo`. The single-item register paths take
+ * `sortAndLimitUtxos(...)[0]`, which orders by asset count and not by value, and
+ * the single-item update and deregister paths fall back to that same element
+ * when nothing clears the floor. Any of those can hand over an input smaller
+ * than the declared total. Without this guard such a build dies at submit with a
+ * phase-1 rejection that names no cause, because phase-1 failures never reach
+ * `evaluateTx`.
+ */
+const REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount);
+
+function assertCollateralCoversDeclaredTotal(collateralUtxo: UTxO): void {
+	const heldLovelace = getLovelaceFromUtxo(collateralUtxo);
+	if (heldLovelace >= REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE) {
+		return;
+	}
+	throw new Error(
+		`Collateral UTxO ${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex} holds ` +
+			`${heldLovelace.toString()} lovelace. Registry transactions declare ` +
+			`${REGISTRY_TOTAL_COLLATERAL_LOVELACE} as total collateral and need an input of at least ` +
+			`${REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE.toString()} lovelace to leave a returnable remainder.`,
+	);
+}
 
 // V2 mint contract Action enum: MintAction=0, UpdateAction=1, BurnAction=2.
 // V1 mint contract Action enum: MintAction=0, BurnAction=1.
@@ -162,6 +193,8 @@ export async function generateRegistryMintTransaction(
 	// is cold (first tx of the process lifetime).
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});
@@ -404,6 +437,8 @@ async function generateRegistryUpdateTransaction(
 	}
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});
@@ -499,6 +534,8 @@ async function generateRegistryDeregisterTransaction(
 	// cache miss.
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	const txBuilder = new MeshTxBuilder({
 		fetcher: blockchainProvider,
 	});

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -17,6 +17,25 @@ export type RegistryMetadata = {
 
 const minimumRegistryFundingLovelace = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount);
 
+/**
+ * Total collateral these registry transactions declare.
+ *
+ * Must stay BELOW what the collateral input holds. `pickCollateralUtxo` only
+ * accepts a UTxO of at least `DEFAULT_MIN_COLLATERAL_LOVELACE` (5 ADA) and
+ * prefers the smallest qualifying one, so it reliably picks the 5 ADA UTxO
+ * that `ensureCollateralReady` mints. Declaring the same 5 ADA collapses
+ * mesh's `collateral_return` to `Coin 0`, which mesh still emits and the
+ * ledger rejects with `BabbageOutputTooSmallUTxO` — a phase-1 failure, so
+ * `evaluateTx` never sees it and the tx only dies at submit.
+ *
+ * 3 ADA covers the requirement with room to spare: at preprod prices the
+ * inflated default budgets (mem 7e6, steps 3e9) come to ~620k lovelace of
+ * script fee, and Conway asks for `collateralPercentage` (150%) of that, so
+ * ~930k. It also matches every sibling call site in this V1 tree and the
+ * `MIN_TOTAL_COLLATERAL_LOVELACE` floor the V2 builders derive from.
+ */
+const REGISTRY_TOTAL_COLLATERAL_LOVELACE = '3000000';
+
 // V2 mint contract Action enum: MintAction=0, UpdateAction=1, BurnAction=2.
 // V1 mint contract Action enum: MintAction=0, BurnAction=1.
 // Map by PaymentSourceType so the same shared helper drives both.
@@ -163,7 +182,7 @@ export async function generateRegistryMintTransaction(
 		})
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount)
+		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE)
 		.txOut(recipientWalletAddress, [
 			{
 				unit: policyId + assetName,
@@ -418,7 +437,7 @@ async function generateRegistryUpdateTransaction(
 		})
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount)
+		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE)
 		.txOut(recipientWalletAddress, [
 			{
 				unit: policyId + newAssetName,
@@ -494,7 +513,7 @@ async function generateRegistryDeregisterTransaction(
 		.mintRedeemerValue({ alternative: burnRedeemerAlternative, fields: [] }, 'Mesh', exUnits)
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral('3000000');
+		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE);
 	for (const utxo of utxos) {
 		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
 	}

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -187,6 +187,8 @@ export async function generateRegistryMintTransaction(
 	// V1 callers MUST NOT pass this (no V1 splitter convention).
 	walletSplitterLovelace?: bigint,
 ) {
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	if (rpcApiKey) {
 		// `protocolParams(...)` below does NOT carry cost models; mesh-sdk
 		// hashes script_data against its BUNDLED cost-model arrays. Patch them
@@ -209,8 +211,6 @@ export async function generateRegistryMintTransaction(
 	// caches the mesh-format Protocol object so we don't repeat
 	// `/epochs/latest/parameters` here. Fall back to a live fetch if the cache
 	// is cold (first tx of the process lifetime).
-	assertCollateralCoversDeclaredTotal(collateralUtxo);
-
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({
@@ -450,11 +450,11 @@ async function generateRegistryUpdateTransaction(
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
 ) {
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	if (rpcApiKey) {
 		await syncMeshCostModelsFromChain(rpcApiKey);
 	}
-	assertCollateralCoversDeclaredTotal(collateralUtxo);
-
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({
@@ -543,6 +543,8 @@ async function generateRegistryDeregisterTransaction(
 	rpcApiKey?: string,
 	walletSplitterLovelace?: bigint,
 ) {
+	assertCollateralCoversDeclaredTotal(collateralUtxo);
+
 	if (rpcApiKey) {
 		// See cost-model sync comment in generateRegistryMintTransaction above.
 		await syncMeshCostModelsFromChain(rpcApiKey);
@@ -550,8 +552,6 @@ async function generateRegistryDeregisterTransaction(
 	// Reuse the cached mesh-format chain params populated by the cost-model
 	// sync (see generateRegistryMintTransaction). Fall back to a live fetch on
 	// cache miss.
-	assertCollateralCoversDeclaredTotal(collateralUtxo);
-
 	const cachedParams = rpcApiKey == null ? null : getCachedChainProtocolParameters(rpcApiKey);
 	const protocolParameters = cachedParams ?? (await blockchainProvider.fetchProtocolParameters(Number.NaN));
 	const txBuilder = new MeshTxBuilder({

--- a/src/services/registry/shared.ts
+++ b/src/services/registry/shared.ts
@@ -11,6 +11,12 @@ import { PaymentSourceType } from '@/generated/prisma/client';
 import { getCachedChainProtocolParameters, syncMeshCostModelsFromChain } from '@/utils/mesh-cost-model-sync';
 import { assertNever } from '@/utils/assert-never';
 import { getLovelaceFromUtxo } from '@/utils/utxo';
+import {
+	MIN_TOTAL_COLLATERAL_LOVELACE,
+	collateralReturnMinLovelace,
+	deriveTotalCollateral,
+	nativeAssetCount,
+} from '@masumi/payment-core/collateral';
 
 export type RegistryMetadata = {
 	[key: string]: string | string[] | RegistryMetadata | RegistryMetadata[] | undefined;
@@ -19,69 +25,72 @@ export type RegistryMetadata = {
 const minimumRegistryFundingLovelace = BigInt(SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount);
 
 /**
- * Total collateral these registry transactions declare.
+ * Total collateral these registry transactions declare, derived per build.
  *
- * Must stay below what the collateral input holds. The ledger returns the
- * difference as a `collateral_return` output, and rejects the transaction when
- * that output falls under the min-UTxO floor. Declaring the full
- * `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount` (5 ADA) against the 5 ADA
- * UTxO the funding path mints leaves nothing to return, which is what these
- * builders used to do.
+ * The declared total is pinned between two moving bounds and a constant cannot
+ * track either one. It must sit ABOVE the ledger's requirement
+ * (`collateralPercentage` of the fee, else the node answers
+ * `InsufficientCollateral`) and strictly BELOW what the collateral input holds,
+ * because mesh ALWAYS emits a `collateral_return` of `input - declared` and
+ * never min-UTxO-checks it (`addCollateralReturn` in both pinned core-cst
+ * lines). Declaring the full `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount`
+ * (5 ADA) against the 5 ADA UTxO the funding path mints produced a zero-lovelace
+ * return, which the ledger rejects in phase 1, before `evaluateTx` ever runs.
  *
- * 3 ADA still covers the requirement: at preprod prices the inflated default
- * budgets (mem 7e6, steps 3e9) come to roughly 620k lovelace of script fee, and
- * Conway asks for `collateralPercentage` (150%) of that, so roughly 930k. It
- * matches the sibling deregister call site and the `MIN_TOTAL_COLLATERAL_LOVELACE`
- * floor the V2 builders derive from.
+ * `deriveTotalCollateral` is the same helper the V2 batch builders use. It scales
+ * with the redeemer budget, floors at `MIN_TOTAL_COLLATERAL_LOVELACE`, and caps
+ * at what this input can cover while still leaving a returnable remainder. On the
+ * first pass `exUnits` is the inflated default and on the second it is the
+ * chain-evaluated budget, so the declared total tracks the real cost either way.
  */
-const REGISTRY_TOTAL_COLLATERAL_LOVELACE = '3000000';
-
-/**
- * Headroom the collateral input must keep above the declared total.
- *
- * The remainder becomes a `collateral_return` output, so it has to clear the
- * ledger min-UTxO floor. 1 ADA is the same round figure the rest of this tree
- * treats as a safe plain-output minimum (see `calculateMinUtxo` in
- * `src/utils/min-utxo`), and it avoids threading protocol parameters into a
- * guard that only needs a floor.
- */
-const REGISTRY_COLLATERAL_RETURN_MARGIN_LOVELACE = 1_000_000n;
+function registryTotalCollateral(
+	exUnits: { mem: number; steps: number },
+	protocolParameters: unknown,
+	collateralUtxo: UTxO,
+): string {
+	return deriveTotalCollateral(
+		[exUnits],
+		protocolParameters,
+		getLovelaceFromUtxo(collateralUtxo),
+		nativeAssetCount(collateralUtxo),
+	);
+}
 
 /**
  * Smallest collateral input these builders accept.
  *
- * Derived from the declared total, deliberately NOT from
- * `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount`. The two are close today,
- * but tying the floor to that constant means lowering it to the declared total
- * would silently re-admit the zero-remainder transaction this guard exists to
- * stop.
+ * `deriveTotalCollateral` caps the declared total to what the input covers, but
+ * it never declares below `MIN_TOTAL_COLLATERAL_LOVELACE`. An input under that
+ * floor plus a returnable remainder therefore still yields a zero or negative
+ * `collateral_return`. This guard turns that into a readable build-time error
+ * instead of a phase-1 rejection at submit that names no cause.
+ *
+ * The floor tracks the collateral's native assets, because mesh copies the full
+ * input value into the return and the ledger's min-UTxO grows with it.
  *
  * The guard is not redundant with `pickCollateralUtxo`. Only some callers route
  * their collateral through it. The single-item register paths take
  * `sortAndLimitUtxos(...)[0]`, which orders by asset count and not by value, and
  * the single-item update and deregister paths fall back to that same element
- * when nothing clears the floor. Any of those can hand over an input smaller
- * than the declared total. Without this guard such a build dies at submit with a
- * phase-1 rejection that names no cause, because phase-1 failures never reach
- * `evaluateTx`.
+ * when nothing clears the floor. Any of those can hand over an input too small
+ * to declare against.
  *
  * It never rejects an input that used to build: these builders previously
  * declared the full 5 ADA, which needed more than 5 ADA of input to leave a
- * returnable remainder, and this floor is 4 ADA.
+ * returnable remainder, and this floor is 4 ADA for pure-ADA collateral.
  */
-const REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE =
-	BigInt(REGISTRY_TOTAL_COLLATERAL_LOVELACE) + REGISTRY_COLLATERAL_RETURN_MARGIN_LOVELACE;
-
 function assertCollateralCoversDeclaredTotal(collateralUtxo: UTxO): void {
 	const heldLovelace = getLovelaceFromUtxo(collateralUtxo);
-	if (heldLovelace >= REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE) {
+	const requiredLovelace =
+		MIN_TOTAL_COLLATERAL_LOVELACE + collateralReturnMinLovelace(nativeAssetCount(collateralUtxo));
+	if (heldLovelace >= requiredLovelace) {
 		return;
 	}
 	throw new Error(
 		`Collateral UTxO ${collateralUtxo.input.txHash}#${collateralUtxo.input.outputIndex} holds ` +
-			`${heldLovelace.toString()} lovelace. Registry transactions declare ` +
-			`${REGISTRY_TOTAL_COLLATERAL_LOVELACE} as total collateral and need an input of at least ` +
-			`${REGISTRY_MIN_COLLATERAL_INPUT_LOVELACE.toString()} lovelace to leave a returnable remainder.`,
+			`${heldLovelace.toString()} lovelace. Registry transactions declare at least ` +
+			`${MIN_TOTAL_COLLATERAL_LOVELACE.toString()} as total collateral and need an input of at least ` +
+			`${requiredLovelace.toString()} lovelace to leave a returnable remainder.`,
 	);
 }
 
@@ -233,7 +242,7 @@ export async function generateRegistryMintTransaction(
 		})
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE)
+		.setTotalCollateral(registryTotalCollateral(exUnits, protocolParameters, collateralUtxo))
 		.txOut(recipientWalletAddress, [
 			{
 				unit: policyId + assetName,
@@ -490,7 +499,7 @@ async function generateRegistryUpdateTransaction(
 		})
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE)
+		.setTotalCollateral(registryTotalCollateral(exUnits, protocolParameters, collateralUtxo))
 		.txOut(recipientWalletAddress, [
 			{
 				unit: policyId + newAssetName,
@@ -568,7 +577,7 @@ async function generateRegistryDeregisterTransaction(
 		.mintRedeemerValue({ alternative: burnRedeemerAlternative, fields: [] }, 'Mesh', exUnits)
 		.txIn(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
 		.txInCollateral(collateralUtxo.input.txHash, collateralUtxo.input.outputIndex)
-		.setTotalCollateral(REGISTRY_TOTAL_COLLATERAL_LOVELACE);
+		.setTotalCollateral(registryTotalCollateral(exUnits, protocolParameters, collateralUtxo));
 	for (const utxo of utxos) {
 		txBuilder.txIn(utxo.input.txHash, utxo.input.outputIndex);
 	}


### PR DESCRIPTION
Rescued from #738, which is superseded by the reporting stack.

## What

Four registry fixes, plus the refactor one of them needed.

### 1. Collateral declaration

The declared total sits between two moving bounds and no constant tracks both.

It must stay ABOVE the ledger's requirement, which is `collateralPercentage` of
the fee, or the node answers `InsufficientCollateral`. It must stay strictly
BELOW what the collateral input holds, because mesh always emits a
`collateral_return` of `input - declared` and never min-UTxO-checks it. That is
`addCollateralReturn`, identical in both pinned core-cst lines:

```js
if (totalCollateral) {
  this.txBody.setTotalCollateral(BigInt(totalCollateral));
  this.addCollateralReturn(totalCollateral, collaterals, collateralReturnAddress ?? changeAddress);
}
```

The builders declared the full 5 ADA `SERVICE_CONSTANTS.SMART_CONTRACT.collateralAmount`
against the 5 ADA UTxO the funding path mints. The return output came out at zero
lovelace, which the ledger rejects in phase 1, so `evaluateTx` never saw it and
the transaction only died at submit. It built at all only when the picked
collateral UTxO happened to exceed roughly 5.9 ADA, and `sortAndLimitUtxos` ranks
by asset-count bloat rather than by value, so which case you got depended on the
wallet's UTxO set that tick.

All three builders now call `deriveTotalCollateral`, the helper the V2 batch
builders already use. It scales with the redeemer budget, floors at
`MIN_TOTAL_COLLATERAL_LOVELACE`, and caps at what the input can cover while still
leaving a returnable remainder. A fixed 3 ADA would have fixed the zero-return
case while lowering the ceiling, because the declaration would no longer grow with
the budget. At the default budget the derived value is the same 3 ADA, so the
evaluation pass is unchanged.

`assertCollateralCoversDeclaredTotal` enforces the one bound the cap cannot reach.
An input below `MIN_TOTAL_COLLATERAL_LOVELACE` plus a returnable remainder still
yields a zero or negative return, and the cap never declares below that floor. The
guard is not redundant with `pickCollateralUtxo`, because not every caller routes
its collateral through it: the V1 single-item register path takes
`limitedFilteredUtxos[0]` directly (`packages/payment-source-v1/src/services/registry/register/service.ts:220`),
and the single-item update and deregister paths fall back to that same element.
The floor is asset-aware, since mesh copies the full input value into the return
and min-UTxO grows with the tokens carried. For pure-ADA collateral it is 4 ADA,
and the old code needed more than 5 ADA of input to build, so the guard rejects
nothing that used to work.

### 2. Collateral math moved to payment-core

The registry builders live in the V1-pinned `src/` tree and cannot import from
`packages/payment-source-v2`, so the shared math moved to
`@masumi/payment-core/collateral`. `batch-helpers` re-exports it and every batch
call site is untouched.

The new module imports no mesh symbol, not even a type. `UTxO` is replaced by a
structural `CollateralUtxoLike` that both pinned mesh lines satisfy, so under
ADR 0005 neither line can be pulled in through it.

The move is behaviour-preserving. Every moved function and constant is identical
to its original once comments and whitespace are stripped. The only signature
change is `nativeAssetCount(utxo: UTxO)` becoming `CollateralUtxoLike`.

### 3. Guarding the fallback that would undo all of this

`deriveTotalCollateral` degrades to `MIN_TOTAL_COLLATERAL_LOVELACE` when it cannot
read the protocol parameters. That is safe, but it discards the scaling the helper
exists to provide, and it did so with no log and no test at the shape production
passes.

Production hands it mesh's `Protocol`, whose field is `collateralPercent`
(`@meshsdk/common` `index.d.ts:214`) with numeric prices. Every existing test used
the `collateralPercentage` alias with string prices. A mesh rename would therefore
have pinned every registry and batch build back to a flat 3 ADA with the whole
suite still green, and the first symptom would have been an
`InsufficientCollateral` rejection at submit. That is the defect this PR exists to
fix, re-entering unnoticed.

`packages/payment-core/src/collateral.spec.ts` now asserts the mesh and raw
blockfrost key shapes directly and asserts that the derivation scales above the
floor on the mesh shape. `deriveTotalCollateral` logs a warning when it takes the
fallback, so the degradation is visible to an operator instead of silent.

### 4. Terminal submit failure

The V2 single-item update and deregister paths reverted to `*Requested` on a
submit rejection with `error` left NULL. A deterministic rejection then retried
every tick forever and an operator saw a queued row with nothing to read. They now
call `markRequestFailed`, matching both batch paths. `UpdateFailed` and
`DeregistrationFailed` record the reason, free the wallet, and stay re-queueable:
the update route accepts `UpdateFailed` (`src/routes/api/registry/update/index.ts:180`)
and the deregister route accepts both (`src/routes/api/registry/deregister/index.ts:138-139`).

### 5. Ambiguous submit failures

`describeAmbiguousRegistrySubmit` splits a definitive node rejection from a failure
that proves nothing. A ledger rejection returns null and the caller stamps the raw
error. A transport failure, a 5xx or a timeout returns an operator-facing message
naming the resolved intended tx hash, because the transaction may already be on
chain. The payment paths hand that case to funding-reconciliation, but the
single-item registry paths submit before they write, so there is no pending
`Transaction` row to reconcile.

### 6. Stale error on re-queue

The deregister route left the previous attempt's `error` on the row it re-queued,
so a fresh request read as failing. The update route already cleared it on the same
transition.

## Known limitation

`computeCollateralFromExUnits` reads the script half of the fee only. The ledger
takes `collateralPercentage` of the whole fee, size fee included. The size half is
bounded by `maxTxSize` and the safety multiplier plus the floor absorb it at every
budget these builders produce, but it is an undercount. It is pre-existing V2 batch
behaviour and fixing it would raise every declared total across the batch builders,
so it is recorded in the module docstring rather than changed here.

## Note on the original commit

The commit in #738 added `error: null` to the deregister payload but never updated
`src/routes/api/registry/deregister/index.spec.ts`, so #738's suite fails today.
Fixed here.

## Verification

Run on this branch:

- `npx tsc --noEmit --pretty false` and `npx eslint src packages` both exit 0.
- `pnpm test` gives `Test Suites: 1 skipped, 268 passed, 268 of 269 total` and
  `Tests: 2 skipped, 3076 passed, 3078 total`.
- The moved code was compared function by function against the originals with
  comments and whitespace stripped. All 12 symbols identical, apart from the
  intended `nativeAssetCount` signature change.
- Every new test was confirmed to bite by reverting only the source and keeping the
  tests. The two collateral-derivation tests fail with `Expected: 3439800n,
  Received: 3000000n` and `Expected: 3200000n, Received: 3000000n`; the earlier
  guard and boundary tests fail the same way. Dropping the `collateralPercent`
  alias from the extractor fails 4 of the new payment-core tests, including the
  derivation reverting to `3_000_000`.

Not verified: on-chain behaviour. The ledger reasoning above is read from the mesh
source and the protocol rules, and no transaction was submitted.
