### PR TITLE
fix(x402): repair registered usdc sources and harden the payload hash

### DIFF
--- a/frontend/src/lib/x402-registration.ts
+++ b/frontend/src/lib/x402-registration.ts
@@ -29,9 +29,12 @@ export type EvmAssetPreset = {
 
 export type X402RegistrationNetwork = X402AvailableNetwork;
 
-// Known USDC deployments per chain. These addresses are also seeded as network
-// defaults by prisma/migrations/20260720010000_x402_network_default_asset_decimals;
-// keep the two lists in sync when adding a chain. A network's configured
+// Known USDC deployments per chain. Migration 20260720010000 backfills
+// defaultAssetDecimals for these (chain, address) pairs; it seeds no defaultAsset.
+// Its Base Sepolia row still carries the typo'd address on purpose, because an
+// applied migration cannot be rewritten without breaking its checksum. Migration
+// 20260729100000 corrects the stored rows instead. When adding a chain, add it here
+// and in a new decimals backfill, not in the historical one. A network's configured
 // defaultAsset/defaultAssetDecimals always takes precedence (see
 // assetPresetsForNetwork below), so drift here only affects the preset labels.
 export const EVM_ASSET_PRESETS: EvmAssetPreset[] = [

--- a/packages/payment-source-x402/src/payload.spec.ts
+++ b/packages/payment-source-x402/src/payload.spec.ts
@@ -29,6 +29,38 @@ function basePayload(extensions: unknown) {
 	};
 }
 
+// Frozen on purpose. paymentPayloadHash is the replay key: it is unique on X402Settlement and
+// it is the advisory claim key the settle guard takes. If the canonical form ever changes, rows
+// written by earlier releases stop matching, the replay fast-path misses, and the service
+// re-settles an authorization that is single-use on chain. The digest below was also produced by
+// the pre-sanitize implementation, so this vector doubles as proof that adding toJsonValue left
+// every already-stored hash intact. Do not regenerate it to make a failing test pass.
+const GOLDEN_PAYLOAD = {
+	x402Version: 2,
+	resource: { url: 'https://agent.example/run' },
+	accepted: {
+		scheme: 'exact',
+		network: 'eip155:84532',
+		asset: '0x036cbd53842c5426634e7929541ec2318f3dcf7e',
+		amount: '10000',
+		payTo: '0x6597342b1dd68216df749a3ccde47be1bf2a98a3',
+		maxTimeoutSeconds: 300,
+		extra: { assetTransferMethod: 'permit2', decimals: 6 },
+	},
+	payload: {
+		signature: '0xdeadbeef',
+		permit2Authorization: {
+			from: '0x57abdb59e14b8edebbfd3567b807274763abb4a2',
+			permitted: { token: '0x036cbd53842c5426634e7929541ec2318f3dcf7e', amount: '10000' },
+			spender: '0x0000000000000000000000000000000000000001',
+			nonce: '42',
+			deadline: '1800000300',
+			witness: { to: '0x6597342b1dd68216df749a3ccde47be1bf2a98a3', validAfter: '1799999700' },
+		},
+	},
+};
+const GOLDEN_DIGEST = '94d6ad0f86720d84ec50f1a6bf50500196bffaa5cd698dd2152fc5383829d5f8';
+
 describe('hashX402PaymentPayload', () => {
 	it('does not throw when extensions is undefined (the default, no-extensions case)', () => {
 		expect(() => hashX402PaymentPayload(basePayload(undefined))).not.toThrow();
@@ -51,10 +83,35 @@ describe('hashX402PaymentPayload', () => {
 		const b = hashX402PaymentPayload(basePayload({ foo: 'baz' }));
 		expect(a).not.toBe(b);
 	});
+
+	it('matches the frozen digest for the golden payload', () => {
+		expect(hashX402PaymentPayload(GOLDEN_PAYLOAD)).toBe(GOLDEN_DIGEST);
+	});
+
+	it('keeps the frozen digest when the SDK sets extensions and resource as undefined keys', () => {
+		// @x402/core assembles the payload as an object literal, so both keys are present and
+		// undefined when the forwarded 402 declared neither. Neither may shift the replay key.
+		const { resource: _resource, ...withoutResource } = GOLDEN_PAYLOAD;
+		expect(hashX402PaymentPayload({ ...GOLDEN_PAYLOAD, extensions: undefined })).toBe(GOLDEN_DIGEST);
+		expect(hashX402PaymentPayload({ ...withoutResource, resource: undefined })).toBe(
+			hashX402PaymentPayload(withoutResource),
+		);
+	});
+
+	it('rejects a non-object payload with a payload-specific error', () => {
+		// toJsonValue would otherwise surface `SyntaxError: "undefined" is not valid JSON`.
+		expect(() => hashX402PaymentPayload(undefined)).toThrow(TypeError);
+		expect(() => hashX402PaymentPayload(undefined)).toThrow(/payment payload must be a non-null object/);
+		expect(() => hashX402PaymentPayload(null)).toThrow(TypeError);
+	});
 });
 
 describe('encryptPaymentPayloadForStorage', () => {
 	it('does not throw when extensions is undefined', () => {
 		expect(() => encryptPaymentPayloadForStorage(basePayload(undefined))).not.toThrow();
+	});
+
+	it('does not throw when resource is undefined', () => {
+		expect(() => encryptPaymentPayloadForStorage({ ...GOLDEN_PAYLOAD, resource: undefined })).not.toThrow();
 	});
 });

--- a/packages/payment-source-x402/src/payload.ts
+++ b/packages/payment-source-x402/src/payload.ts
@@ -30,10 +30,29 @@ export function toJsonValue(value: unknown): Prisma.InputJsonValue {
 	return parsed as Prisma.InputJsonValue;
 }
 
+// Canonical serialization shared by the payload hash and the encrypted audit copy.
+//
+// canonical-json routes a value of `undefined` into its object branch and calls Object.keys on
+// it, so any own key valued undefined throws `TypeError: Cannot convert undefined or null to
+// object`. @x402/core assembles a signed payload as an object literal and sets `extensions` and
+// `resource` as own keys even when the forwarded 402 declared neither, so a payload straight
+// from the SDK crashes an unguarded canonicalStringify. toJsonValue drops those keys first.
+//
+// Both callers must work over identical bytes. paymentPayloadHash is the replay key (unique on
+// X402Settlement, and the advisory claim key around settle), so a hashed form that drifts from
+// the stored form would be invisible. Deriving the string in one place makes that drift
+// impossible.
+function canonicalPayloadString(paymentPayload: unknown): string {
+	// Without this guard a non-object reaches JSON.parse(undefined) inside toJsonValue and reports
+	// `SyntaxError: "undefined" is not valid JSON`, which points at JSON rather than at the payload.
+	if (typeof paymentPayload !== 'object' || paymentPayload === null) {
+		throw new TypeError('x402 payment payload must be a non-null object');
+	}
+	return canonicalStringify(toJsonValue(paymentPayload));
+}
+
 export function hashX402PaymentPayload(paymentPayload: unknown): string {
-	return createHash('sha256')
-		.update(canonicalStringify(toJsonValue(paymentPayload)))
-		.digest('hex');
+	return createHash('sha256').update(canonicalPayloadString(paymentPayload)).digest('hex');
 }
 
 // The signed x402 payload embeds a reusable payment authorization (EIP-3009 / Permit2
@@ -41,7 +60,7 @@ export function hashX402PaymentPayload(paymentPayload: unknown): string {
 // is a write-only audit record (never selected back by the service); decrypt with the
 // configured key only for manual forensics. Stored as a JSON string in the Json column.
 export function encryptPaymentPayloadForStorage(paymentPayload: unknown): Prisma.InputJsonValue {
-	return encrypt(canonicalStringify(toJsonValue(paymentPayload)));
+	return encrypt(canonicalPayloadString(paymentPayload));
 }
 
 export function getPaymentIdentifier(paymentPayload: PaymentPayload): { id: string | null; errors: string[] } {

--- a/packages/payment-source-x402/src/service.spec.ts
+++ b/packages/payment-source-x402/src/service.spec.ts
@@ -332,6 +332,14 @@ const paymentPayload = {
 };
 const typedPaymentPayload = paymentPayload as Parameters<typeof service.settleX402Payment>[0]['paymentPayload'];
 
+// What @x402/core actually hands back on the buy side, which is NOT what arrives over the wire on
+// the sell side. The client assembles the payload as an object literal and sets `extensions` and
+// `resource` as own keys even when the forwarded 402 declared neither, so both are present and
+// undefined in the common case. canonical-json throws on any own key valued undefined, so signing
+// every extension-free payment used to fail here. The sell-side fixture above stays wire-shaped:
+// its body is zod-parsed, and zod omits absent optional keys rather than setting them.
+const sdkPaymentPayload = { ...paymentPayload, extensions: undefined };
+
 // A raw 402 the buyer forwards to the service (buy side).
 const paymentRequired = {
 	x402Version: 2,
@@ -441,7 +449,7 @@ describe('x402 service helpers', () => {
 			validation: { valid: true },
 		});
 		mockEncodePaymentSignatureHeader.mockReturnValue('x-payment-header-base64');
-		mockCreatePaymentPayload.mockResolvedValue(paymentPayload);
+		mockCreatePaymentPayload.mockResolvedValue(sdkPaymentPayload);
 		mockBudgetFindFirst.mockResolvedValue({ id: 'budget-1', remainingAmount: 1_000_000n, generation: 0 });
 		// Default the on-chain balance well above any test amount so the pre-check passes; the
 		// insufficient-balance case overrides mockReadContract per test.
@@ -1448,6 +1456,30 @@ describe('x402 service helpers', () => {
 			);
 			// The service never fetches the resource.
 			expect(mockBudgetUpdate).not.toHaveBeenCalled();
+		});
+
+		it('signs a payload whose extensions and resource are undefined keys from the SDK', async () => {
+			// The default mock already covers `extensions`; drop `resource` too so both of the keys
+			// @x402/core leaves undefined are exercised on one payment.
+			const { resource: _resource, ...withoutResource } = sdkPaymentPayload;
+			const sdkPayloadWithoutResource = { ...withoutResource, resource: undefined };
+			mockCreatePaymentPayload.mockResolvedValue(sdkPayloadWithoutResource);
+
+			const result = await service.createX402Payment({
+				apiKeyId: 'api-key-1',
+				caip2NetworkLimit: [source.network],
+				evmWalletId: 'wallet-1',
+				paymentRequired,
+				usageLimited: false,
+			});
+
+			expect(result.paymentPayloadHash).toBe(service.hashX402PaymentPayload(sdkPayloadWithoutResource));
+			expect(mockX402PaymentAttemptUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: 'attempt-outbound-1' },
+					data: expect.objectContaining({ status: 'Verified', resource: undefined }),
+				}),
+			);
 		});
 
 		it('pins the client policy to the single budgeted requirement', async () => {

--- a/prisma/migrations/20260826170000_repair_base_sepolia_usdc_registered_sources/migration.sql
+++ b/prisma/migrations/20260826170000_repair_base_sepolia_usdc_registered_sources/migration.sql
@@ -1,0 +1,76 @@
+-- Companion to 20260729100000, which repaired only X402Network."defaultAsset".
+--
+-- The Base Sepolia USDC typo also reached REGISTERED sources: the registration UI
+-- offered ...dcf7c as its preset, and src/services/registry/source-pricing.ts writes
+-- that asset into three places per source. All three must move together, so a source
+-- that cannot have all three repaired is left entirely alone:
+--   1. "UnitValue"."unit"                      (Fixed pricing amounts)
+--   2. "SupportedPaymentSource"."dynamicAsset" (Dynamic pricing allowlist)
+--   3. "SupportedPaymentSource"."canonicalKey" (duplicate-detection key; embeds the
+--      lowercased asset verbatim, so a literal REPLACE reproduces exactly what
+--      getSupportedPaymentSourceCanonicalKey would emit for the corrected asset)
+--
+-- packages/payment-source-x402/src/requirements.ts builds PaymentRequirements.asset
+-- from 1 and 2, so until this runs those sources quote a contract that was never
+-- deployed on Base Sepolia and no payment against them can settle.
+--
+-- Scope: EVM sources on eip155:84532 only. Attempt and settlement history is left as
+-- written, because those rows record what actually happened. On-chain registry
+-- metadata is published FROM these rows, so an already-registered agent keeps
+-- advertising the old asset on chain until its operator updates the registration;
+-- the update path republishes from the corrected rows.
+
+-- Sources that are safe to repair. "SupportedPaymentSource" is unique on
+-- (registryRequestId, canonicalKey), so a source whose corrected key would collide
+-- with a sibling that already carries the real address is skipped rather than left
+-- with pricing and canonicalKey disagreeing. Those need an operator to merge the
+-- duplicate options by hand.
+CREATE TEMPORARY TABLE "_repair_base_sepolia_usdc" AS
+SELECT
+  src."id",
+  REPLACE(
+    src."canonicalKey",
+    '0x036cbd53842c5426634e7929541ec2318f3dcf7c',
+    '0x036cbd53842c5426634e7929541ec2318f3dcf7e'
+  ) AS "repairedKey"
+FROM "SupportedPaymentSource" src
+WHERE src."chain" = 'EVM'
+  AND src."network" = 'eip155:84532'
+  AND src."canonicalKey" LIKE '%0x036cbd53842c5426634e7929541ec2318f3dcf7c%'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "SupportedPaymentSource" sibling
+    WHERE sibling."registryRequestId" = src."registryRequestId"
+      AND sibling."id" <> src."id"
+      AND sibling."canonicalKey" = REPLACE(
+        src."canonicalKey",
+        '0x036cbd53842c5426634e7929541ec2318f3dcf7c',
+        '0x036cbd53842c5426634e7929541ec2318f3dcf7e'
+      )
+  );
+
+-- 1. Fixed pricing amounts. Reached only through this source's own pricing chain, so
+-- API-key usage credits and Cardano amounts in the shared "UnitValue" table are not
+-- candidates regardless of what they hold.
+UPDATE "UnitValue" amount
+SET "unit" = '0x036cbd53842c5426634e7929541ec2318f3dcf7e'
+FROM "AgentFixedPricing" fixed
+JOIN "AgentPricing" pricing ON pricing."id" = fixed."agentPricingId"
+JOIN "_repair_base_sepolia_usdc" repair ON repair."id" = pricing."supportedPaymentSourceId"
+WHERE amount."agentFixedPricingId" = fixed."id"
+  AND amount."unit" = '0x036cbd53842c5426634e7929541ec2318f3dcf7c';
+
+-- 2. Dynamic pricing allowlist.
+UPDATE "SupportedPaymentSource" src
+SET "dynamicAsset" = '0x036cbd53842c5426634e7929541ec2318f3dcf7e'
+FROM "_repair_base_sepolia_usdc" repair
+WHERE src."id" = repair."id"
+  AND src."dynamicAsset" = '0x036cbd53842c5426634e7929541ec2318f3dcf7c';
+
+-- 3. Duplicate-detection key, last so it stays consistent with 1 and 2.
+UPDATE "SupportedPaymentSource" src
+SET "canonicalKey" = repair."repairedKey"
+FROM "_repair_base_sepolia_usdc" repair
+WHERE src."id" = repair."id";
+
+DROP TABLE "_repair_base_sepolia_usdc";


### PR DESCRIPTION
## **Purpose of this Pull Request**

[x] Bug fix

## **Overview of Changes**

Review follow-ups to #722, which is already merged into `dev`. One data repair, plus hardening and the test gap that let the original bug ship.

### Data repair

**Registered sources still hold the dead USDC address.** Migration `20260729100000` repaired only `X402Network."defaultAsset"`. The registration UI offered the typo'd address as its preset, and `src/services/registry/source-pricing.ts` writes that asset into three places per source: `UnitValue."unit"` for Fixed pricing, `SupportedPaymentSource."dynamicAsset"` for Dynamic, and the `"canonicalKey"` that embeds it. `requirements.ts` builds `PaymentRequirements.asset` from the first two, so those sources quote a contract that was never deployed on Base Sepolia and no payment against them can settle.

The new migration moves all three together. `canonicalKey` embeds the lowercased asset verbatim, so a literal `REPLACE` reproduces byte for byte what `getSupportedPaymentSourceCanonicalKey` emits for the corrected asset. That is asserted against the real function, not assumed. The table is unique on `(registryRequestId, canonicalKey)`, so a source whose corrected key would collide with a sibling already carrying the real address is skipped **in full**, leaving its pricing and its key in agreement for an operator to merge by hand.

Attempt and settlement history is left as written, because those rows record what actually happened. On-chain metadata is published *from* these rows, so a registered agent keeps advertising the old asset on chain until its operator updates the registration; the update path then republishes from the corrected rows.

### Hardening

**One canonical form.** `hashX402PaymentPayload` and `encryptPaymentPayloadForStorage` each re-derived the canonical string. They must be taken over identical bytes, because `paymentPayloadHash` is the replay key: unique on `X402Settlement`, and the advisory claim key around settle. A drift between the hashed form and the stored form would be silent. Both now go through one `canonicalPayloadString()`, which also carries the reason the sanitize exists so a later cleanup pass cannot mistake it for dead JSON churn.

**Non-object guard.** Passing `undefined` reached `JSON.parse(undefined)` and reported `SyntaxError: "undefined" is not valid JSON`, which points at JSON rather than at a missing payload. It now throws `TypeError: x402 payment payload must be a non-null object`. That also closes a pre-existing hole: `canonicalStringify(null)` returned the string `'null'` and produced a real digest, so every null payload would have shared one settlement claim.

**The fixture that let the bug ship.** `service.spec.ts` stood in for `@x402/core`'s output but omitted `extensions` entirely, so the suite passed over a shape the client never produces. The client assembles the payload as an object literal and sets both `extensions` and `resource` as own keys even when the forwarded 402 declared neither, and `canonical-json` throws on any own key valued `undefined`. The buy-side fixture now carries that shape, and a new test drops `resource` as well. The sell-side fixture stays wire-shaped: its body is zod-parsed, and zod omits absent optional keys rather than setting them.

**Frozen golden digest.** `paymentPayloadHash` had no pinned vector, so a later change to `toJsonValue` would shift every hash and stop matching rows written by earlier releases. `94d6ad0f...29d5f8` is now pinned. The pre-sanitize implementation produces the same digest, so the vector doubles as proof that #722 left every already-stored hash intact.

**Stale comment.** The `EVM_ASSET_PRESETS` comment sent maintainers to migration `20260720010000` as the source of these addresses and told them to keep the two lists in sync. That migration backfills `defaultAssetDecimals` and seeds no `defaultAsset`, and its Base Sepolia entry still holds the typo'd address, so the two lists now disagree by design.

## **Issue Addressed**

Follow-up to #722.

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable)

## **Focus for Reviewers**

**The migration.** Verified against a throwaway Postgres seeded with seven cases: both repair paths, three controls that must not move (a Base **mainnet** source holding the same string, a Cardano amount, and an API-key usage credit in the shared `UnitValue` table), the collision case, and an already-correct source. 11/11 assertions pass, the repaired key matches the application-computed key exactly, a second run is a no-op, and a fresh install applies cleanly. There is no migration-test harness in the repo, so this verification is not automated.

**The fixture change.** Against the pre-#722 source (`5481d0db3`) the two specs report **19 failures**. Before this PR they reported none. That is the whole point of the change.

**Not verified.** The `eip155:1` and `eip155:11155111` preset addresses have no entry in `@x402/evm`'s `DEFAULT_STABLECOINS`, so I had no primary source to check them against in this repo. They are outside this repair, which is Base Sepolia only.
