### PR TITLE
docs(reports): add design records

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -143,5 +143,8 @@ jobs:
       - name: Run Frontend TypeScript Check
         run: pnpm run typecheck:frontend
 
+      - name: Run Frontend Tests
+        run: pnpm run test:frontend
+
       - name: Run Next Build
         run: cd frontend && pnpm run build

--- a/docs/wayfinder/transaction-financial-reporting/map.md
+++ b/docs/wayfinder/transaction-financial-reporting/map.md
@@ -1,0 +1,61 @@
+---
+title: Chart transaction financial reporting and exports
+label: wayfinder:map
+status: open
+based_on: feat/transaction-csv-export@ebf6536e
+---
+
+## Destination
+
+REPORTED: Give an authorized admin one Payment Source report for transaction-level and aggregated seller revenue, buyer spend, refunds, protocol fees, Cardano transaction fees, and net values. The same filters must drive dashboard cards, history charts, paginated JSON, direct CSV files, and a ZIP package. Reports must cover Web3CardanoV1 and Web3CardanoV2 and calculate on demand from existing payment and purchase records.
+
+## Notes
+
+- Planning only. Do not implement production code in this map.
+- VERIFIED: The baseline is `feat/transaction-csv-export` at `ebf6536e`.
+- VERIFIED: The current browser export builds ten CSV columns in `frontend/src/pages/transactions.tsx:313` and downloads one client-side file at `frontend/src/pages/transactions.tsx:387`.
+- VERIFIED: The current download query sends network, cursor, history, and limit only at `frontend/src/components/transactions/download-details.helpers.ts:12`.
+- VERIFIED: Payment and purchase list queries select Web3CardanoV1 by default when source type and address filters are absent at `src/routes/api/payments/queries.ts:17` and `src/routes/api/purchases/queries.ts:17`.
+- Local tracker convention: child tickets live in `tickets/`. A ticket is frontier when it is open, unassigned, and every `blocked_by` ticket is closed.
+
+## Confirmed constraints
+
+- REPORTED: Every report requires one accessible Payment Source. It may filter managed wallets, external addresses, buyer or seller role, states, date range, date basis, and revenue mode. Every aggregate must use the same filters as its rows. The selected Payment Source fixes the source version.
+- REPORTED: Billable revenue is the default. Cash received and requested gross remain selectable. Seller output separates gross revenue, protocol fees, seller Cardano fees, and net revenue. Buyer output separates gross spend, refunds, buyer Cardano fees, and net spend.
+- REPORTED: V1 protocol fees must use the payment source rate and the contract formula during reporting. The report marks a withdrawn fee as calculated and an unlocked ResultSubmitted fee as projected. V2 protocol fees are exact zero. Other states treat the fee as not applicable.
+- REPORTED: Each metric uses wide ADA, USDM, and USDCx decimal-string columns in CSV, with no parallel raw columns. Other assets remain raw atomic strings only inside `other_assets_json`. JSON includes raw and decimal strings plus asset metadata.
+- REPORTED: Exact per-asset values are the default. Fiat is optional. Supplied rates override configured CoinGecko rates. Bucket-average historical rates are the fiat default, with a per-row accounting-date option. Outputs name the rate mode, source, date, and currency.
+- REPORTED: Date basis can be request creation, funds-locked block time, or revenue-recognition time. API time zones default to UTC. The UI sends the browser IANA time zone unless the admin overrides it. Chart buckets switch between daily, weekly, and monthly, with a manual override.
+- REPORTED: JSON is paginated. CSV and ZIP responses stream synchronously and are not stored as report jobs. Direct downloads remain available for `transactions.csv`, `wallet-summary.csv`, and `totals.csv`.
+- REPORTED: Read permission is sufficient. Payment Source access, wallet scopes, and network limits still apply. Soft-deleted wallets and archived Payment Sources remain reportable when those checks pass, and the output labels them.
+- REPORTED: The admin dashboard defaults to 30 days, all wallets, buyer and seller roles, all states, and Billable revenue. It needs cards, history charts, wallet breakdowns, and the expanded transaction export dialog.
+
+## Open tickets
+
+- [Define the reporting metric contract](tickets/define-reporting-metric-contract.md) (`wayfinder:grilling`, frontier)
+- [Trace authorization for archived reporting](tickets/trace-archived-report-authorization.md) (`wayfinder:task`, frontier)
+- [Define filters and amount representation](tickets/define-filter-and-amount-contract.md) (`wayfinder:grilling`)
+- [Fiat conversion contract](tickets/choose-fiat-conversion-contract.md) (`wayfinder:grilling`)
+- [Define the shared report query contract](tickets/define-report-query-contract.md) (`wayfinder:grilling`)
+- [Streaming export boundary](tickets/choose-streaming-export-boundary.md) (`wayfinder:grilling`)
+- [Prototype the dashboard and export flow](tickets/prototype-dashboard-and-export-flow.md) (`wayfinder:prototype`)
+- [Set report resource and failure limits](tickets/set-report-resource-and-failure-limits.md) (`wayfinder:grilling`)
+- [Finalize the reporting API contract](tickets/define-reporting-api-contract.md) (`wayfinder:grilling`)
+- [Confirm cross-format acceptance](tickets/confirm-cross-format-acceptance.md) (`wayfinder:grilling`)
+
+## Decisions so far
+
+- [Research historical fiat rate windows](tickets/research-historical-fiat-rate-windows.md): VERIFIED: one automatic-range call per asset and quote currency can cover the report window. Demo and Basic limit history to one and two years. Missing samples remain unavailable. The fiat and resource tickets must choose averaging, partial coverage, and a commercial plan.
+
+## Not yet specified
+
+- INFERRED: Existing records might not retain enough relation data to enforce historical wallet scopes after deletion. The authorization trace must settle this before the API contract.
+- INFERRED: Extending the current payment and purchase endpoints might preserve compatibility better than a new detail endpoint. The response and pagination contract must settle this.
+- INFERRED: The supported report range and commercial CoinGecko plan remain unset. The resource-limit ticket must choose them from the verified provider windows and call budget.
+
+## Out of scope
+
+- REPORTED: Scheduled exports and stored report jobs.
+- REPORTED: x402 payments, swaps, registry operations, and wallet fund transfers.
+- REPORTED: New reporting tables, materialized aggregates, or persistent reporting caches in the first implementation.
+- REPORTED: A mandatory fiat conversion when an asset has no approved rate.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/choose-fiat-conversion-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/choose-fiat-conversion-contract.md
@@ -22,7 +22,7 @@ How should supplied rates and CoinGecko historical data produce repeatable bucke
 - REPORTED: Fiat is optional. Exact per-asset totals remain authoritative.
 - REPORTED: A supplied asset rate wins. CoinGecko may fill only missing rates when configured.
 - REPORTED: Charts and exports default to one average historical rate per bucket. A caller may select a rate at each row's accounting date.
