### PR TITLE
feat(reports): group the report filters and explain a download

### DIFF
--- a/frontend/openapi-docs.json
+++ b/frontend/openapi-docs.json
@@ -39008,6 +39008,33 @@
                                                                     "items": {
                                                                         "type": "string"
                                                                     }
+                                                                },
+                                                                "rates": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rate": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "supplied",
+                                                                                    "coingecko"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rate",
+                                                                            "source"
+                                                                        ]
+                                                                    }
                                                                 }
                                                             },
                                                             "required": [
@@ -39018,7 +39045,8 @@
                                                                 "isDemoKey",
                                                                 "demoHistoryDays",
                                                                 "completeness",
-                                                                "unpricedUnits"
+                                                                "unpricedUnits",
+                                                                "rates"
                                                             ]
                                                         },
                                                         "warnings": {
@@ -41701,6 +41729,33 @@
                                                                     "items": {
                                                                         "type": "string"
                                                                     }
+                                                                },
+                                                                "rates": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rate": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "supplied",
+                                                                                    "coingecko"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rate",
+                                                                            "source"
+                                                                        ]
+                                                                    }
                                                                 }
                                                             },
                                                             "required": [
@@ -41711,7 +41766,8 @@
                                                                 "isDemoKey",
                                                                 "demoHistoryDays",
                                                                 "completeness",
-                                                                "unpricedUnits"
+                                                                "unpricedUnits",
+                                                                "rates"
                                                             ]
                                                         },
                                                         "warnings": {

--- a/frontend/src/components/dashboard/FinancialReportSection.tsx
+++ b/frontend/src/components/dashboard/FinancialReportSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Download, Loader2, RefreshCw, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { InfoHint } from '@/components/ui/info-hint';
 import { Skeleton } from '@/components/ui/skeleton';
 import { shortenAddress } from '@/lib/utils';
 import {
@@ -125,23 +126,27 @@ export function FinancialReportSection() {
       aria-labelledby="financial-reporting-title"
       aria-busy={isBusy}
     >
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-        <div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="flex items-center gap-1.5">
           <h2 id="financial-reporting-title" className="text-lg font-semibold">
             Money and fees
           </h2>
-          <p className="text-sm text-muted-foreground">
-            What this payment source earned, spent, and paid in fees.
-          </p>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-            <span>{periodLabel}</span>
-            {generatedAt && <span>· Updated {generatedAt}</span>}
-            {summary && (
-              <ReportCompletenessNote warnings={summary.metadata.warnings} className="ml-1" />
-            )}
-          </div>
+          <InfoHint label="money and fees">
+            <p>What this payment source earned, spent, and paid in fees.</p>
+            <p>
+              Every figure comes from one database snapshot, so the cards, the history, and the
+              export agree with each other.
+            </p>
+          </InfoHint>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          <span>{periodLabel}</span>
+          {generatedAt && <span>· Updated {generatedAt}</span>}
+          {summary && (
+            <ReportCompletenessNote warnings={summary.metadata.warnings} className="ml-1" />
+          )}
+        </div>
+        <div className="ml-auto flex flex-wrap gap-2">
           <Button type="button" variant="ghost" size="sm" onClick={resetReport}>
             <RotateCcw className="h-4 w-4" /> Reset
           </Button>
@@ -169,14 +174,11 @@ export function FinancialReportSection() {
 
       <ReportFilterBar
         form={model.form}
-        isLoading={model.isLoadingFacets}
         managedWallets={model.managedWallets}
-        paymentSources={model.paymentSources}
         assetUnits={assetUnits}
         selectedUnit={selectedUnit}
         assetLabel={assetLabel}
         onSelectUnit={setRequestedUnit}
-        onSetPaymentSource={model.setPaymentSource}
         onToggleRole={model.toggleRole}
         onToggleState={model.toggleState}
         onToggleWallet={model.toggleWallet}

--- a/frontend/src/components/dashboard/report/ReportFilterBar.tsx
+++ b/frontend/src/components/dashboard/report/ReportFilterBar.tsx
@@ -102,7 +102,7 @@ function FieldHeader({
   hint,
 }: Readonly<{ title: string; action: React.ReactNode; hint?: React.ReactNode }>) {
   return (
-    <div className="flex min-h-7 items-center justify-between gap-2">
+    <div className="flex min-h-8 items-center justify-between gap-2">
       <span className="flex items-center gap-1 text-sm font-medium">
         {title}
         {hint}

--- a/frontend/src/components/dashboard/report/ReportFilterBar.tsx
+++ b/frontend/src/components/dashboard/report/ReportFilterBar.tsx
@@ -120,6 +120,26 @@ function ResetFieldButton({ onClick }: Readonly<{ onClick: () => void }>) {
   );
 }
 
+/**
+ * A checked row that stands for "no filter at all".
+ *
+ * A list of empty checkboxes reads as "nothing is included", when an empty
+ * filter in fact includes everything. Showing the default as a ticked row says
+ * which of the two it is without the reader having to know the rule.
+ */
+function IncludeAllRow({
+  label,
+  isActive,
+  onSelect,
+}: Readonly<{ label: string; isActive: boolean; onSelect: () => void }>) {
+  return (
+    <label className="mb-0.5 flex cursor-pointer items-center gap-2 rounded border-b px-2 py-1.5 text-xs hover:bg-muted/50">
+      <Checkbox checked={isActive} onCheckedChange={onSelect} />
+      <span className="font-medium">{label}</span>
+    </label>
+  );
+}
+
 function GroupButton({
   label,
   count,
@@ -399,12 +419,15 @@ export function ReportFilterBar({
               action={
                 form.managedWalletIds.length > 0 ? (
                   <ResetFieldButton onClick={() => onUpdate({ managedWalletIds: [] })} />
-                ) : (
-                  <span className="text-[11px] text-muted-foreground">All wallets</span>
-                )
+                ) : null
               }
             />
             <div className="max-h-40 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
+              <IncludeAllRow
+                label="Every wallet"
+                isActive={form.managedWalletIds.length === 0}
+                onSelect={() => onUpdate({ managedWalletIds: [] })}
+              />
               {managedWallets.length === 0 ? (
                 <p className="px-2 py-3 text-xs text-muted-foreground">
                   This payment source has no wallets yet.
@@ -440,12 +463,15 @@ export function ReportFilterBar({
               action={
                 form.states.length > 0 ? (
                   <ResetFieldButton onClick={() => onUpdate({ states: [] })} />
-                ) : (
-                  <span className="text-[11px] text-muted-foreground">All states</span>
-                )
+                ) : null
               }
             />
-            <div className="grid max-h-40 gap-0.5 overflow-y-auto rounded-md border p-1.5">
+            <div className="max-h-40 gap-0.5 overflow-y-auto rounded-md border p-1.5">
+              <IncludeAllRow
+                label="Every state"
+                isActive={form.states.length === 0}
+                onSelect={() => onUpdate({ states: [] })}
+              />
               {REPORT_ON_CHAIN_STATES.map((state) => (
                 <label
                   key={state}

--- a/frontend/src/components/dashboard/report/ReportFilterBar.tsx
+++ b/frontend/src/components/dashboard/report/ReportFilterBar.tsx
@@ -13,7 +13,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
 import { defaultCustomDateRange, formatCalendarDate } from '@/lib/date-picker-calendar';
 import { cn, shortenAddress } from '@/lib/utils';
 import {
@@ -35,6 +34,8 @@ import {
   type ReportRole,
   type TransactionReportFormState,
 } from '@/components/transactions/download-details.helpers';
+import { AddressListField } from '@/components/transactions/report-export/AddressListField';
+import { knownAddressesFromWallets } from '@/components/transactions/report-export/address-filter';
 import { FiatSettingsField } from '@/components/transactions/report-export/FiatSettingsField';
 import {
   NO_FIAT_CURRENCY,
@@ -46,14 +47,11 @@ type ReportFacets = GetReportsFacetsResponses[200]['data'];
 
 type ReportFilterBarProps = Readonly<{
   form: TransactionReportFormState;
-  isLoading: boolean;
   managedWallets: ReportFacets['managedWallets'];
-  paymentSources: ReportFacets['paymentSources'];
   assetUnits: readonly string[];
   selectedUnit: string | null;
   assetLabel: (unit: string) => string;
   onSelectUnit: (unit: string) => void;
-  onSetPaymentSource: (paymentSourceId: string) => void;
   onToggleRole: (role: ReportRole) => void;
   onToggleState: (state: ReportOnChainState) => void;
   onToggleWallet: (walletId: string) => void;
@@ -62,25 +60,62 @@ type ReportFilterBarProps = Readonly<{
   fiatIssue: FiatIssue | null;
 }>;
 
-function sourceLabel(source: ReportFacets['paymentSources'][number]): string {
-  const version = source.paymentSourceType === 'Web3CardanoV2' ? 'Cardano V2' : 'Cardano V1';
-  return `${version} · ${shortenAddress(source.smartContractAddress, 7)}${source.deletedAt ? ' · Archived' : ''}`;
-}
-
 function todayAsDateInput(): string {
   return formatCalendarDate(new Date());
 }
 
-/** Counts only the filters that are hidden behind "More filters". */
-function countHiddenFilters(form: TransactionReportFormState): number {
+type FilterGroup = 'rules' | 'currency' | 'scope';
+
+/**
+ * How many settings each group holds that are not on their default.
+ *
+ * The count is what makes hiding a group safe: a reader can see that something
+ * is narrowing the report without having to open every panel to find it.
+ */
+function countGroupChanges(form: TransactionReportFormState, group: FilterGroup): number {
+  if (group === 'rules') {
+    return (
+      (form.dateBasis === 'RevenueRecognizedAt' ? 0 : 1) +
+      (form.revenueMode === 'Billable' ? 0 : 1) +
+      (form.bucket === 'Auto' ? 0 : 1)
+    );
+  }
+  if (group === 'currency') return form.fiatCurrency === NO_FIAT_CURRENCY ? 0 : 1;
   return (
     (form.managedWalletIds.length > 0 ? 1 : 0) +
     (form.states.length > 0 ? 1 : 0) +
-    (form.externalAddressesText.trim() ? 1 : 0) +
-    (form.dateBasis === 'RevenueRecognizedAt' ? 0 : 1) +
-    (form.revenueMode === 'Billable' ? 0 : 1) +
-    (form.bucket === 'Auto' ? 0 : 1) +
-    (form.fiatCurrency === NO_FIAT_CURRENCY ? 0 : 1)
+    (form.externalAddressesText.trim() ? 1 : 0)
+  );
+}
+
+const FILTER_GROUPS: ReadonlyArray<Readonly<{ value: FilterGroup; label: string }>> = [
+  { value: 'scope', label: 'Narrow' },
+  { value: 'rules', label: 'Rules' },
+  { value: 'currency', label: 'Currency' },
+];
+
+function GroupButton({
+  label,
+  count,
+  isOpen,
+  onClick,
+}: Readonly<{ label: string; count: number; isOpen: boolean; onClick: () => void }>) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-expanded={isOpen}
+      onClick={onClick}
+      className={isOpen ? 'bg-muted' : undefined}
+    >
+      {label}
+      {count > 0 && (
+        <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/15 px-1.5 text-xs">
+          {count}
+        </span>
+      )}
+    </Button>
   );
 }
 
@@ -108,14 +143,11 @@ function RoleToggle({
 
 export function ReportFilterBar({
   form,
-  isLoading,
   managedWallets,
-  paymentSources,
   assetUnits,
   selectedUnit,
   assetLabel,
   onSelectUnit,
-  onSetPaymentSource,
   onToggleRole,
   onToggleState,
   onToggleWallet,
@@ -123,8 +155,7 @@ export function ReportFilterBar({
   fiatCapability,
   fiatIssue,
 }: ReportFilterBarProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const hiddenFilterCount = countHiddenFilters(form);
+  const [openGroup, setOpenGroup] = useState<FilterGroup | null>(null);
   const maxDate = todayAsDateInput();
 
   return (
@@ -186,22 +217,20 @@ export function ReportFilterBar({
           ))}
         </div>
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="ml-auto"
-          aria-expanded={isExpanded}
-          onClick={() => setIsExpanded((current) => !current)}
-        >
-          <SlidersHorizontal className="h-4 w-4" />
-          More filters
-          {hiddenFilterCount > 0 && (
-            <span className="ml-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-xs">
-              {hiddenFilterCount}
-            </span>
-          )}
-        </Button>
+        <div className="ml-auto flex items-center gap-0.5" role="group" aria-label="Filter groups">
+          <SlidersHorizontal className="mr-1 h-4 w-4 text-muted-foreground" />
+          {FILTER_GROUPS.map((group) => (
+            <GroupButton
+              key={group.value}
+              label={group.label}
+              count={countGroupChanges(form, group.value)}
+              isOpen={openGroup === group.value}
+              onClick={() =>
+                setOpenGroup((current) => (current === group.value ? null : group.value))
+              }
+            />
+          ))}
+        </div>
       </div>
 
       {form.datePreset === 'custom' && (
@@ -232,57 +261,8 @@ export function ReportFilterBar({
         </div>
       )}
 
-      {isExpanded && (
-        <div className="grid gap-5 border-t bg-muted/10 p-4 lg:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="report-source">Payment source</Label>
-            <Select
-              value={form.paymentSourceId || undefined}
-              onValueChange={onSetPaymentSource}
-              disabled={isLoading || paymentSources.length === 0}
-            >
-              <SelectTrigger id="report-source">
-                <SelectValue placeholder={isLoading ? 'Loading…' : 'Select a source'} />
-              </SelectTrigger>
-              <SelectContent>
-                {paymentSources.map((source) => (
-                  <SelectItem key={source.id} value={source.id}>
-                    {sourceLabel(source)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <FiatSettingsField
-            currency={form.fiatCurrency}
-            mode={form.fiatMode}
-            capability={fiatCapability}
-            issue={fiatIssue}
-            onChange={onUpdate}
-            idPrefix="dashboard"
-            isPlain
-          />
-
-          <div className="space-y-1.5">
-            <Label htmlFor="report-bucket">Group the history by</Label>
-            <Select
-              value={form.bucket}
-              onValueChange={(value) => onUpdate({ bucket: value as ReportBucket })}
-            >
-              <SelectTrigger id="report-bucket">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(REPORT_BUCKET_LABELS).map(([value, label]) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
+      {openGroup === 'rules' && (
+        <div className="grid gap-5 border-t bg-muted/10 p-4 lg:grid-cols-3">
           <div className="space-y-1.5">
             <Label htmlFor="report-date-basis">Count a payment by</Label>
             <Select
@@ -327,6 +307,65 @@ export function ReportFilterBar({
             </p>
           </div>
 
+          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-1">
+            <div className="space-y-1.5">
+              <Label htmlFor="report-bucket">Group the history by</Label>
+              <Select
+                value={form.bucket}
+                onValueChange={(value) => onUpdate({ bucket: value as ReportBucket })}
+              >
+                <SelectTrigger id="report-bucket">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(REPORT_BUCKET_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="report-time-zone">Time zone</Label>
+              <Input
+                id="report-time-zone"
+                list="report-time-zones"
+                value={form.timeZone}
+                onChange={(event) => onUpdate({ timeZone: event.target.value })}
+                placeholder="Europe/Prague"
+              />
+              <datalist id="report-time-zones">
+                <option value="Etc/UTC" />
+                <option value={form.timeZone} />
+              </datalist>
+              <p className="text-[11px] text-muted-foreground">
+                Days and weeks start and end in this zone.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {openGroup === 'currency' && (
+        <div className="border-t bg-muted/10 p-4">
+          <div className="max-w-xl">
+            <FiatSettingsField
+              currency={form.fiatCurrency}
+              mode={form.fiatMode}
+              capability={fiatCapability}
+              issue={fiatIssue}
+              onChange={onUpdate}
+              idPrefix="dashboard"
+              isPlain
+            />
+          </div>
+        </div>
+      )}
+
+      {openGroup === 'scope' && (
+        <div className="grid gap-5 border-t bg-muted/10 p-4 lg:grid-cols-3">
           <fieldset className="relative space-y-1.5">
             <legend className="text-sm font-medium">Wallets</legend>
             <Button
@@ -358,7 +397,7 @@ export function ReportFilterBar({
                     </span>
                     <span className="text-muted-foreground">
                       {wallet.type === 'Selling' ? 'Selling' : 'Buying'}
-                      {wallet.deletedAt ? ' · Archived' : ''}
+                      {wallet.deletedAt ? ' \u00b7 Archived' : ''}
                     </span>
                   </label>
                 ))
@@ -393,37 +432,12 @@ export function ReportFilterBar({
             </div>
           </fieldset>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="report-addresses">Only these addresses</Label>
-            <Textarea
-              id="report-addresses"
-              className="min-h-16 font-mono text-xs"
-              placeholder="Optional. One address per line."
-              value={form.externalAddressesText}
-              onChange={(event) => onUpdate({ externalAddressesText: event.target.value })}
-            />
-            <p className="text-[11px] text-muted-foreground">
-              Matches the other side, the payout, and the return address.
-            </p>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="report-time-zone">Time zone</Label>
-            <Input
-              id="report-time-zone"
-              list="report-time-zones"
-              value={form.timeZone}
-              onChange={(event) => onUpdate({ timeZone: event.target.value })}
-              placeholder="Europe/Prague"
-            />
-            <datalist id="report-time-zones">
-              <option value="Etc/UTC" />
-              <option value={form.timeZone} />
-            </datalist>
-            <p className="text-[11px] text-muted-foreground">
-              Days and weeks start and end in this zone.
-            </p>
-          </div>
+          <AddressListField
+            value={form.externalAddressesText}
+            onChange={(externalAddressesText) => onUpdate({ externalAddressesText })}
+            knownAddresses={knownAddressesFromWallets(managedWallets)}
+            idPrefix="dashboard"
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/dashboard/report/ReportFilterBar.tsx
+++ b/frontend/src/components/dashboard/report/ReportFilterBar.tsx
@@ -35,6 +35,7 @@ import {
   type TransactionReportFormState,
 } from '@/components/transactions/download-details.helpers';
 import { AddressListField } from '@/components/transactions/report-export/AddressListField';
+import { PaymentStatesHint } from '@/components/transactions/report-export/PaymentStatesHint';
 import { knownAddressesFromWallets } from '@/components/transactions/report-export/address-filter';
 import { FiatSettingsField } from '@/components/transactions/report-export/FiatSettingsField';
 import {
@@ -89,10 +90,35 @@ function countGroupChanges(form: TransactionReportFormState, group: FilterGroup)
 }
 
 const FILTER_GROUPS: ReadonlyArray<Readonly<{ value: FilterGroup; label: string }>> = [
-  { value: 'scope', label: 'Narrow' },
+  { value: 'scope', label: 'Include' },
   { value: 'rules', label: 'Rules' },
   { value: 'currency', label: 'Currency' },
 ];
+
+/** Keeps a group heading and its reset control from colliding in a narrow column. */
+function FieldHeader({
+  title,
+  action,
+  hint,
+}: Readonly<{ title: string; action: React.ReactNode; hint?: React.ReactNode }>) {
+  return (
+    <div className="flex min-h-7 items-center justify-between gap-2">
+      <span className="flex items-center gap-1 text-sm font-medium">
+        {title}
+        {hint}
+      </span>
+      {action}
+    </div>
+  );
+}
+
+function ResetFieldButton({ onClick }: Readonly<{ onClick: () => void }>) {
+  return (
+    <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onClick}>
+      Use all
+    </Button>
+  );
+}
 
 function GroupButton({
   label,
@@ -366,18 +392,19 @@ export function ReportFilterBar({
 
       {openGroup === 'scope' && (
         <div className="grid gap-5 border-t bg-muted/10 p-4 lg:grid-cols-3">
-          <fieldset className="relative space-y-1.5">
-            <legend className="text-sm font-medium">Wallets</legend>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="absolute right-0 top-0 h-auto px-1 py-0 text-xs"
-              onClick={() => onUpdate({ managedWalletIds: [] })}
-            >
-              Use all
-            </Button>
-            <div className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-2">
+          <fieldset className="space-y-1.5">
+            <legend className="sr-only">Wallets</legend>
+            <FieldHeader
+              title="Wallets"
+              action={
+                form.managedWalletIds.length > 0 ? (
+                  <ResetFieldButton onClick={() => onUpdate({ managedWalletIds: [] })} />
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">All wallets</span>
+                )
+              }
+            />
+            <div className="max-h-40 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
               {managedWallets.length === 0 ? (
                 <p className="px-2 py-3 text-xs text-muted-foreground">
                   This payment source has no wallets yet.
@@ -395,7 +422,7 @@ export function ReportFilterBar({
                     <span className="min-w-0 flex-1 truncate">
                       {wallet.note?.trim() || shortenAddress(wallet.walletAddress, 8)}
                     </span>
-                    <span className="text-muted-foreground">
+                    <span className="shrink-0 text-muted-foreground">
                       {wallet.type === 'Selling' ? 'Selling' : 'Buying'}
                       {wallet.deletedAt ? ' \u00b7 Archived' : ''}
                     </span>
@@ -405,18 +432,20 @@ export function ReportFilterBar({
             </div>
           </fieldset>
 
-          <fieldset className="relative space-y-1.5">
-            <legend className="text-sm font-medium">Payment states</legend>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="absolute right-0 top-0 h-auto px-1 py-0 text-xs"
-              onClick={() => onUpdate({ states: [] })}
-            >
-              Use all
-            </Button>
-            <div className="grid max-h-40 grid-cols-2 gap-1 overflow-y-auto rounded-md border p-2">
+          <fieldset className="space-y-1.5">
+            <legend className="sr-only">Payment states</legend>
+            <FieldHeader
+              title="Payment states"
+              hint={<PaymentStatesHint />}
+              action={
+                form.states.length > 0 ? (
+                  <ResetFieldButton onClick={() => onUpdate({ states: [] })} />
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">All states</span>
+                )
+              }
+            />
+            <div className="grid max-h-40 gap-0.5 overflow-y-auto rounded-md border p-1.5">
               {REPORT_ON_CHAIN_STATES.map((state) => (
                 <label
                   key={state}
@@ -426,7 +455,7 @@ export function ReportFilterBar({
                     checked={form.states.includes(state)}
                     onCheckedChange={() => onToggleState(state)}
                   />
-                  <span>{humanizeReportValue(state)}</span>
+                  <span className="min-w-0">{humanizeReportValue(state)}</span>
                 </label>
               ))}
             </div>

--- a/frontend/src/components/transactions/report-export/AddressListField.tsx
+++ b/frontend/src/components/transactions/report-export/AddressListField.tsx
@@ -60,9 +60,11 @@ export function AddressListField({
 
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex min-h-8 items-center justify-between gap-2">
         <div className="flex items-center gap-1">
-          <Label htmlFor={inputId}>Only these addresses</Label>
+          <Label htmlFor={inputId} className="leading-normal">
+            Only these addresses
+          </Label>
           <InfoHint label="address filter">
             <p>
               Keeps only requests where one of these addresses is the counterparty, the payout

--- a/frontend/src/components/transactions/report-export/AddressListField.tsx
+++ b/frontend/src/components/transactions/report-export/AddressListField.tsx
@@ -3,20 +3,43 @@ import { Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { InfoHint } from '@/components/ui/info-hint';
 import { shortenAddress } from '@/lib/utils';
-import { MAX_ADDRESSES, addAddresses, parseAddressEntries } from './address-filter';
+import {
+  MAX_ADDRESSES,
+  addAddresses,
+  parseAddressEntries,
+  type KnownAddress,
+} from './address-filter';
 
 type AddressListFieldProps = Readonly<{
   value: string;
   onChange: (value: string) => void;
+  /** Addresses offered in the picker. Anything else is still typed by hand. */
+  knownAddresses?: readonly KnownAddress[];
+  /** Keeps the input id unique when the field appears twice on one screen. */
+  idPrefix?: string;
 }>;
 
-/** Builds the address filter one address at a time, or from a pasted list. */
-export function AddressListField({ value, onChange }: AddressListFieldProps) {
+/** Builds the address filter from the known addresses, or from pasted text. */
+export function AddressListField({
+  value,
+  onChange,
+  knownAddresses = [],
+  idPrefix = 'report',
+}: AddressListFieldProps) {
   const [draft, setDraft] = useState('');
   const [error, setError] = useState<string | null>(null);
   const addresses = parseAddressEntries(value);
+  const inputId = `${idPrefix}-address-input`;
+  const unusedKnown = knownAddresses.filter((known) => !addresses.includes(known.address));
 
   const commitAddresses = (next: readonly string[]) => onChange(next.join('\n'));
 
@@ -39,7 +62,7 @@ export function AddressListField({ value, onChange }: AddressListFieldProps) {
     <div className="space-y-1.5">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1">
-          <Label htmlFor="report-address-input">Only these addresses</Label>
+          <Label htmlFor={inputId}>Only these addresses</Label>
           <InfoHint label="address filter">
             <p>
               Keeps only requests where one of these addresses is the counterparty, the payout
@@ -91,11 +114,42 @@ export function AddressListField({ value, onChange }: AddressListFieldProps) {
         </ul>
       )}
 
+      {unusedKnown.length > 0 && (
+        <Select
+          value=""
+          onValueChange={(address) => {
+            const result = addAddresses(addresses, address);
+            if (result.addresses == null) {
+              setError(result.error);
+              return;
+            }
+            commitAddresses(result.addresses);
+            setError(null);
+          }}
+        >
+          <SelectTrigger aria-label="Add a known address">
+            <SelectValue placeholder="Add a wallet of this payment source…" />
+          </SelectTrigger>
+          <SelectContent>
+            {unusedKnown.map((known) => (
+              <SelectItem key={known.address} value={known.address}>
+                <span className="truncate">{known.label}</span>
+                <span className="ml-2 text-muted-foreground">{known.hint}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
       <div className="flex gap-2">
         <Input
-          id="report-address-input"
+          id={inputId}
           className="font-mono text-xs"
-          placeholder="addr_test1… or paste several at once"
+          placeholder={
+            unusedKnown.length > 0
+              ? 'Or paste any other address'
+              : 'addr_test1… or paste several at once'
+          }
           value={draft}
           aria-invalid={error != null}
           onChange={(event) => {

--- a/frontend/src/components/transactions/report-export/PaymentStatesHint.tsx
+++ b/frontend/src/components/transactions/report-export/PaymentStatesHint.tsx
@@ -1,0 +1,28 @@
+import { InfoHint } from '@/components/ui/info-hint';
+
+/**
+ * The state filter is easy to misread as "which payments count as revenue".
+ *
+ * It is not that. It drops whole requests from the report, fees included, while
+ * the revenue mode decides when money counts. Saying so at the field itself is
+ * cheaper than explaining a total that fell for no visible reason.
+ */
+export function PaymentStatesHint() {
+  return (
+    <InfoHint label="payment states">
+      <p>
+        Chooses which requests appear at all. Leave every box clear to include all of them, which is
+        the normal setting.
+      </p>
+      <p>
+        This does not decide when money counts. That is the job of &ldquo;Count revenue when it
+        is&rdquo;, which already counts work as earned once the escrow unlocks, before any
+        withdrawal.
+      </p>
+      <p>
+        So picking only <em>Withdrawn</em> does not give you settled revenue. It removes every
+        request that has not been withdrawn yet, together with its fees, and the totals drop.
+      </p>
+    </InfoHint>
+  );
+}

--- a/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
+++ b/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
@@ -23,6 +23,7 @@ import {
 } from '../download-details.helpers';
 import type { useDownloadDetailsModel } from '../useDownloadDetailsModel';
 import { AddressListField } from './AddressListField';
+import { knownAddressesFromWallets } from './address-filter';
 import { reportPurposeShows } from './report-purposes';
 
 type ReportModel = ReturnType<typeof useDownloadDetailsModel>;
@@ -240,6 +241,7 @@ export function ReportScopeFields({ model }: Readonly<{ model: ReportModel }>) {
         <AddressListField
           value={model.form.externalAddressesText}
           onChange={(externalAddressesText) => model.updateForm({ externalAddressesText })}
+          knownAddresses={knownAddressesFromWallets(model.managedWallets)}
         />
       )}
     </div>

--- a/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
+++ b/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
@@ -49,6 +49,25 @@ function FieldHeader({
   );
 }
 
+/**
+ * A checked row that stands for "no filter at all".
+ *
+ * A list of empty checkboxes reads as "nothing is included", when an empty
+ * filter in fact includes everything.
+ */
+function IncludeAllRow({
+  label,
+  isActive,
+  onSelect,
+}: Readonly<{ label: string; isActive: boolean; onSelect: () => void }>) {
+  return (
+    <label className="mb-0.5 flex cursor-pointer items-center gap-2 rounded border-b px-2 py-1.5 text-xs hover:bg-muted/50">
+      <Checkbox checked={isActive} onCheckedChange={onSelect} />
+      <span className="font-medium">{label}</span>
+    </label>
+  );
+}
+
 function RoleToggle({
   role,
   isActive,
@@ -173,12 +192,15 @@ export function ReportScopeFields({ model }: Readonly<{ model: ReportModel }>) {
                 >
                   Use all
                 </Button>
-              ) : (
-                <span className="text-[11px] text-muted-foreground">All wallets included</span>
-              )
+              ) : null
             }
           />
           <div className="max-h-40 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
+            <IncludeAllRow
+              label="Every wallet"
+              isActive={model.form.managedWalletIds.length === 0}
+              onSelect={() => model.updateForm({ managedWalletIds: [] })}
+            />
             {model.managedWallets.length === 0 ? (
               <p className="px-2 py-3 text-xs text-muted-foreground">
                 This payment source has no wallets yet.
@@ -224,12 +246,15 @@ export function ReportScopeFields({ model }: Readonly<{ model: ReportModel }>) {
                 >
                   Use all
                 </Button>
-              ) : (
-                <span className="text-[11px] text-muted-foreground">All states included</span>
-              )
+              ) : null
             }
           />
-          <div className="grid max-h-40 grid-cols-2 gap-0.5 overflow-y-auto rounded-md border p-1.5">
+          <div className="max-h-40 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
+            <IncludeAllRow
+              label="Every state"
+              isActive={model.form.states.length === 0}
+              onSelect={() => model.updateForm({ states: [] })}
+            />
             {REPORT_ON_CHAIN_STATES.map((state) => (
               <label
                 key={state}

--- a/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
+++ b/frontend/src/components/transactions/report-export/ReportScopeFields.tsx
@@ -23,6 +23,7 @@ import {
 } from '../download-details.helpers';
 import type { useDownloadDetailsModel } from '../useDownloadDetailsModel';
 import { AddressListField } from './AddressListField';
+import { PaymentStatesHint } from './PaymentStatesHint';
 import { knownAddressesFromWallets } from './address-filter';
 import { reportPurposeShows } from './report-purposes';
 
@@ -32,10 +33,17 @@ function todayAsDateInput(): string {
   return formatCalendarDate(new Date());
 }
 
-function FieldHeader({ title, action }: Readonly<{ title: string; action?: ReactNode }>) {
+function FieldHeader({
+  title,
+  action,
+  hint,
+}: Readonly<{ title: string; action?: ReactNode; hint?: ReactNode }>) {
   return (
     <div className="flex min-h-8 items-center justify-between gap-2">
-      <span className="text-sm font-medium">{title}</span>
+      <span className="flex items-center gap-1 text-sm font-medium">
+        {title}
+        {hint}
+      </span>
       {action}
     </div>
   );
@@ -204,6 +212,7 @@ export function ReportScopeFields({ model }: Readonly<{ model: ReportModel }>) {
           <legend className="sr-only">Payment states</legend>
           <FieldHeader
             title="Payment states"
+            hint={<PaymentStatesHint />}
             action={
               model.form.states.length > 0 ? (
                 <Button

--- a/frontend/src/components/transactions/report-export/address-filter.test.ts
+++ b/frontend/src/components/transactions/report-export/address-filter.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { addAddresses, parseAddressEntries } from './address-filter';
+import { addAddresses, knownAddressesFromWallets, parseAddressEntries } from './address-filter';
 
 const FIRST = 'addr_test1qzbuya0000000000000000000000000000000000000000000000000q2wn7cf';
 const SECOND = 'addr_test1qzextbuyer00000000000000000000000000000000000000000000q8fh2we';
@@ -42,5 +42,36 @@ describe('report address filter', () => {
     const result = addAddresses(filled, SECOND);
     assert.equal(result.addresses, null);
     assert.match(result.error ?? '', /at most 100 addresses/);
+  });
+});
+
+describe('knownAddressesFromWallets', () => {
+  const WALLET = {
+    walletAddress: 'addr_test1qqselling',
+    note: '  Payout wallet  ',
+    type: 'Selling',
+    deletedAt: null,
+  };
+
+  it('names a wallet by its note and side', () => {
+    assert.deepEqual(knownAddressesFromWallets([WALLET]), [
+      { address: 'addr_test1qqselling', label: 'Payout wallet', hint: 'Selling' },
+    ]);
+  });
+
+  it('falls back to the address when the wallet has no note', () => {
+    const [known] = knownAddressesFromWallets([{ ...WALLET, note: '   ' }]);
+    assert.equal(known.label, 'addr_test1qqselling');
+  });
+
+  it('marks an archived wallet so an old address is not mistaken for a live one', () => {
+    const [known] = knownAddressesFromWallets([
+      { ...WALLET, type: 'Purchasing', deletedAt: new Date('2026-01-01') },
+    ]);
+    assert.equal(known.hint, 'Buying · Archived');
+  });
+
+  it('keeps one entry per address when two wallets share it', () => {
+    assert.equal(knownAddressesFromWallets([WALLET, { ...WALLET, note: 'Other' }]).length, 1);
   });
 });

--- a/frontend/src/components/transactions/report-export/address-filter.ts
+++ b/frontend/src/components/transactions/report-export/address-filter.ts
@@ -76,3 +76,34 @@ export function addAddresses(current: readonly string[], draft: string): Address
   }
   return { addresses: merged, error: null, invalidAddress: null };
 }
+
+/** An address this service already knows, offered so it need not be pasted. */
+export type KnownAddress = Readonly<{ address: string; label: string; hint: string }>;
+
+type ManagedWalletLike = Readonly<{
+  walletAddress: string;
+  note?: string | null;
+  type: string;
+  deletedAt?: Date | string | null;
+}>;
+
+/**
+ * Offers the payment source's own wallets as ready-made filter entries.
+ *
+ * These are the only addresses the service can name. A counterparty address
+ * belongs to somebody else, so it still has to be pasted.
+ */
+export function knownAddressesFromWallets(wallets: readonly ManagedWalletLike[]): KnownAddress[] {
+  const seen = new Set<string>();
+  const known: KnownAddress[] = [];
+  for (const wallet of wallets) {
+    if (!wallet.walletAddress || seen.has(wallet.walletAddress)) continue;
+    seen.add(wallet.walletAddress);
+    known.push({
+      address: wallet.walletAddress,
+      label: wallet.note?.trim() || wallet.walletAddress,
+      hint: `${wallet.type === 'Selling' ? 'Selling' : 'Buying'}${wallet.deletedAt ? ' · Archived' : ''}`,
+    });
+  }
+  return known;
+}

--- a/frontend/src/lib/api/generated/types.gen.ts
+++ b/frontend/src/lib/api/generated/types.gen.ts
@@ -16068,6 +16068,11 @@ export type PostReportsTransactionsResponses = {
                     demoHistoryDays: number | null;
                     completeness: 'complete' | 'partial';
                     unpricedUnits: Array<string>;
+                    rates: Array<{
+                        unit: string;
+                        rate: string;
+                        source: 'supplied' | 'coingecko';
+                    }> | null;
                 } | null;
                 warnings: Array<{
                     code: string;
@@ -16587,6 +16592,11 @@ export type PostReportsSummaryResponses = {
                     demoHistoryDays: number | null;
                     completeness: 'complete' | 'partial';
                     unpricedUnits: Array<string>;
+                    rates: Array<{
+                        unit: string;
+                        rate: string;
+                        source: 'supplied' | 'coingecko';
+                    }> | null;
                 } | null;
                 warnings: Array<{
                     code: string;

--- a/src/routes/api/reports/schemas.ts
+++ b/src/routes/api/reports/schemas.ts
@@ -214,6 +214,9 @@ const reportFiatMetadataSchema = z.object({
 	demoHistoryDays: z.number().int().nullable(),
 	completeness: z.enum(['complete', 'partial']),
 	unpricedUnits: z.array(z.string()),
+	rates: z
+		.array(z.object({ unit: z.string(), rate: z.string(), source: z.enum(['supplied', 'coingecko']) }))
+		.nullable(),
 });
 
 const reportMetadataSchema = z.object({

--- a/src/services/transaction-report/csv.spec.ts
+++ b/src/services/transaction-report/csv.spec.ts
@@ -151,7 +151,7 @@ function csvRecord(buffer: Buffer, rowIndex = 1): Record<string, string> {
 describe('transaction report CSV', () => {
 	it('carries the withdraw transaction hash and names the withdraw type', () => {
 		const output = createTransactionsCsv([row()], metadata());
-		const values = csvRecord(output, 2);
+		const values = csvRecord(output);
 
 		expect(values.settlement_tx_hash).toBe('hash-1');
 		expect(values.settlement_tx_type).toBe('Withdrawn');
@@ -179,7 +179,7 @@ describe('transaction report CSV', () => {
 			],
 			metadata(),
 		);
-		const values = csvRecord(output, 2);
+		const values = csvRecord(output);
 
 		expect(values.result_submitted_tx_hash).toBe('hash-submit');
 		expect(values.settlement_tx_hash).toBe('');
@@ -188,9 +188,8 @@ describe('transaction report CSV', () => {
 
 	it('exports normalized asset decimals and exact unknown atomic amounts', () => {
 		const output = createTransactionsCsv([row()], metadata());
-		const values = csvRecord(output, 2);
+		const values = csvRecord(output);
 
-		expect(values.record_type).toBe('transaction');
 		expect(values.seller_gross_revenue_ada).toBe('1.234567');
 		expect(values.seller_gross_revenue_usdm).toBe('3.000000');
 		expect(values.seller_gross_revenue_usdcx).toBe('3.000001');
@@ -222,7 +221,7 @@ describe('transaction report CSV', () => {
 				},
 			],
 		});
-		const values = csvRecord(createTransactionsCsv([buyer], metadata()), 2);
+		const values = csvRecord(createTransactionsCsv([buyer], metadata()));
 
 		expect(values.role).toBe('Buyer');
 		expect(values.seller_gross_revenue_ada).toBe('');
@@ -245,7 +244,7 @@ describe('transaction report CSV', () => {
 			metadata: '\ncommand',
 		});
 		const output = createTransactionsCsv([dangerous], metadata());
-		const values = csvRecord(output, 2);
+		const values = csvRecord(output);
 
 		expect(values.id).toBe("'\tcommand");
 		expect(values.blockchain_identifier).toBe("'\rcommand");
@@ -268,60 +267,32 @@ describe('transaction report CSV', () => {
 		expect(first.equals(second)).toBe(true);
 		expect(first.toString('utf8').endsWith('\r\n')).toBe(true);
 		expect(withoutRecords).not.toMatch(/[\r\n]/u);
-		expect(first.toString('utf8').startsWith('"generated_at","as_of","payment_source_id"')).toBe(true);
+		expect(first.toString('utf8').startsWith('"id","blockchain_identifier","role"')).toBe(true);
 	});
 
-	it('writes context once and leaves all transaction context cells blank', () => {
+	it('carries no report context columns, because the export README holds them', () => {
 		const output = createTransactionsCsv(
 			[row(), row({ id: 'request-2', blockchainIdentifier: 'chain-2' })],
 			metadata(),
 		);
 		const parsedRows = parseCsv(output);
-		const contextValues = csvRecord(output);
-		const firstValues = csvRecord(output, 2);
-		const secondValues = csvRecord(output, 3);
-		const recordTypeIndex = parsedRows[0].indexOf('record_type');
+		const headers = parsedRows[0];
 
-		expect(parsedRows).toHaveLength(4);
-		expect(new Set(parsedRows[0]).size).toBe(parsedRows[0].length);
-		expect(parsedRows.slice(1).filter((values) => values[recordTypeIndex] === 'report_context')).toHaveLength(1);
-		expect(contextValues.generated_at).toBe('2026-02-02T01:02:03.000Z');
-		expect(contextValues.as_of).toBe('2026-02-02T00:00:00.000Z');
-		expect(contextValues.payment_source_id).toBe('source-1');
-		expect(contextValues.payment_source_network).toBe('Preprod');
-		expect(contextValues.payment_source_type).toBe('Web3CardanoV1');
-		expect(contextValues.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
-		expect(contextValues.filter_external_addresses_json).toBe('["addr-a","addr-z"]');
-		expect(contextValues.filter_roles_json).toBe('["Buyer","Seller"]');
-		expect(contextValues.filter_states_json).toBe('["Withdrawn"]');
-		expect(contextValues.filter_from).toBe('2026-01-01T00:00:00.000Z');
-		expect(contextValues.filter_to).toBe('2026-02-01T00:00:00.000Z');
-		expect(contextValues.filter_date_basis).toBe('CreatedAt');
-		expect(contextValues.filter_revenue_mode).toBe('RequestedGross');
-		expect(contextValues.filter_time_zone).toBe('Etc/UTC');
-		expect(contextValues.filter_bucket).toBe('Auto');
-		expect(contextValues.report_bucket).toBe('Day');
-		expect(firstValues.record_type).toBe('transaction');
-		expect(firstValues.payment_source_id).toBe('');
-		expect(firstValues.filter_states_json).toBe('');
-		expect(secondValues.record_type).toBe('transaction');
-		expect(secondValues.payment_source_id).toBe('');
-		expect(secondValues.filter_states_json).toBe('');
+		expect(parsedRows).toHaveLength(3);
+		expect(new Set(headers).size).toBe(headers.length);
+		for (const header of ['record_type', 'generated_at', 'as_of', 'payment_source_id', 'filter_states_json']) {
+			expect(headers).not.toContain(header);
+		}
+		expect(csvRecord(output).id).toBe('request-1');
+		expect(csvRecord(output, 2).id).toBe('request-2');
 	});
 
-	it('keeps an empty direct export auditable with one context record', () => {
+	it('writes only a header row when the period holds no request', () => {
 		const output = createTransactionsCsv([], metadata());
 		const rows = parseCsv(output);
-		const values = csvRecord(output);
 
-		expect(rows).toHaveLength(2);
-		expect(values.record_type).toBe('report_context');
-		expect(values.payment_source_id).toBe('source-1');
-		expect(values.filter_states_json).toBe('["Withdrawn"]');
-		expect(values.filter_bucket).toBe('Auto');
-		expect(values.report_bucket).toBe('Day');
-		expect(values.id).toBe('');
-		expect(values.seller_gross_revenue_ada).toBe('');
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toContain('seller_gross_revenue_ada');
 	});
 
 	it('measures multibyte, quote, and formula escaping before allocating the final buffer', () => {
@@ -330,7 +301,7 @@ describe('transaction report CSV', () => {
 		const exactBytes = unrestricted.byteLength;
 
 		expect(createTransactionsCsv([reportRow], metadata(), { maxBytes: exactBytes })).toEqual(unrestricted);
-		expect(csvRecord(unrestricted, 2).agent_name).toBe('\'  =λ"😀,value');
+		expect(csvRecord(unrestricted).agent_name).toBe('\'  =λ"😀,value');
 
 		const allocationSpy = jest.spyOn(Buffer, 'allocUnsafe');
 		let thrown: unknown;
@@ -349,18 +320,12 @@ describe('transaction report CSV', () => {
 });
 
 describe('transaction report aggregate CSV', () => {
-	it('includes exact source, filter, financial, and completeness context in totals', () => {
+	it('includes exact financial and completeness figures in totals', () => {
 		const reportRow = row();
 		const result = aggregateReportRows([reportRow], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
 		const output = createTotalsCsv(result, metadata());
 		const values = csvRecord(output);
 
-		expect(values.as_of).toBe('2026-02-02T00:00:00.000Z');
-		expect(values.payment_source_id).toBe('source-1');
-		expect(values.payment_source_fee_rate_percent).toBe('5.0');
-		expect(values.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
-		expect(values.filter_roles_json).toBe('["Buyer","Seller"]');
-		expect(values.warning_codes_json).toBe('["A_WARNING","Z_WARNING"]');
 		expect(values.transaction_count).toBe('1');
 		expect(values.seller_gross_revenue_ada).toBe('1.234567');
 		expect(values.seller_gross_revenue_completeness).toBe('complete');
@@ -381,42 +346,26 @@ describe('transaction report aggregate CSV', () => {
 		const result = aggregateReportRows([first, second], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
 		const output = createWalletSummaryCsv(result, metadata());
 		const rows = parseCsv(output);
-		const contextValues = csvRecord(output);
-		const firstValues = csvRecord(output, 2);
-		const secondValues = csvRecord(output, 3);
-		const recordTypeIndex = rows[0].indexOf('record_type');
+		const firstValues = csvRecord(output);
+		const secondValues = csvRecord(output, 2);
 
-		expect(rows).toHaveLength(4);
-		expect(rows.slice(1).filter((values) => values[recordTypeIndex] === 'report_context')).toHaveLength(1);
-		expect(contextValues.payment_source_id).toBe('source-1');
-		expect(contextValues.report_bucket).toBe('Day');
-		expect(firstValues.record_type).toBe('wallet_summary');
-		expect(firstValues.payment_source_id).toBe('');
-		expect(firstValues.report_bucket).toBe('');
+		expect(rows).toHaveLength(3);
+		expect(rows[0]).not.toContain('payment_source_id');
 		expect(firstValues.managed_wallet_id).toBe('wallet-a');
 		expect(firstValues.role).toBe('Seller');
 		expect(firstValues.seller_gross_revenue_usdm).toBe('3.000000');
 		expect(firstValues.protocol_fees_completeness).toBe('partial');
 		expect(firstValues.actor_cardano_fees_ada).toBe('0.123456');
-		expect(secondValues.record_type).toBe('wallet_summary');
-		expect(secondValues.payment_source_id).toBe('');
+		expect(secondValues.managed_wallet_id).toBe('wallet-z');
 	});
 
-	it('keeps an empty wallet summary auditable with blank wallet and metric fields', () => {
+	it('writes only a header row when no wallet moved money', () => {
 		const result = aggregateReportRows([], 'Day', 'Etc/UTC', FROM, TO, 'CreatedAt');
 		const output = createWalletSummaryCsv(result, metadata());
 		const rows = parseCsv(output);
-		const values = csvRecord(output);
 
-		expect(rows).toHaveLength(2);
-		expect(values.record_type).toBe('report_context');
-		expect(values.payment_source_id).toBe('source-1');
-		expect(values.filter_managed_wallet_ids_json).toBe('["wallet-a","wallet-z"]');
-		expect(values.report_bucket).toBe('Day');
-		expect(values.managed_wallet_id).toBe('');
-		expect(values.role).toBe('');
-		expect(values.transaction_count).toBe('');
-		expect(values.total_cardano_fees_ada).toBe('');
-		expect(values.total_cardano_fees_completeness).toBe('');
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toContain('managed_wallet_id');
+		expect(rows[0]).toContain('total_cardano_fees_completeness');
 	});
 });

--- a/src/services/transaction-report/csv.ts
+++ b/src/services/transaction-report/csv.ts
@@ -10,6 +10,7 @@ import type {
 	RequestedReportBucket,
 } from './aggregate';
 import type { ReportFiatMetadata } from './fiat';
+import type { FiatRowRates } from './fiat/rates';
 import type { ReportRow, ReportWarning } from './records';
 
 type CsvCell = Readonly<{ value: string; isUntrusted: boolean }>;
@@ -59,7 +60,35 @@ export class ReportCsvSizeLimitError extends Error {
 	}
 }
 
-const AMOUNT_SUFFIXES = ['ada', 'usdm', 'usdcx', 'other_assets_json', 'fiat'] as const;
+const AMOUNT_SUFFIXES = ['ada', 'usdm', 'usdcx', 'other_assets_json'] as const;
+
+/** The on-chain assets that get their own rate column, in column order. */
+const RATE_ASSET_KEYS = ['ada', 'usdm', 'usdcx'] as const;
+
+/**
+ * How the money columns are laid out for one export.
+ *
+ * The converted column is named after the currency, the same way the asset
+ * columns are, so a row states its own currency without anyone having to look
+ * up a separate context row.
+ */
+type ReportCsvLayout = Readonly<{ fiatSuffix: string | null }>;
+
+function csvLayout(metadata: ReportCsvMetadata): ReportCsvLayout {
+	return { fiatSuffix: metadata.fiat == null ? null : metadata.fiat.currency.toLowerCase() };
+}
+
+function rateHeaders(layout: ReportCsvLayout): string[] {
+	return layout.fiatSuffix == null ? [] : RATE_ASSET_KEYS.map((key) => `${key}_${layout.fiatSuffix}_rate`);
+}
+
+function rateCells(rates: FiatRowRates | null, layout: ReportCsvLayout): CsvCell[] {
+	if (layout.fiatSuffix == null) return [];
+	return RATE_ASSET_KEYS.map((key) => {
+		const match = (rates ?? []).find((rate) => getReportAssetMetadata(rate.unit)?.key === key);
+		return trusted(match?.rate ?? '');
+	});
+}
 const AGGREGATE_METRICS = [
 	'sellerGrossRevenue',
 	'protocolFees',
@@ -88,34 +117,6 @@ const AGGREGATE_METRIC_NAMES: Record<(typeof AGGREGATE_METRICS)[number], string>
 	totalCardanoFees: 'total_cardano_fees',
 };
 
-const CONTEXT_HEADERS = [
-	'generated_at',
-	'as_of',
-	'payment_source_id',
-	'payment_source_network',
-	'payment_source_type',
-	'payment_source_fee_rate_permille',
-	'payment_source_fee_rate_percent',
-	'payment_source_smart_contract_address',
-	'payment_source_deleted_at',
-	'filter_managed_wallet_ids_json',
-	'filter_external_addresses_json',
-	'filter_roles_json',
-	'filter_states_json',
-	'filter_from',
-	'filter_to',
-	'filter_date_basis',
-	'filter_revenue_mode',
-	'filter_time_zone',
-	'filter_bucket',
-	'report_bucket',
-	'fiat_currency',
-	'fiat_rate_mode',
-	'fiat_rate_provider',
-	'fiat_completeness',
-	'warning_codes_json',
-] as const;
-
 function trusted(value: string | number | boolean | null | undefined): CsvCell {
 	return { value: value == null ? '' : String(value), isUntrusted: false };
 }
@@ -126,10 +127,6 @@ function untrusted(value: string | null | undefined): CsvCell {
 
 function dateCell(value: Date | null): CsvCell {
 	return trusted(value?.toISOString());
-}
-
-function stableStringArrayJson(values: readonly string[] | null): string {
-	return JSON.stringify(values == null ? null : [...new Set(values)].sort((left, right) => left.localeCompare(right)));
 }
 
 const CSV_RECORD_SEPARATOR = '\r\n';
@@ -260,78 +257,42 @@ function splitAmounts(amounts: readonly AtomicAmount[] | null): AmountColumns | 
 	};
 }
 
-function amountHeaders(prefix: string): string[] {
-	return AMOUNT_SUFFIXES.map((suffix) => `${prefix}_${suffix}`);
+function amountHeaders(prefix: string, layout: ReportCsvLayout): string[] {
+	const headers = AMOUNT_SUFFIXES.map((suffix) => `${prefix}_${suffix}`);
+	return layout.fiatSuffix == null ? headers : [...headers, `${prefix}_${layout.fiatSuffix}`];
 }
 
-function amountCells(amounts: readonly AtomicAmount[] | null): CsvCell[] {
+function amountCells(amounts: readonly AtomicAmount[] | null, layout: ReportCsvLayout): CsvCell[] {
 	const columns = splitAmounts(amounts);
-	return columns == null
-		? [trusted(''), trusted(''), trusted(''), trusted(''), trusted('')]
-		: [
-				trusted(columns.ada),
-				trusted(columns.usdm),
-				trusted(columns.usdcx),
-				trusted(columns.otherAssets),
-				trusted(columns.fiat),
-			];
+	const cells =
+		columns == null
+			? [trusted(''), trusted(''), trusted(''), trusted('')]
+			: [trusted(columns.ada), trusted(columns.usdm), trusted(columns.usdcx), trusted(columns.otherAssets)];
+	if (layout.fiatSuffix == null) return cells;
+	return [...cells, trusted(columns == null ? '' : columns.fiat)];
 }
 
-function aggregateMetricHeaders(prefix: string): string[] {
-	return [...amountHeaders(prefix), `${prefix}_completeness`];
+function aggregateMetricHeaders(prefix: string, layout: ReportCsvLayout): string[] {
+	return [...amountHeaders(prefix, layout), `${prefix}_completeness`];
 }
 
-function aggregateMetricCells(metric: ReportAggregateMetric): CsvCell[] {
-	return [...amountCells(metric.amounts), trusted(metric.completeness)];
+function aggregateMetricCells(metric: ReportAggregateMetric, layout: ReportCsvLayout): CsvCell[] {
+	return [...amountCells(metric.amounts, layout), trusted(metric.completeness)];
 }
 
-function aggregateHeaders(): string[] {
+function aggregateHeaders(layout: ReportCsvLayout): string[] {
 	return [
 		'transaction_count',
 		'transaction_count_completeness',
-		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricHeaders(AGGREGATE_METRIC_NAMES[metric])),
+		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricHeaders(AGGREGATE_METRIC_NAMES[metric], layout)),
 	];
 }
 
-function aggregateCells(aggregate: ReportAggregate): CsvCell[] {
+function aggregateCells(aggregate: ReportAggregate, layout: ReportCsvLayout): CsvCell[] {
 	return [
 		trusted(aggregate.transactionCount),
 		trusted(aggregate.transactionCountCompleteness),
-		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricCells(aggregate[metric])),
-	];
-}
-
-function contextCells(metadata: ReportCsvMetadata): CsvCell[] {
-	const filters = metadata.filters;
-	const warningCodes = [...new Set((metadata.warnings ?? []).map((warning) => warning.code))].sort((left, right) =>
-		left.localeCompare(right),
-	);
-	return [
-		dateCell(metadata.generatedAt),
-		dateCell(metadata.asOf),
-		untrusted(metadata.paymentSource.id),
-		trusted(metadata.paymentSource.network),
-		trusted(metadata.paymentSource.paymentSourceType),
-		trusted(metadata.paymentSource.feeRatePermille),
-		trusted(atomicToDecimalString(BigInt(metadata.paymentSource.feeRatePermille), 1)),
-		untrusted(metadata.paymentSource.smartContractAddress),
-		dateCell(metadata.paymentSource.deletedAt),
-		trusted(stableStringArrayJson(filters.managedWalletIds)),
-		trusted(stableStringArrayJson(filters.externalAddresses)),
-		trusted(stableStringArrayJson(filters.roles)),
-		trusted(stableStringArrayJson(filters.states)),
-		dateCell(filters.from),
-		dateCell(filters.to),
-		trusted(filters.dateBasis),
-		trusted(filters.revenueMode),
-		untrusted(filters.timeZone),
-		trusted(metadata.requestedBucket),
-		trusted(metadata.bucket),
-		trusted(metadata.fiat == null ? '' : metadata.fiat.currency.toUpperCase()),
-		trusted(metadata.fiat?.mode ?? ''),
-		trusted(metadata.fiat?.provider ?? ''),
-		trusted(metadata.fiat?.completeness ?? ''),
-		trusted(JSON.stringify(warningCodes)),
+		...AGGREGATE_METRICS.flatMap((metric) => aggregateMetricCells(aggregate[metric], layout)),
 	];
 }
 
@@ -359,55 +320,58 @@ const TRANSACTION_AMOUNT_PREFIXES = [
 	'buyer_net_spend',
 ] as const;
 
-const TRANSACTION_HEADERS = [
-	'id',
-	'blockchain_identifier',
-	'role',
-	'request_type',
-	'on_chain_state',
-	'created_at',
-	'funds_locked_at',
-	'seller_revenue_recognized_at',
-	'buyer_gross_spend_at',
-	'buyer_returned_at',
-	'result_submitted_tx_hash',
-	'settlement_tx_hash',
-	'settlement_tx_type',
-	'managed_wallet_id',
-	'managed_wallet_address',
-	'managed_wallet_vkey',
-	'managed_wallet_collection_address',
-	'managed_wallet_deleted_at',
-	'agent_identifier',
-	'agent_name',
-	'counterparty_address',
-	'buyer_return_address',
-	'seller_return_address',
-	'metadata',
-	...TRANSACTION_AMOUNT_PREFIXES.flatMap(amountHeaders),
-	'protocol_fee_configured_rate_permille',
-	'protocol_fee_configured_rate_percent',
-	'protocol_fee_applied_rate_permille',
-	'protocol_fee_applied_rate_percent',
-	'protocol_fee_provenance',
-	'protocol_fee_basis',
-	'protocol_fee_completeness',
-	'seller_payout_completeness',
-	'buyer_payout_completeness',
-	'seller_cardano_fee_timing',
-	'buyer_cardano_fee_timing',
-	'actor_cardano_fee_allocation_strategy',
-	'actor_cardano_fee_allocation_completeness',
-	'actor_cardano_fee_allocation_attached_at',
-	'fee_allocation_scope',
-	'fee_component_scope',
-	'reconciliation_buyer_cardano_fee_ada',
-	'reconciliation_seller_cardano_fee_ada',
-	'reconciliation_admin_cardano_fee_ada',
-	'reconciliation_total_cardano_fee_ada',
-	'reconciliation_completeness',
-	'reconciliation_is_aggregation_owner',
-] as const;
+function transactionHeaders(layout: ReportCsvLayout): string[] {
+	return [
+		'id',
+		'blockchain_identifier',
+		'role',
+		'request_type',
+		'on_chain_state',
+		'created_at',
+		'funds_locked_at',
+		'seller_revenue_recognized_at',
+		'buyer_gross_spend_at',
+		'buyer_returned_at',
+		'result_submitted_tx_hash',
+		'settlement_tx_hash',
+		'settlement_tx_type',
+		'managed_wallet_id',
+		'managed_wallet_address',
+		'managed_wallet_vkey',
+		'managed_wallet_collection_address',
+		'managed_wallet_deleted_at',
+		'agent_identifier',
+		'agent_name',
+		'counterparty_address',
+		'buyer_return_address',
+		'seller_return_address',
+		'metadata',
+		...TRANSACTION_AMOUNT_PREFIXES.flatMap((prefix) => amountHeaders(prefix, layout)),
+		...rateHeaders(layout),
+		'protocol_fee_configured_rate_permille',
+		'protocol_fee_configured_rate_percent',
+		'protocol_fee_applied_rate_permille',
+		'protocol_fee_applied_rate_percent',
+		'protocol_fee_provenance',
+		'protocol_fee_basis',
+		'protocol_fee_completeness',
+		'seller_payout_completeness',
+		'buyer_payout_completeness',
+		'seller_cardano_fee_timing',
+		'buyer_cardano_fee_timing',
+		'actor_cardano_fee_allocation_strategy',
+		'actor_cardano_fee_allocation_completeness',
+		'actor_cardano_fee_allocation_attached_at',
+		'fee_allocation_scope',
+		'fee_component_scope',
+		'reconciliation_buyer_cardano_fee_ada',
+		'reconciliation_seller_cardano_fee_ada',
+		'reconciliation_admin_cardano_fee_ada',
+		'reconciliation_total_cardano_fee_ada',
+		'reconciliation_completeness',
+		'reconciliation_is_aggregation_owner',
+	];
+}
 
 function optionalPermillePercent(value: number | null): CsvCell {
 	return value == null ? trusted('') : trusted(atomicToDecimalString(BigInt(value), 1));
@@ -417,7 +381,7 @@ function optionalAda(value: bigint | null): CsvCell {
 	return value == null ? trusted('') : trusted(atomicToDecimalString(value, 6));
 }
 
-function transactionCells(row: ReportRow): CsvCell[] {
+function transactionCells(row: ReportRow, layout: ReportCsvLayout): CsvCell[] {
 	const protocolFee = row.seller?.protocolFee;
 	return [
 		untrusted(row.id),
@@ -444,7 +408,8 @@ function transactionCells(row: ReportRow): CsvCell[] {
 		untrusted(row.buyerReturnAddress),
 		untrusted(row.sellerReturnAddress),
 		untrusted(row.metadata),
-		...rowAmountGroups(row).flatMap(amountCells),
+		...rowAmountGroups(row).flatMap((amounts) => amountCells(amounts, layout)),
+		...rateCells(row.fiatRates ?? null, layout),
 		trusted(protocolFee?.configuredRatePermille),
 		optionalPermillePercent(protocolFee?.configuredRatePermille ?? null),
 		trusted(protocolFee?.appliedRatePermille),
@@ -471,21 +436,21 @@ function transactionCells(row: ReportRow): CsvCell[] {
 }
 
 /**
- * The file stays rectangular and standalone. One report_context row holds the filters and snapshot. Transaction rows
- * leave those context cells blank, which keeps large exports bounded without losing audit data.
+ * One row per request and side, and nothing else.
+ *
+ * The filters, snapshot time, and payment source used to sit in 25 columns
+ * repeated on every row. They live in the export's README instead, which can
+ * explain them in words rather than making every reader scroll past them.
  */
 export function createTransactionsCsv(
 	rows: readonly ReportRow[],
 	metadata: ReportCsvMetadata,
 	options: ReportCsvOptions = {},
 ): Buffer {
-	const headers = [...CONTEXT_HEADERS, 'record_type', ...TRANSACTION_HEADERS];
-	const blankContextCells = CONTEXT_HEADERS.map(() => trusted(''));
+	const layout = csvLayout(metadata);
+	const headers = transactionHeaders(layout);
 	function* outputRows(): Iterable<readonly CsvCell[]> {
-		yield [...contextCells(metadata), trusted('report_context'), ...TRANSACTION_HEADERS.map(() => trusted(''))];
-		for (const row of rows) {
-			yield [...blankContextCells, trusted('transaction'), ...transactionCells(row)];
-		}
+		for (const row of rows) yield transactionCells(row, layout);
 	}
 	return createCsv(headers, outputRows, options);
 }
@@ -495,7 +460,8 @@ export function createWalletSummaryCsv(
 	metadata: ReportCsvMetadata,
 	options: ReportCsvOptions = {},
 ): Buffer {
-	const aggregateColumnHeaders = aggregateHeaders();
+	const layout = csvLayout(metadata);
+	const aggregateColumnHeaders = aggregateHeaders(layout);
 	const walletColumnHeaders = [
 		'managed_wallet_id',
 		'managed_wallet_address',
@@ -505,37 +471,27 @@ export function createWalletSummaryCsv(
 		'role',
 	] as const;
 	const headers = [
-		...CONTEXT_HEADERS,
-		'record_type',
 		'history_fee_completeness',
 		...walletColumnHeaders,
 		...aggregateColumnHeaders,
+		...rateHeaders(layout),
 	];
 	const wallets = [...result.wallets].sort((left, right) => {
 		const walletComparison = (left.managedWallet?.id ?? '').localeCompare(right.managedWallet?.id ?? '');
 		return walletComparison || left.role.localeCompare(right.role);
 	});
-	const blankContextCells = CONTEXT_HEADERS.map(() => trusted(''));
 	function* outputRows(): Iterable<readonly CsvCell[]> {
-		yield [
-			...contextCells(metadata),
-			trusted('report_context'),
-			trusted(result.historyFeeCompleteness),
-			...walletColumnHeaders.map(() => trusted('')),
-			...aggregateColumnHeaders.map(() => trusted('')),
-		];
 		for (const wallet of wallets) {
 			yield [
-				...blankContextCells,
-				trusted('wallet_summary'),
-				trusted(''),
+				trusted(result.historyFeeCompleteness),
 				untrusted(wallet.managedWallet?.id),
 				untrusted(wallet.managedWallet?.walletAddress),
 				untrusted(wallet.managedWallet?.walletVkey),
 				untrusted(wallet.managedWallet?.collectionAddress),
 				dateCell(wallet.managedWallet?.deletedAt ?? null),
 				trusted(wallet.role),
-				...aggregateCells(wallet.metrics),
+				...aggregateCells(wallet.metrics, layout),
+				...rateCells(metadata.fiat?.rates ?? null, layout),
 			];
 		}
 	}
@@ -547,8 +503,13 @@ export function createTotalsCsv(
 	metadata: ReportCsvMetadata,
 	options: ReportCsvOptions = {},
 ): Buffer {
-	const headers = [...CONTEXT_HEADERS, 'history_fee_completeness', ...aggregateHeaders()];
-	const row = [...contextCells(metadata), trusted(result.historyFeeCompleteness), ...aggregateCells(result.totals)];
+	const layout = csvLayout(metadata);
+	const headers = ['history_fee_completeness', ...aggregateHeaders(layout), ...rateHeaders(layout)];
+	const row = [
+		trusted(result.historyFeeCompleteness),
+		...aggregateCells(result.totals, layout),
+		...rateCells(metadata.fiat?.rates ?? null, layout),
+	];
 	function* outputRows(): Iterable<readonly CsvCell[]> {
 		yield row;
 	}

--- a/src/services/transaction-report/export-files.spec.ts
+++ b/src/services/transaction-report/export-files.spec.ts
@@ -6,6 +6,7 @@ import { unzipSync } from 'fflate';
 import { REPORT_CSV_CONTENT_TYPE, REPORT_ZIP_CONTENT_TYPE, stageReportCsv, stageReportZip } from './export-files';
 
 const csvFiles = {
+	readme: Buffer.from('# Masumi transaction report\n', 'utf8'),
 	transactions: Buffer.from('id,amount\r\ntransaction-1,1000000\r\n', 'utf8'),
 	walletSummary: Buffer.from('wallet_id,revenue\r\nwallet-1,950000\r\n', 'utf8'),
 	totals: Buffer.from('gross,fees,net\r\n1000000,50000,950000\r\n', 'utf8'),
@@ -42,14 +43,20 @@ describe('stageReportCsv', () => {
 });
 
 describe('stageReportZip', () => {
-	it('stages exactly three CSV members without changing their bytes', async () => {
+	it('stages the readme and the three CSV members without changing their bytes', async () => {
 		const artifact = await stageReportZip(csvFiles, 'financial-report');
 
 		try {
 			const zipBytes = await readFile(artifact.filePath);
 			const members = unzipSync(zipBytes);
 
-			expect(Object.keys(members).sort()).toEqual(['totals.csv', 'transactions.csv', 'wallet-summary.csv']);
+			expect(Object.keys(members).sort()).toEqual([
+				'README.md',
+				'totals.csv',
+				'transactions.csv',
+				'wallet-summary.csv',
+			]);
+			expect(Buffer.from(members['README.md'])).toEqual(csvFiles.readme);
 			expect(Buffer.from(members['transactions.csv'])).toEqual(csvFiles.transactions);
 			expect(Buffer.from(members['wallet-summary.csv'])).toEqual(csvFiles.walletSummary);
 			expect(Buffer.from(members['totals.csv'])).toEqual(csvFiles.totals);

--- a/src/services/transaction-report/export-files.ts
+++ b/src/services/transaction-report/export-files.ts
@@ -20,6 +20,7 @@ export type StagedReportArtifact = {
 };
 
 export type ReportCsvFiles = {
+	readme: Buffer;
 	transactions: Buffer;
 	walletSummary: Buffer;
 	totals: Buffer;
@@ -86,6 +87,7 @@ async function writeZipExclusive(filePath: string, files: ReportCsvFiles): Promi
 
 	try {
 		for (const [filename, content] of [
+			['README.md', files.readme],
 			['transactions.csv', files.transactions],
 			['wallet-summary.csv', files.walletSummary],
 			['totals.csv', files.totals],

--- a/src/services/transaction-report/export-readme.ts
+++ b/src/services/transaction-report/export-readme.ts
@@ -1,0 +1,168 @@
+import { getReportAssetMetadata } from '@/utils/asset-units';
+import type { ReportCsvMetadata } from './csv';
+
+/**
+ * The export's own documentation.
+ *
+ * The filters, snapshot time, and payment source used to occupy 25 columns on
+ * every row of every file. They belong in prose, where each one can say what it
+ * means, rather than in a wall of repeated cells nobody reads.
+ */
+
+const DATE_BASIS_TEXT: Record<ReportCsvMetadata['filters']['dateBasis'], string> = {
+	CreatedAt: 'the day the request was created',
+	FundsLockedAt: 'the day the funds were locked in the contract',
+	RevenueRecognizedAt: 'the day the money was earned or spent',
+};
+
+const REVENUE_MODE_TEXT: Record<ReportCsvMetadata['filters']['revenueMode'], string> = {
+	Billable: 'earned, counted once the escrow unlocks even if the payout is still in the contract (accrual)',
+	CashReceived: 'paid out, counted only once the funds reach the wallet (cash)',
+	RequestedGross: 'requested, counted at the amount asked for whether or not it settled',
+};
+
+function formatDate(value: Date | null): string {
+	return value == null ? 'not set' : value.toISOString();
+}
+
+function formatList(values: readonly string[] | null, allText: string): string {
+	if (values == null || values.length === 0) return allText;
+	return values.join(', ');
+}
+
+function assetLabel(unit: string): string {
+	return getReportAssetMetadata(unit)?.symbol ?? unit;
+}
+
+function fiatSection(metadata: ReportCsvMetadata): string[] {
+	const fiat = metadata.fiat;
+	if (fiat == null) {
+		return [
+			'## Currency',
+			'',
+			'No conversion was applied. Every money column is in its own asset, so do not add ADA and a stablecoin together.',
+			'',
+		];
+	}
+	const code = fiat.currency.toUpperCase();
+	const modeText =
+		fiat.mode === 'PeriodAverage'
+			? `one average rate for the whole period, so every request in this export used the same rate`
+			: `the rate of each request's own accounting date, so requests booked on different days used different rates`;
+	const lines = [
+		'## Currency',
+		'',
+		`Every money column also appears in ${code}, in a column ending \`_${fiat.currency.toLowerCase()}\`.`,
+		'',
+		`- Rate basis: ${modeText}.`,
+		`- Rate source: ${fiat.provider === 'coingecko' ? 'CoinGecko' : 'rates supplied with the request'}.`,
+		`- Completeness: ${fiat.completeness}.`,
+	];
+	if (fiat.unpricedUnits.length > 0) {
+		lines.push(
+			`- No rate was found for ${fiat.unpricedUnits.map(assetLabel).join(', ')}. Figures holding those assets carry no converted value, rather than counting as zero.`,
+		);
+	}
+	if (fiat.rates != null && fiat.rates.length > 0) {
+		lines.push('', 'Rates used:', '');
+		for (const rate of fiat.rates) {
+			lines.push(`- 1 ${assetLabel(rate.unit)} = ${rate.rate} ${code}`);
+		}
+	} else if (fiat.mode === 'AccountingDate') {
+		lines.push(
+			'',
+			`Each request carries the rates it used, in the \`*_${fiat.currency.toLowerCase()}_rate\` columns of transactions.csv.`,
+		);
+	}
+	if (fiat.attribution != null) lines.push('', fiat.attribution + '.');
+	if (fiat.isDemoKey) {
+		lines.push(
+			`This service uses a free CoinGecko key, which prices only the last ${fiat.demoHistoryDays ?? 365} days.`,
+		);
+	}
+	lines.push('');
+	return lines;
+}
+
+function warningSection(metadata: ReportCsvMetadata): string[] {
+	const warnings = metadata.warnings ?? [];
+	if (warnings.length === 0) {
+		return ['## Estimates', '', 'No figure in this export is an estimate.', ''];
+	}
+	return [
+		'## Estimates',
+		'',
+		'Some figures could not be derived exactly. Each note below says why.',
+		'',
+		...warnings.map((warning) => `- **${warning.code}** ${warning.message}`),
+		'',
+	];
+}
+
+export function createReportReadme(metadata: ReportCsvMetadata): Buffer {
+	const filters = metadata.filters;
+	const fiatSuffix = metadata.fiat == null ? null : metadata.fiat.currency.toLowerCase();
+	const lines = [
+		'# Masumi transaction report',
+		'',
+		`Generated ${formatDate(metadata.generatedAt)}.`,
+		'',
+		'Every figure in this export comes from one database snapshot, so the files agree with each other.',
+		'',
+		'## What this export covers',
+		'',
+		`- Snapshot taken at: ${formatDate(metadata.asOf)}`,
+		`- Period: ${formatDate(filters.from)} up to but not including ${formatDate(filters.to)}`,
+		`- Time zone used for day and period boundaries: ${filters.timeZone}`,
+		`- A request counts on: ${DATE_BASIS_TEXT[filters.dateBasis]}`,
+		`- Money counts when it is: ${REVENUE_MODE_TEXT[filters.revenueMode]}`,
+		`- History grouped by: ${metadata.bucket}${metadata.requestedBucket === 'Auto' ? ' (chosen automatically)' : ''}`,
+		'',
+		'## Payment source',
+		'',
+		`- Id: ${metadata.paymentSource.id}`,
+		`- Network: ${metadata.paymentSource.network}`,
+		`- Contract version: ${metadata.paymentSource.paymentSourceType}`,
+		`- Contract address: ${metadata.paymentSource.smartContractAddress}`,
+		metadata.paymentSource.paymentSourceType === 'Web3CardanoV2'
+			? '- Protocol fee: none. The V2 contract takes no protocol fee.'
+			: `- Protocol fee rate: ${metadata.paymentSource.feeRatePermille / 10}% of gross revenue`,
+		...(metadata.paymentSource.deletedAt == null
+			? []
+			: [`- Archived on: ${formatDate(metadata.paymentSource.deletedAt)}`]),
+		'',
+		'## Filters applied',
+		'',
+		`- Sides: ${formatList(filters.roles, 'both selling and buying')}`,
+		`- Managed wallets: ${formatList(filters.managedWalletIds, 'all wallets of this payment source')}`,
+		`- Counterparty addresses: ${formatList(filters.externalAddresses, 'no address filter')}`,
+		`- Request states: ${formatList(filters.states, 'all states')}`,
+		'',
+		'## Files',
+		'',
+		'- `transactions.csv` — one row per request and side. The line-item detail behind everything else.',
+		'- `wallet-summary.csv` — the same money, added up per managed wallet and side.',
+		'- `totals.csv` — one row for the whole period.',
+		'',
+		'## Reading the money columns',
+		'',
+		'Each figure gets one column per asset, because a request can be paid in ADA or in a stablecoin:',
+		'',
+		'- `*_ada` — amounts in ADA',
+		'- `*_usdm` — amounts in USDM',
+		'- `*_usdcx` — amounts in USDCx',
+		'- `*_other_assets_json` — any other token, as a JSON object of unit to atomic amount',
+		...(fiatSuffix == null ? [] : [`- \`*_${fiatSuffix}\` — the same money converted, see Currency below`]),
+		'',
+		'An empty money cell means the figure could not be determined, which is not the same as zero.',
+		'',
+		...fiatSection(metadata),
+		...warningSection(metadata),
+		'## A note on Cardano network fees',
+		'',
+		'One Cardano transaction can settle several requests at once. When a fee cannot be attributed to a single',
+		'request, the affected figures are marked partial rather than split by guesswork.',
+		'',
+	];
+	return Buffer.from(lines.join('\n'), 'utf8');
+}

--- a/src/services/transaction-report/export-service.spec.ts
+++ b/src/services/transaction-report/export-service.spec.ts
@@ -55,7 +55,32 @@ const totals = Buffer.from('totals');
 const report = {
 	rows: [{ id: 'row-1' }],
 	aggregate: { totals: {}, wallets: [], bucket: 'Day' },
-	metadata: { generatedAt: new Date('2026-08-24T12:34:56.789Z') },
+	metadata: {
+		generatedAt: new Date('2026-08-24T12:34:56.789Z'),
+		asOf: new Date('2026-08-24T12:00:00.000Z'),
+		paymentSource: {
+			id: 'source-1',
+			network: 'Preprod',
+			paymentSourceType: 'Web3CardanoV1',
+			feeRatePermille: 50,
+			smartContractAddress: 'addr_test1w',
+			deletedAt: null,
+		},
+		filters: {
+			paymentSourceId: 'source-1',
+			managedWalletIds: null,
+			externalAddresses: [],
+			roles: ['Buyer', 'Seller'],
+			states: [],
+			from: new Date('2026-08-01T00:00:00.000Z'),
+			to: new Date('2026-08-24T00:00:00.000Z'),
+			dateBasis: 'CreatedAt',
+			revenueMode: 'Billable',
+			timeZone: 'Etc/UTC',
+		},
+		fiat: null,
+		warnings: [],
+	},
 };
 const artifact = {
 	filePath: '/tmp/report.csv',
@@ -94,7 +119,7 @@ describe('createReportExport', () => {
 		expect(mockStageReportZip).not.toHaveBeenCalled();
 	});
 
-	it('stages one ZIP from the same three CSV buffers', async () => {
+	it('stages one ZIP from the same three CSV buffers, alongside the README', async () => {
 		await createReportExport(input, ctx, 'zip');
 
 		expect(mockGetCompleteReportData).toHaveBeenCalledTimes(1);
@@ -129,9 +154,11 @@ describe('createReportExport', () => {
 			},
 		);
 		expect(mockStageReportZip).toHaveBeenCalledWith(
-			{ transactions, walletSummary, totals },
+			expect.objectContaining({ transactions, walletSummary, totals }),
 			'masumi-transaction-report-20260824T123456Z',
 		);
+		const [zipFiles] = mockStageReportZip.mock.calls[0] as [{ readme: Buffer }];
+		expect(zipFiles.readme.toString('utf8')).toContain('# Masumi transaction report');
 		expect(mockStageReportCsv).not.toHaveBeenCalled();
 	});
 

--- a/src/services/transaction-report/export-service.ts
+++ b/src/services/transaction-report/export-service.ts
@@ -10,6 +10,7 @@ import {
 	ReportCsvSizeLimitError,
 } from './csv';
 import { stageReportCsv, stageReportZip, type StagedReportArtifact } from './export-files';
+import { createReportReadme } from './export-readme';
 import { getCompleteReportData } from './service';
 
 export type ReportExportKind = 'transactions' | 'wallet-summary' | 'totals' | 'zip';
@@ -162,7 +163,7 @@ export async function createReportExport(
 		}
 
 		const stageOperation = stageReportZip(
-			{ transactions, walletSummary, totals },
+			{ readme: createReportReadme(csvMetadata), transactions, walletSummary, totals },
 			`masumi-transaction-report-${timestamp}`,
 		);
 		trackPendingWork?.(stageOperation);

--- a/src/services/transaction-report/fiat/apply.spec.ts
+++ b/src/services/transaction-report/fiat/apply.spec.ts
@@ -12,6 +12,9 @@ function sellerRow(overrides: Partial<ReportRow> = {}): ReportRow {
 	return {
 		role: 'Seller',
 		createdAt: new Date('2026-08-02T00:00:00Z'),
+		requestedFunds: [{ unit: 'lovelace', amount: 3_000_001n }],
+		withdrawnForBuyer: [],
+		withdrawnForSeller: [],
 		timestamps: {
 			createdAt: new Date('2026-08-02T00:00:00Z'),
 			fundsLockedAt: new Date('2026-08-02T00:00:00Z'),

--- a/src/services/transaction-report/fiat/apply.ts
+++ b/src/services/transaction-report/fiat/apply.ts
@@ -1,8 +1,8 @@
-import { fiatAssetUnit } from '@/utils/asset-units';
+import { fiatAssetUnit, normalizeAssetUnit } from '@/utils/asset-units';
 import type { AtomicAmount } from '../amounts';
 import type { ReportMetricWindow, ReportRow } from '../records';
 import { withFiatAmount } from './convert';
-import type { FiatRateContext, FiatRateTable } from './rates';
+import type { FiatRateContext, FiatRateSource, FiatRateTable, FiatRowRates } from './rates';
 
 type ReportDateBasis = ReportMetricWindow['dateBasis'];
 
@@ -30,6 +30,19 @@ function rateContext(
 	window: FiatWindow,
 ): FiatRateContext {
 	return table.mode === 'AccountingDate' ? { at: accountingDate(row, dateBasis) } : window;
+}
+
+/** Every on-chain asset the row actually holds, so no rate is reported unused. */
+function rowAssetUnits(row: ReportRow): string[] {
+	const units = new Set<string>();
+	for (const group of [row.requestedFunds, row.withdrawnForBuyer, row.withdrawnForSeller]) {
+		for (const amount of group) {
+			if (amount.amount !== 0n) units.add(normalizeAssetUnit(amount.unit));
+		}
+	}
+	// Cardano fees are always lovelace, and every row can carry them.
+	units.add('lovelace');
+	return [...units];
 }
 
 function fiatValueOf(amounts: readonly AtomicAmount[] | null, unit: string): bigint | null {
@@ -80,6 +93,11 @@ export function applyFiatToReportRows(
 	const missingUnits = new Set<string>();
 	const converted = rows.map((row) => {
 		const context = rateContext(row, table, dateBasis, window);
+		const usedRates = new Map<string, Readonly<{ unit: string; rate: string; source: FiatRateSource }>>();
+		for (const unit of rowAssetUnits(row)) {
+			const lookup = table.rateFor(unit, context);
+			if (lookup != null) usedRates.set(unit, { unit, rate: lookup.rate, source: lookup.source });
+		}
 		const convert = (amounts: readonly AtomicAmount[] | null): AtomicAmount[] | null => {
 			const result = withFiatAmount(amounts, table, context);
 			for (const unit of result.missingUnits) missingUnits.add(unit);
@@ -120,7 +138,7 @@ export function applyFiatToReportRows(
 				]),
 			};
 		}
-		return { ...row, seller, buyer };
+		return { ...row, seller, buyer, fiatRates: [...usedRates.values()] satisfies FiatRowRates };
 	});
 	return { rows: converted, missingUnits: [...missingUnits] };
 }

--- a/src/services/transaction-report/fiat/index.ts
+++ b/src/services/transaction-report/fiat/index.ts
@@ -39,6 +39,12 @@ export type ReportFiatMetadata = Readonly<{
 	completeness: 'complete' | 'partial';
 	/** Units the report holds that no rate covers. Their money has no fiat figure. */
 	unpricedUnits: string[];
+	/**
+	 * The rates behind every figure, but only when one set covers the whole
+	 * report. Under AccountingDate each request has its own rate, so a single
+	 * report-wide rate would be a fiction; those rates sit on the rows instead.
+	 */
+	rates: Array<{ unit: string; rate: string; source: 'supplied' | 'coingecko' }> | null;
 }>;
 
 function collectReportUnits(rows: readonly ReportRow[]): string[] {
@@ -91,6 +97,13 @@ export async function applyReportFiat(
 			attribution: needsProvider ? COINGECKO_ATTRIBUTION : null,
 			isDemoKey,
 			demoHistoryDays: isDemoKey ? DEMO_HISTORY_DAYS : null,
+			rates:
+				fiat.mode === 'PeriodAverage'
+					? reportUnits
+							.map((unit) => table.rateFor(unit, window))
+							.map((lookup, index) => (lookup == null ? null : { unit: reportUnits[index], ...lookup }))
+							.filter((rate): rate is NonNullable<typeof rate> => rate != null)
+					: null,
 			completeness: applied.missingUnits.length > 0 ? 'partial' : 'complete',
 			unpricedUnits: [...applied.missingUnits],
 		},

--- a/src/services/transaction-report/fiat/rates.ts
+++ b/src/services/transaction-report/fiat/rates.ts
@@ -25,6 +25,9 @@ export type FiatPricePoint = readonly [number, number];
 
 export type FiatRateContext = Readonly<{ at: Date }> | Readonly<{ from: Date; to: Date }>;
 
+/** The rate each asset was converted at, so a reader can redo the arithmetic. */
+export type FiatRowRates = ReadonlyArray<Readonly<{ unit: string; rate: string; source: FiatRateSource }>>;
+
 export type FiatRateLookup = Readonly<{ rate: string; source: FiatRateSource }> | null;
 
 /** Rate precision. Prices below a cent still have to survive the round trip. */

--- a/src/services/transaction-report/records.ts
+++ b/src/services/transaction-report/records.ts
@@ -1,5 +1,6 @@
 import { serializeReportAmount } from '@/utils/asset-units';
 import { addAmounts, subtractAmounts, type AtomicAmount } from './amounts';
+import type { FiatRowRates } from './fiat/rates';
 import {
 	calculateBuyerMetrics,
 	calculateSellerMetrics,
@@ -332,6 +333,8 @@ export function buildReportRow(
 		feeComponentScope,
 		timestamps,
 		settlement,
+		/** Filled in by the fiat pass when a currency was asked for. */
+		fiatRates: null as FiatRowRates | null,
 		seller,
 		buyer,
 		actorCardanoFeeAllocation,

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -39008,6 +39008,33 @@
                                                                     "items": {
                                                                         "type": "string"
                                                                     }
+                                                                },
+                                                                "rates": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rate": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "supplied",
+                                                                                    "coingecko"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rate",
+                                                                            "source"
+                                                                        ]
+                                                                    }
                                                                 }
                                                             },
                                                             "required": [
@@ -39018,7 +39045,8 @@
                                                                 "isDemoKey",
                                                                 "demoHistoryDays",
                                                                 "completeness",
-                                                                "unpricedUnits"
+                                                                "unpricedUnits",
+                                                                "rates"
                                                             ]
                                                         },
                                                         "warnings": {
@@ -41701,6 +41729,33 @@
                                                                     "items": {
                                                                         "type": "string"
                                                                     }
+                                                                },
+                                                                "rates": {
+                                                                    "type": "array",
+                                                                    "nullable": true,
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "unit": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "rate": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "source": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "supplied",
+                                                                                    "coingecko"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "unit",
+                                                                            "rate",
+                                                                            "source"
+                                                                        ]
+                                                                    }
                                                                 }
                                                             },
                                                             "required": [
@@ -41711,7 +41766,8 @@
                                                                 "isDemoKey",
                                                                 "demoHistoryDays",
                                                                 "completeness",
-                                                                "unpricedUnits"
+                                                                "unpricedUnits",
+                                                                "rates"
                                                             ]
                                                         },
                                                         "warnings": {


### PR DESCRIPTION
Filter UI for the report, and the export context that explains a download.

- `feat(reports): move export context into a README`. A downloaded ZIP now carries a README naming the filters, the time zone, the bucket, and the rate that produced it, so a CSV read months later still says what it is.
- `feat(reports): group the dashboard filters and offer known addresses`. Filters group by scope, rule, and currency, and the address field offers the addresses the payment source already knows.
- `fix(reports): stop the filter headings colliding and explain the states`, `fix(reports): show the unfiltered default as a ticked row`, `fix(reports): align the three filter column headings`. Three follow-up fixes to that filter bar.

Stacked on #761.
