### PR TITLE
fix(x402): gate the setup guide on backend rail readiness

### DIFF
--- a/docs/adr/0008-standard-evm-x402-payment-rail.md
+++ b/docs/adr/0008-standard-evm-x402-payment-rail.md
@@ -5,6 +5,10 @@
 Accepted. Decision 2 (per-wallet budgets) is amended by
 [ADR 0016](0016-x402-key-scoped-spend-caps.md): spend caps are per-API-key
 usage credits; `X402WalletBudget` and `/x402/budgets` no longer exist.
+Decision 5 and the Consequences section still describe the original
+wallet-budget model. They are kept as written, because an ADR records the
+decision as it was made, and carry an inline superseded note where they
+mention budgets.
 
 ## Context
 
@@ -37,6 +41,8 @@ wire-compatible with `Mainnet` / `Preprod` request and response schemas.
    sell side (`canPay`) is an x402 facilitator that verifies and settles
    inbound payments for a registered resource. `canAdmin` manages x402
    rail config, wallets, networks, and budgets.
+   (Superseded by ADR 0016: a payment is charged against the API key's
+   usage credits, not a wallet budget, and there are no budgets to manage.)
 6. V1 Cardano registry behavior stays frozen and does not advertise x402.
    V2 registry entries may advertise x402 Supported Payment Sources.
 
@@ -55,7 +61,9 @@ performs an outbound resource fetch, so there is no SSRF surface and no
 proxied response to cache.
 
 Managed wallet spend is bounded by API-key CAIP-2 chain limits and
-wallet budget rows before a payment payload is signed. On the sell side,
+wallet budget rows before a payment payload is signed. (Superseded by
+ADR 0016: the bound is the API key's usage credits for the
+`eip155:<chainId>:<asset>` unit, and only when the key is `usageLimited`.) On the sell side,
 settlements are deduplicated by canonical x402 payment payload hash, and
 a replay is honored only when it is bound to the same registered source.
 

--- a/frontend/src/components/x402/X402SetupGuide.tsx
+++ b/frontend/src/components/x402/X402SetupGuide.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/card';
 import { cn, shortenAddress } from '@/lib/utils';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { useX402Networks, useX402Wallets } from '@/lib/hooks/useX402';