-- REPORTED: Every fiat result carries its currency, source, method, and rate date or date range.
+- REPORTED: Every fiat result carries its currency, source, method, and rate date or date range. A bucket average also carries the provenance named in [research-historical-fiat-rate-windows.md](research-historical-fiat-rate-windows.md): cadence, sample count, first and last sample timestamps, asset identity, quote currency, and fetch time. JSON and CSV both export these fields. A rate date alone cannot identify the observations behind an average when coverage is partial or the cadence changes.
 
 ## Evidence
 
@@ -34,6 +34,6 @@ How should supplied rates and CoinGecko historical data produce repeatable bucke
 
 - Precedence, rate lookup identity, request-scoped deduplication, rounding, precision, and missing-rate behavior are exact.
 - Bucket-average and per-row formulas name their timestamp source and provider observations.
-- JSON and CSV metadata can reproduce which rate affected each value.
+- JSON and CSV metadata can reproduce which rate affected each value, including the bucket-average provenance listed above.
 - Provider failure cannot prevent the default exact-asset report.
 - Client construction selects `demoAPIKey` or `proAPIKey` to match the configured CoinGecko environment.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/choose-fiat-conversion-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/choose-fiat-conversion-contract.md
@@ -1,0 +1,39 @@
+---
+title: Choose the fiat conversion contract
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - define-reporting-metric-contract.md
+  - research-historical-fiat-rate-windows.md
+  - define-filter-and-amount-contract.md
+blocks:
+  - define-report-query-contract.md
+  - prototype-dashboard-and-export-flow.md
+  - set-report-resource-and-failure-limits.md
+---
+
+## Question
+
+How should supplied rates and CoinGecko historical data produce repeatable bucket-average or per-row fiat values without changing exact asset totals?
+
+## Confirmed constraints
+
+- REPORTED: Fiat is optional. Exact per-asset totals remain authoritative.
+- REPORTED: A supplied asset rate wins. CoinGecko may fill only missing rates when configured.
+- REPORTED: Charts and exports default to one average historical rate per bucket. A caller may select a rate at each row's accounting date.
+- REPORTED: Every fiat result carries its currency, source, method, and rate date or date range.
+
+## Evidence
+
+- VERIFIED: The current invoice path combines caller mappings with CoinGecko results at `src/routes/api/invoice/monthly/shared.ts:293`.
+- VERIFIED: The current invoice path fails when an asset still has no conversion at `src/routes/api/invoice/monthly/shared.ts:393`.
+- VERIFIED: Invoice output types keep conversion factor, decimals, unit, and conversion date at `src/utils/invoice/template.ts:92`.
+
+## Resolve when
+
+- Precedence, rate lookup identity, request-scoped deduplication, rounding, precision, and missing-rate behavior are exact.
+- Bucket-average and per-row formulas name their timestamp source and provider observations.
+- JSON and CSV metadata can reproduce which rate affected each value.
+- Provider failure cannot prevent the default exact-asset report.
+- Client construction selects `demoAPIKey` or `proAPIKey` to match the configured CoinGecko environment.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/choose-streaming-export-boundary.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/choose-streaming-export-boundary.md
@@ -1,0 +1,35 @@
+---
+title: Choose the streaming export boundary
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - define-report-query-contract.md
+blocks:
+  - set-report-resource-and-failure-limits.md
+  - define-reporting-api-contract.md
+---
+
+## Question
+
+How should the service stream direct CSV and ZIP responses from one filtered calculation path while keeping files complete, internally consistent, and safe under disconnects or query failures?
+
+## Confirmed constraints
+
+- REPORTED: Exports run synchronously. The service does not create stored report jobs.
+- REPORTED: Direct files are `transactions.csv`, `wallet-summary.csv`, and `totals.csv`. The ZIP package contains those same files.
+- REPORTED: All files use the same Payment Source, wallet, address, role, state, date range, date basis, mode, and time-zone filters. They also use the same asset representation and fiat conversion settings. The selected Payment Source fixes the source version.
+- REPORTED: Each metric uses wide ADA, USDM, and USDCx decimal-string columns in CSV, with no parallel raw columns. Other assets remain as raw atomic strings only in `other_assets_json`.
+
+## Evidence
+
+- VERIFIED: The current UI creates one CSV Blob in browser memory at `frontend/src/pages/transactions.tsx:387`.
+- VERIFIED: Its CSV encoder doubles quotation marks and quotes every field at `frontend/src/pages/transactions.tsx:374`.
+- VERIFIED: The current download loop treats a failed page as the end of available data and can return earlier pages at `frontend/src/components/transactions/DownloadDetailsDialog.tsx:58`.
+
+## Resolve when
+
+- The ticket defines when headers become committed and how a pre-stream or mid-stream failure reaches the caller.
+- Direct files and ZIP members share column definitions, sort order, totals, metadata, and snapshot semantics.
+- The approach states its memory bound and cancellation behavior without adding a report-job subsystem.
+- CSV injection handling, RFC 4180 encoding, filenames, and content-disposition behavior are exact.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/confirm-cross-format-acceptance.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/confirm-cross-format-acceptance.md
@@ -1,0 +1,32 @@
+---
+title: Confirm cross-format acceptance
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - define-reporting-api-contract.md
+blocks: []
+---
+
+## Question
+
+What acceptance evidence proves that dashboard values, paginated JSON, each direct CSV, and every ZIP member apply the same filters, formulas, wallet groups, amount precision, and fiat metadata?
+
+## Confirmed constraints
+
+- REPORTED: State and wallet filters affect rows and every aggregate.
+- REPORTED: `transactions.csv`, `wallet-summary.csv`, and `totals.csv` are available directly and inside the ZIP package.
+- REPORTED: Exact assets remain authoritative when fiat is disabled or unavailable.
+- REPORTED: V1 and V2, active and archived records, buyer and seller roles, and all revenue modes need acceptance coverage.
+
+## Evidence
+
+- VERIFIED: Current CSV values are built separately in the Transactions page at `frontend/src/pages/transactions.tsx:313`.
+- VERIFIED: Current income and spending summaries use independent route implementations at `src/routes/api/payments/income/index.ts:149` and `src/routes/api/purchases/spending/index.ts:149`.
+
+## Resolve when
+
+- A test matrix covers formulas, filters, permission boundaries, deleted records, pagination, streaming failures, and asset conversion.
+- For one fixed data snapshot, detail rows sum to wallet summaries and totals for every metric and asset.
+- Direct CSV files and ZIP members use the same schemas, ordering, metadata, and escaping rules.
+- UI acceptance names the displayed metric, time zone, bucket, fiat method, and active filters for every chart or total.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/define-filter-and-amount-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/define-filter-and-amount-contract.md
@@ -1,0 +1,40 @@
+---
+title: Define filters and amount representation
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - define-reporting-metric-contract.md
+blocks:
+  - choose-fiat-conversion-contract.md
+  - define-report-query-contract.md
+  - prototype-dashboard-and-export-flow.md
+---
+
+## Question
+
+What exact filter fields, defaults, date semantics, and amount shapes must every detail row, aggregate, chart, JSON page, and export share?
+
+## Confirmed constraints
+
+- REPORTED: Every request selects one Payment Source. Optional filters cover managed wallet, external address, buyer or seller role, state, date range, date basis, revenue mode, time zone, and chart bucket. The selected Payment Source fixes the source version.
+- REPORTED: External address matching covers payout, return, and counterparty addresses, but remains separate from managed-wallet selection.
+- REPORTED: Date basis options are request creation, funds-locked block time, and revenue-recognition time. API defaults to UTC. The UI supplies a browser IANA time zone unless overridden.
+- REPORTED: Each metric uses wide ADA, USDM, and USDCx decimal-string columns in CSV, with no parallel raw columns. Other assets use raw strings only inside `other_assets_json`.
+- REPORTED: JSON returns atomic strings, decimal strings, and asset metadata. Decimal conversion must not pass monetary values through Number.
+
+## Evidence
+
+- VERIFIED: Existing download filtering uses only `createdAt` at `frontend/src/components/transactions/DownloadDetailsDialog.tsx:141`.
+- VERIFIED: PaymentRequest and PurchaseRequest keep buyer and seller return addresses at `prisma/schema.prisma:807` and `prisma/schema.prisma:895`.
+- VERIFIED: Transaction records keep Cardano fees and block time at `prisma/schema.prisma:187`.
+- VERIFIED: Existing income and spending endpoints accept a time zone at `src/routes/api/payments/income/index.ts:44` and `src/routes/api/purchases/spending/index.ts:44`. They group by local day or month at `src/routes/api/payments/income/index.ts:139` and `src/routes/api/purchases/spending/index.ts:139`.
+
+## Resolve when
+
+- One input schema names all enums, null rules, multi-select behavior, date inclusivity, and defaults.
+- One row schema names role, state, source version, managed wallet, external addresses, accounting timestamp, fee provenance, and all amount fields.
+- The wallet summary defines its grouping key, role handling, deleted label, and missing-wallet behavior. It states whether external addresses are filters only or also groups.
+- PaymentRequest maps to seller reporting and PurchaseRequest maps to buyer reporting. Wallet summary amounts must reconcile with filtered totals.
+- CSV headers and JSON asset objects are exact. They define ADA, USDM, USDCx, and `other_assets_json` behavior.
+- The contract states how filters compose and how empty results differ from invalid filters.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/define-report-query-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/define-report-query-contract.md
@@ -1,0 +1,39 @@
+---
+title: Define the shared report query contract
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - trace-archived-report-authorization.md
+  - define-filter-and-amount-contract.md
+  - choose-fiat-conversion-contract.md
+blocks:
+  - choose-streaming-export-boundary.md
+  - prototype-dashboard-and-export-flow.md
+  - set-report-resource-and-failure-limits.md
+  - define-reporting-api-contract.md
+---
+
+## Question
+
+What shared report contract can serve the dashboard and every export before HTTP transport details are final while defining calculation boundaries plus row and summary shapes and stable order?
+
+## Confirmed constraints
+
+- REPORTED: One accessible Payment Source is mandatory. The selected source fixes network and source version.
+- REPORTED: Filtered detail JSON uses pagination. Summary JSON supplies cards, chart series, wallet summaries, and totals.
+- REPORTED: Rows and summaries use the same metric, wallet-grouping, asset, date, state, role, and fiat rules.
+- REPORTED: Calculation remains on demand from PaymentRequest and PurchaseRequest records in the first implementation.
+
+## Evidence
+
+- VERIFIED: Existing payment income and purchase spending endpoints already calculate asset totals and time series at `src/routes/api/payments/income/index.ts:149` and `src/routes/api/purchases/spending/index.ts:149`.
+- VERIFIED: Existing list endpoints apply wallet scope filters at `src/routes/api/payments/queries.ts:40` and `src/routes/api/purchases/queries.ts:43`.
+- VERIFIED: PaymentRequest keeps source and wallet IDs from `prisma/schema.prisma:774`, then state, fee, transaction, and amount fields through `prisma/schema.prisma:821`. PurchaseRequest keeps the corresponding fields from `prisma/schema.prisma:860` through `prisma/schema.prisma:909`.
+
+## Resolve when
+
+- Domain inputs and outputs are exact and do not depend on CSV, ZIP, or React types.
+- Detail and summary models use one vocabulary: metric names, amount shapes, fee provenance, wallet keys, and accounting timestamps.
+- Pagination is exact. The resolution defines stable sort, snapshot assumptions, and empty-result behavior.
+- Authorization inputs come from authenticated context rather than caller-supplied scope IDs.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/define-reporting-api-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/define-reporting-api-contract.md
@@ -1,0 +1,39 @@
+---
+title: Finalize the reporting API contract
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - define-report-query-contract.md
+  - choose-streaming-export-boundary.md
+  - prototype-dashboard-and-export-flow.md
+  - set-report-resource-and-failure-limits.md
+blocks:
+  - confirm-cross-format-acceptance.md
+---
+
+## Question
+
+After the query, export, prototype, and resource decisions are closed, which authenticated endpoints and response schemas expose detail rows, totals, chart series, wallet summaries, direct CSV files, and the ZIP package while preserving current clients?
+
+## Confirmed constraints
+
+- REPORTED: Read permission is sufficient. Every request requires an accessible Payment Source and enforces wallet scopes and network limits.
+- REPORTED: The UI needs paginated JSON for rows and JSON summaries for cards, charts, and wallet breakdowns.
+- REPORTED: Direct CSV endpoints return transactions, wallet summary, or totals. A ZIP endpoint includes all three files.
+- REPORTED: V1 and V2 records must be explicit. The selected Payment Source fixes the source version, so reporting must not fall back to the current V1 list default.
+- REPORTED: Existing payment and purchase detail endpoints may be extended when that keeps the contract clear. Separate reporting endpoints remain an option.
+
+## Evidence
+
+- VERIFIED: Payment and purchase list queries currently default to Web3CardanoV1 at `src/routes/api/payments/queries.ts:17` and `src/routes/api/purchases/queries.ts:17`.
+- VERIFIED: Current income and spending routes use `readAuthenticatedEndpointFactory` and check network limits at `src/routes/api/payments/income/index.ts:149` and `src/routes/api/purchases/spending/index.ts:149`.
+- VERIFIED: The current browser export fetches complete list pages and may return pages collected before an error at `frontend/src/components/transactions/DownloadDetailsDialog.tsx:51`.
+
+## Resolve when
+
+- Each route has an exact method, path, input, output, media type, status code, and pagination rule.
+- The contract names the shared reporting calculation boundary used by JSON and exports.
+- Export status, header commitment, and pre-stream or mid-stream failure behavior match the streaming decision.
+- Authorization order and not-found behavior prevent Payment Source or wallet enumeration.
+- Compatibility notes state which existing schemas change and which remain unchanged.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/define-reporting-metric-contract.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/define-reporting-metric-contract.md
@@ -1,0 +1,41 @@
+---
+title: Define the reporting metric contract
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by: []
+blocks:
+  - define-filter-and-amount-contract.md
+  - choose-fiat-conversion-contract.md
+---
+
+## Question
+
+What exact row-level and aggregate formulas define seller revenue, buyer spend, refunds, protocol fees, Cardano transaction fees, and net values for every relevant state, source version, and revenue mode?
+
+## Confirmed constraints
+
+- REPORTED: Billable is the default revenue mode. It includes Withdrawn, unlocked ResultSubmitted, and the seller share of DisputedWithdrawn.
+- REPORTED: Cash received includes Withdrawn and DisputedWithdrawn. Requested gross includes requested amounts even when they remain pending or later refund, subject to selected state filters.
+- REPORTED: Seller metrics show gross revenue, protocol fees, seller Cardano fees, and net revenue separately. Protocol fees reduce their own asset units. Seller Cardano fees reduce ADA only.
+- REPORTED: Buyer metrics show gross spend, returned assets, buyer Cardano fees, and net spend separately. Returned assets reduce their own units. Buyer Cardano fees increase ADA spend only.
+- REPORTED: V1 protocol fees use the selected Payment Source rate and current contract formula. V2 protocol fees are exact zero. Reports distinguish calculated, projected, zero, and not-applicable values.
+
+## Evidence
+
+- VERIFIED: PaymentRequest stores both Cardano fee totals, RequestedFunds, WithdrawnForBuyer, and WithdrawnForSeller at `prisma/schema.prisma:814`.
+- VERIFIED: PurchaseRequest stores both Cardano fee totals, PaidFunds, WithdrawnForBuyer, and WithdrawnForSeller at `prisma/schema.prisma:883`.
+- VERIFIED: V1 collection calculates a proportional fee for every asset and applies a lovelace minimum at `packages/payment-source-v1/src/services/payments/collection/service.ts:181`. The minimum is `1435230n` at `packages/payment-core/src/config.ts:326`.
+- VERIFIED: V2 collection assigns zero protocol fees at `packages/payment-source-v2/src/services/payments/collection/service.ts:172`.
+- VERIFIED: Transaction sync attributes seller and buyer Cardano fees by redeemer at `src/services/transactions/tx-sync/util/index.ts:123` and splits a batch fee across entries at `src/services/transactions/tx-sync/util/index.ts:497`.
+- VERIFIED: Disputed withdrawal uses an admin-paid redeemer and assigns its Cardano fee to neither buyer nor seller at `src/services/transactions/tx-sync/util/index.ts:143`.
+- VERIFIED: PaymentSource stores `feeRatePermille` at `prisma/schema.prisma:973`.
+
+## Resolve when
+
+- One state table defines the asset source, sign, accounting date, and inclusion rule for each metric and revenue mode.
+- The table covers V1 and V2, including disputed splits, refunds, pending rows, unlocked ResultSubmitted, and missing history.
+- Protocol fee rate and amount are separate row and aggregate fields for each applicable asset.
+- Admin-paid or otherwise unattributed Cardano fees have an explicit reconciliation rule. Buyer, seller, admin, and total fee values reconcile when transaction history supplies the total.
+- The contract defines zero, null, not applicable, calculated, and projected without overloading one value.
+- The formulas use BigInt atomic amounts before any decimal or fiat conversion.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/prototype-dashboard-and-export-flow.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/prototype-dashboard-and-export-flow.md
@@ -1,0 +1,40 @@
+---
+title: Prototype the dashboard and export flow
+label: wayfinder:prototype
+status: open
+parent: ../map.md
+blocked_by:
+  - define-filter-and-amount-contract.md
+  - choose-fiat-conversion-contract.md
+  - define-report-query-contract.md
+blocks:
+  - define-reporting-api-contract.md
+---
+
+## Question
+
+Which dashboard hierarchy and export controls let an admin understand seller revenue or buyer spend, narrow one Payment Source, and download the same filtered data without hiding fee or fiat assumptions?
+
+## Prototype brief
+
+Build a rough artifact with the existing admin design system. Include cards, a history chart, wallet breakdown, shared filters, metric explanations, empty and partial-fiat states, and direct or ZIP download choices. Ask the user to react to the artifact before production UI work.
+
+## Confirmed constraints
+
+- REPORTED: Default view is 30 days, all wallets, buyer and seller roles, all states, Billable revenue, and the browser IANA time zone.
+- REPORTED: Buckets default to daily for 30 days, weekly through one year, and monthly beyond one year. Manual override remains available.
+- REPORTED: The Transactions download dialog expands rather than moving export into a separate product area.
+- REPORTED: Cards and charts show gross, fees, refunds, and net as distinct values. Fiat views state their rate method and source.
+
+## Evidence
+
+- VERIFIED: `wc -l frontend/src/pages/transactions.tsx` returned `740 frontend/src/pages/transactions.tsx` on 2026-08-24.
+- VERIFIED: The current Transactions page owns CSV generation and download behavior at `frontend/src/pages/transactions.tsx:313`.
+- VERIFIED: The current download dialog exposes date presets and custom dates at `frontend/src/components/transactions/DownloadDetailsDialog.tsx:45`.
+
+## Resolve when
+
+- The artifact covers default, filtered, empty, loading, error, archived-wallet, and missing-fiat states.
+- User feedback chooses the card order, chart metric control, wallet breakdown, and export control placement.
+- The resolution states which view, model, and shared components own each concern.
+- Production work can keep `frontend/src/pages/transactions.tsx` below the 750-line source-file limit.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/research-historical-fiat-rate-windows.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/research-historical-fiat-rate-windows.md
@@ -1,0 +1,87 @@
+---
+title: Research historical fiat rate windows
+label: wayfinder:research
+status: closed
+parent: ../map.md
+assignee: fiat_rate_research
+blocked_by: []
+blocks:
+  - choose-fiat-conversion-contract.md
+---
+
+## Question
+
+Can the configured CoinGecko API supply auditable historical prices for bucket-average and per-row conversion across the required date ranges, assets, currencies, and request limits?
+
+## Resolution
+
+Resolved 2026-08-24 from official CoinGecko documentation and the installed `@coingecko/coingecko-typescript@2.0.0` package.
+
+### Range behavior
+
+- VERIFIED: [`GET /coins/{id}/market_chart/range`](https://docs.coingecko.com/reference/coins-id-market-chart-range) and [`GET /coins/{platform}/contract/{address}/market_chart/range`](https://docs.coingecko.com/reference/contract-address-market-chart-range) return timestamped price samples for one asset and one quote currency. They accept UNIX time or ISO `YYYY-MM-DD` and `YYYY-MM-DDTHH:MM` values.
+- VERIFIED: Automatic granularity is five minutes for the current day, hourly for historical ranges through 90 days, and daily at 00:00 UTC above 90 days. Explicit hourly ranges allow 100 days per request. Explicit five-minute ranges allow 10 days and require Enterprise.
+- VERIFIED: The endpoints return samples, not report-bucket averages. The application must calculate and label its own average.
+- VERIFIED: Data availability depends on when CoinGecko started tracking each asset. A requested window can return partial coverage.
+
+### Plan and call limits
+
+VERIFIED: The [CoinGecko pricing table](https://www.coingecko.com/en/api/pricing) publishes these current limits.
+
+| Plan    |                 Historical window | Monthly call credits | Calls per minute |
+| ------- | --------------------------------: | -------------------: | ---------------: |
+| Demo    |                            1 year |               10,000 |              100 |
+| Basic   |                           2 years |              100,000 |              300 |
+| Analyst | Daily from 2013, hourly from 2018 |              500,000 |              500 |
+
+VERIFIED: For one quote currency, the range method needs three asset calls for ADA, USDM, and USDCx. A cold request adds one coin-list call and one supported-currency call. Per-date history needs one call per asset and distinct UTC date.
+
+| Range      | Range calls | Cold range total | Per-date history calls |
+| ---------- | ----------: | ---------------: | ---------------------: |
+| 30 days    |           3 |                5 |                     90 |
+| 365 days   |           3 |                5 |                  1,095 |
+| 1,095 days |           3 |                5 |                  3,285 |
+
+VERIFIED: These counts use 30, 365, and 1,095 distinct UTC dates. Each leap day adds three per-date history calls.
+
+- VERIFIED: Each extra quote currency adds three range calls. Per-date history returns all quote currencies in one response.
+- VERIFIED: The installed SDK defaults to two retries at `node_modules/@coingecko/coingecko-typescript/client.d.ts:81`. One logical request can make three HTTP attempts.
+- VERIFIED: [`GET /key`](https://docs.coingecko.com/reference/key) reports the active plan and request limits. Configuration alone does not attest the subscribed plan.
+
+### Reporting consequences
+
+- VERIFIED: The [attribution guide](https://brand.coingecko.com/resources/attribution-guide) requires visible attribution near displayed data and a link to CoinGecko or its API page.
+- INFERRED: Preserve exact asset values and return null fiat fields with a structured reason when mapping, plan access, provider calls, or sample coverage fail. Never substitute a current price.
+- INFERRED: A candidate bucket method is the arithmetic mean of valid samples. Its metadata must state cadence, sample count, first and last timestamps, asset identity, quote currency, and fetch time. The fiat contract must still choose arithmetic or time-weighted averaging and a partial-sample threshold.
+- INFERRED: USDCx and USDM can have shorter histories than ADA. The implementation must disclose the actual first and last samples instead of promising the full requested range.
+- VERIFIED: The invoice client passes `demoAPIKey` even when it selects the Pro environment at `src/routes/api/invoice/monthly/shared.ts:320`. The installed SDK has separate `proAPIKey` and `demoAPIKey` options at `node_modules/@coingecko/coingecko-typescript/client.d.ts:37`. Pro reporting must select the matching key field.
+
+### Downstream decisions
+
+- The resource-limit ticket must set the maximum range and required CoinGecko plan.
+- The fiat contract must set the average formula, partial-sample threshold, unavailable-rate shape, attribution placement, and commercial redistribution rule.
+- The implementation route must fix Demo versus Pro client authentication before it depends on paid history.
+
+## Research brief
+
+Use official CoinGecko documentation and the installed SDK contract. Record the supported historical endpoints, date precision, range limits, currency coverage, plan limits, attribution rules, error behavior, and batching options. Check ADA, USDM, and USDCx identity mapping. Do not treat a current price as a historical average.
+
+## Confirmed constraints
+
+- REPORTED: Exact per-asset reporting remains the default and must work without fiat.
+- REPORTED: User-supplied rates override provider rates. Configured CoinGecko fills only missing rates.
+- REPORTED: Bucket-average historical rates are the default fiat method. Per-row accounting-date rates remain optional.
+- REPORTED: Outputs name fiat currency, source, method, and applicable rate dates.
+
+## Evidence
+
+- VERIFIED: Monthly invoice conversion first reads caller mappings, then resolves missing assets through CoinGecko at `src/routes/api/invoice/monthly/shared.ts:293`.
+- VERIFIED: The current code requests one historical date based on invoice creation time at `src/routes/api/invoice/monthly/shared.ts:315` and `src/routes/api/invoice/monthly/shared.ts:345`.
+- VERIFIED: The current code treats ADA, USDM, and USDCx as six-decimal assets at `src/routes/api/invoice/monthly/shared.ts:353`.
+
+## Resolve when
+
+- Findings link to official documentation and quote exact endpoint or plan limits.
+- A small call-count model covers 30 days, one year, and a multi-year range for three default assets.
+- The ticket states which average can be computed from provider data and what happens when a rate is unavailable.
+- The ticket names any assumption that needs a product or billing-plan decision.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/set-report-resource-and-failure-limits.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/set-report-resource-and-failure-limits.md
@@ -1,0 +1,37 @@
+---
+title: Set report resource and failure limits
+label: wayfinder:grilling
+status: open
+parent: ../map.md
+blocked_by:
+  - choose-fiat-conversion-contract.md
+  - define-report-query-contract.md
+  - choose-streaming-export-boundary.md
+blocks:
+  - define-reporting-api-contract.md
+---
+
+## Question
+
+What row, date-range, page, provider-call, memory, and time limits keep paginated JSON and synchronous exports predictable on supported networks?
+
+## Confirmed constraints
+
+- REPORTED: JSON uses pagination. CSV and ZIP stream without background jobs.
+- REPORTED: Network and wallet limits apply before report work begins.
+- REPORTED: Fiat provider failure must not block an exact per-asset report.
+- REPORTED: The implementation may add query indexes when measurements show that existing indexes do not support the final filter and sort contract.
+
+## Evidence
+
+- VERIFIED: PaymentRequest already has indexes for creation time, Payment Source plus creation time, Payment Source plus state, and Payment Source plus pay-by time at `prisma/schema.prisma:826`.
+- VERIFIED: PurchaseRequest has matching state and time indexes starting at `prisma/schema.prisma:911`.
+- VERIFIED: Current export pagination uses 100 rows per request at `frontend/src/components/transactions/download-details.helpers.ts:10`.
+- VERIFIED: V2 transaction fees can be shared across multiple request entries at `src/services/transactions/tx-sync/util/index.ts:497`.
+
+## Resolve when
+
+- Limits are numeric and tied to a measured query, serialization, memory, or provider-call cost.
+- The contract covers JSON page size, synchronous export range or row cap, timeout, disconnect, and cancellation.
+- Errors distinguish invalid filters, forbidden scope, missing rates, provider failure, limit excess, and internal failure.
+- The plan names any required index and the query shape that uses it.

--- a/docs/wayfinder/transaction-financial-reporting/tickets/trace-archived-report-authorization.md
+++ b/docs/wayfinder/transaction-financial-reporting/tickets/trace-archived-report-authorization.md
@@ -1,0 +1,38 @@
+---
+title: Trace authorization for archived reporting
+label: wayfinder:task
+status: open
+parent: ../map.md
+blocked_by: []
+blocks:
+  - define-report-query-contract.md
+---
+
+## Question
+
+How can reports include soft-deleted wallets and archived Payment Sources while still enforcing Read permission, Payment Source access, wallet scopes, and network limits?
+
+## Task
+
+Trace the authenticated request context into payment and purchase queries. Record which stable IDs remain on historical rows after wallet or Payment Source deletion. Test whether scoped and unscoped keys can distinguish the same archived records. Do not change deletion or authorization behavior in this ticket.
+
+## Confirmed constraints
+
+- REPORTED: One accessible Payment Source is mandatory for each report request.
+- REPORTED: Scoped credentials may see only matching managed wallets. Network limits still apply.
+- REPORTED: Archived Payment Sources and soft-deleted wallets remain reportable when the caller still has access. The output labels deleted records.
+- REPORTED: External payout, return, and counterparty addresses are separate filters. They do not grant access by themselves.
+
+## Evidence
+
+- VERIFIED: `buildWalletScopeFilter` limits requests by `smartContractWalletId` at `src/utils/shared/wallet-scope.ts:3`.
+- VERIFIED: Current payment queries exclude deleted Payment Sources at `src/routes/api/payments/queries.ts:34` and deleted SmartContractWallet relations at `src/routes/api/payments/queries.ts:49`.
+- VERIFIED: PaymentSource has `deletedAt` at `prisma/schema.prisma:976` and keeps HotWallet, PaymentRequest, and PurchaseRequest relations from `prisma/schema.prisma:984`.
+- VERIFIED: PaymentRequest retains Payment Source and smart-contract wallet IDs at `prisma/schema.prisma:774`. PurchaseRequest retains those IDs at `prisma/schema.prisma:860`.
+
+## Resolve when
+
+- A data-flow note names each authorization check and its order.
+- Tests or query probes show allowed and denied behavior for active, deleted, scoped, unscoped, and wrong-network cases.
+- The ticket identifies any missing historical relation that would require a migration.
+- The API ticket receives a clear authorization rule or an explicit blocker.


### PR DESCRIPTION
Re-split of the already merged #742 so the whole reporting chain reads as uniform small layers.

Content is unchanged: the top of the chain is byte identical to the previous `feat/transaction-report-download-ui` tip.