+import { useRailReadiness } from '@/lib/hooks/useRailReadiness';
 import {
   hasPurchasingWalletOnEnabledNetworks,
   walletsForNetworks,
@@ -26,20 +27,25 @@ type DialogKind = 'wallet' | 'chain' | null;
  * gates the later actions until a managed wallet exists. It reuses the same dialogs
  * the tabs use, so there is no second source of truth for creating these records.
  *
- * It hides itself once at least one capability (facilitator for receiving, or a
- * Purchasing wallet for paying) exists — i.e. the rail can actually do something —
- * or when collapsed by the user.
+ * It hides itself once at least one capability (receiving, or a Purchasing wallet
+ * for paying) exists — i.e. the rail can actually do something — or when collapsed
+ * by the user.
  */
 export function X402SetupGuide() {
   const queryClient = useQueryClient();
   const { apiClient, authorized } = useAppContext();
   const { wallets, isLoading: walletsLoading } = useX402Wallets();
   const { networks, isLoading: networksLoading } = useX402Networks();
+  const {
+    x402: x402Readiness,
+    isLoading: readinessLoading,
+    isUnavailable: readinessUnavailable,
+  } = useRailReadiness();
   const [openDialog, setOpenDialog] = useState<DialogKind>(null);
   const [walletType, setWalletType] = useState<X402Wallet['type']>('Selling');
   const [collapsed, setCollapsed] = useState(false);
 
-  const loading = walletsLoading || networksLoading;
+  const loading = walletsLoading || networksLoading || readinessLoading;
   const envWallets = useMemo(() => walletsForNetworks(wallets, networks), [wallets, networks]);
   // Wallets are split by direction: a Selling wallet settles inbound payments (facilitator),
   // a Purchasing wallet funds outbound ones. Each capability needs its own type.
@@ -50,22 +56,29 @@ export function X402SetupGuide() {
     () => hasPurchasingWalletOnEnabledNetworks(wallets, networks),
     [wallets, networks],
   );
-  // A chain settles either through an owned Selling wallet or a remote facilitator URL —
-  // both count as "receiving works", so a remote-only rail doesn't re-show the guide.
-  const hasFacilitator = networks.some(
-    (network) => network.isEnabled && (!!network.facilitatorWalletId || !!network.facilitatorUrl),
-  );
-  const completedCount = [hasFacilitator, canPay].filter(Boolean).length;
-  // "Usable" = at least one side works (facilitator for receiving, a Purchasing
-  // wallet for paying). We intentionally don't require both — an operator may only
-  // do one side. Spend caps are per-API-key usage credits, not a rail concern.
-  const usable = hasFacilitator || canPay;
+  // Backend-owned, not re-derived here. A facilitator alone does not make receiving
+  // work: `isReady` also requires an enabled chain with a usable RPC URL and exactly
+  // one facilitator mode, so deriving this from the chain list marked the rail done
+  // in states where settle would fail.
+  const canReceive = x402Readiness?.isReady ?? false;
+  const completedCount = [canReceive, canPay].filter(Boolean).length;
+  // "Usable" = at least one side works (receiving, or a Purchasing wallet for
+  // paying). We intentionally don't require both — an operator may only do one
+  // side. Spend caps are per-API-key usage credits, not a rail concern.
+  //
+  // `canPay` stays client-side on purpose: the readiness payload reports the
+  // purchasing-wallet check for one chain (the ready or best one), while this guide
+  // asks whether the rail can pay on ANY enabled chain.
+  const usable = canReceive || canPay;
 
   // Wait for auth before deciding anything: the x402 hooks return empty arrays while
   // disabled (unauthenticated), which would otherwise flash the guide on a fully
   // configured rail. Then avoid flashing during the real load, and step aside once the
   // rail can actually do something.
-  if (!apiClient || !authorized || loading || usable) return null;
+  //
+  // A failed readiness request means UNKNOWN, not "nothing is configured", so stay
+  // hidden rather than telling an operator with a working rail to set it up.
+  if (!apiClient || !authorized || loading || readinessUnavailable || usable) return null;
 
   // Prefer attaching a facilitator to an existing enabled chain — Base ships
   // preconfigured by the seed — and fall back to adding a brand new chain. Never pick a
@@ -113,21 +126,21 @@ export function X402SetupGuide() {
   // confusing standalone "create a wallet" step that the next steps then re-demand.
   const steps = [
     {
-      done: hasFacilitator,
+      done: canReceive,
       icon: Link2,
       title: 'Enable receiving payments',
       body: 'Configure a remote facilitator, or assign a Selling wallet for self-hosted settlement, so your agents can be paid over x402.',
       detail: (
         <>
           {walletChips('Selling')}
-          {hasFacilitator && configuredChain && (
+          {canReceive && configuredChain && (
             <p className="pt-1.5 text-xs text-green-600 dark:text-green-500">
               Facilitator set on {configuredChain.displayName}.
             </p>
           )}
         </>
       ),
-      actionLabel: hasFacilitator ? 'Manage chains' : 'Configure facilitator',
+      actionLabel: canReceive ? 'Manage chains' : 'Configure facilitator',
       onAction: () => setOpenDialog('chain'),
     },
     {


### PR DESCRIPTION
Finishes the two CodeRabbit findings from #746 / #747 that were resolved on the thread but never actually landed in the code. Verified against `dev` at `46f49c9f7` by reading the merged tree, not the thread status.

## 1. Setup guide could hide itself on a rail that cannot receive

`X402SetupGuide` derived "receiving works" from the chain list: any enabled chain with a facilitator wallet or URL. `evaluateX402Readiness` requires more — a usable RPC URL and exactly one facilitator mode — so a chain with a facilitator and a blank RPC URL hid the guide and marked the step done while settle would fail.

It now reads `isReady` from `useRailReadiness`, the same source `X402SetupWelcome` already uses.

Two deliberate limits, both commented in the diff:

- **`canPay` stays client-side.** The readiness payload reports the purchasing-wallet check for one chain (the ready or best one), while this guide asks whether the rail can pay on *any* enabled chain.
- **A failed readiness request hides the guide** rather than showing it. Readiness is then unknown, not false, and telling an operator with a working rail to set it up is the worse error. This matches the contract `useRailReadiness` documents for `isUnavailable`.

`hasFacilitator` is renamed to `canReceive`, since it is no longer a fact about facilitator rows.

The other half of that finding — a Purchasing wallet on a *disabled* chain suppressing setup — did land in #746 as `hasPurchasingWalletOnEnabledNetworks`, and is untouched here.

## 2. ADR 0008 still described wallet budgets as live

The status header amended Decision 2 only. Decision 5 and the Consequences section still said buy-side payments are charged against a wallet budget and that admins manage budgets.

The original text stays as written, because an ADR records the decision as it was made. Each budget mention now carries an inline superseded note, and the status header names those sections.

## Verification

- `pnpm -C frontend run typecheck` — exit 0
- `pnpm -C frontend run lint` (`eslint . --max-warnings=0`) — clean
- `pnpm -C frontend run format:check` — `All matched files use Prettier code style!`
- `npx tsx --test src/lib/x402-rail.test.ts` — `pass 7, fail 0`

The root jest suite was not run: its `roots` are `src` and `packages`, and this PR touches only `frontend/` and a Markdown file, so it exercises none of it.

## Not addressed here

While reading `X402SetupGuide` I noticed a **pre-existing** issue this PR does not touch: the component returns `null` whenever `usable` is true, so by the time the steps render, both `done` flags are false by construction and `completedCount` is always 0. The step checkmarks and the "N of 2" counter are therefore dead. That predates the budget removal and needs its own change.
