### PR TITLE
fix(reports): order the fee batch by code point, not by locale

### DIFF
--- a/src/services/transaction-report/fee-split.spec.ts
+++ b/src/services/transaction-report/fee-split.spec.ts
@@ -39,6 +39,17 @@ describe('feeShareForPaymentKey', () => {
 		expect(shares(['charlie', 'bravo', 'alpha'])).toEqual([33n, 33n, 34n]);
 	});
 
+	it('orders mixed case by code point, so the remainder does not follow the runtime locale', () => {
+		// `localeCompare` puts 'apple' before 'Banana' and 'apple' before 'Zulu'.
+		// Code point order puts every capital first. The remainder goes to the
+		// earliest shares, so the two orders disagree about who pays the extra
+		// lovelace. Code point order is the same on every runtime and locale.
+		const keys = ['apple', 'Banana', 'Zulu'];
+		expect(feeShareForPaymentKey(100n, keys, 'Banana')).toBe(34n);
+		expect(feeShareForPaymentKey(100n, keys, 'Zulu')).toBe(33n);
+		expect(feeShareForPaymentKey(100n, keys, 'apple')).toBe(33n);
+	});
+
 	it('counts a repeated key once', () => {
 		expect(feeShareForPaymentKey(100n, ['alpha', 'alpha'], 'alpha')).toBe(100n);
 	});

--- a/src/services/transaction-report/fee-split.ts
+++ b/src/services/transaction-report/fee-split.ts
@@ -33,9 +33,18 @@ export function splitFeeEvenly(fee: bigint, shareCount: number): bigint[] {
 	return Array.from({ length: shareCount }, (_unused, index) => (index < remainder ? base + 1n : base));
 }
 
-/** The batch a fee is shared across, in one fixed order on every run. */
+/**
+ * The batch a fee is shared across, in one fixed order on every run.
+ *
+ * The order decides which requests receive the remainder, so it must not depend
+ * on where the service runs. `localeCompare` reads the runtime's ICU build and
+ * default locale, and it orders mixed case differently from code points, so two
+ * deployments could hand the same leftover lovelace to different requests. A
+ * code point comparison is the same everywhere, and it matches the plain
+ * `sort()` the query layer already uses on these keys.
+ */
 function sortedBatch(paymentKeys: readonly string[]): string[] {
-	return Array.from(new Set(paymentKeys)).sort((left, right) => left.localeCompare(right));
+	return Array.from(new Set(paymentKeys)).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
 }
 
 /**


### PR DESCRIPTION
The batch order decides which requests receive the remainder when a Cardano fee does not divide evenly across the requests one transaction settles. That order was produced by `localeCompare`.

## The problem

`localeCompare` with no locale argument reads the runtime's ICU build and default locale. For mixed case it disagrees with code point order:

```
pair                 locale  codeunit  differ
["A","a"]                 1        -1   yes
["a","B"]                -1         1   yes
["Z","a"]                 1        -1   yes
```

`blockchainIdentifier` is an unconstrained `String @unique` in the schema, so mixed case is possible. Two deployments with different ICU builds or `LANG` settings could hand the same leftover lovelace to different requests for the same report.

Totals are unaffected. Only the row carrying the extra lovelace moves. But `fee-split.ts` states in its own header that the same inputs always give the same parts, and `feeShareForPaymentKey` indexes straight into this order.

It was also inconsistent with the plain `sort()` the query layer already uses on these same key lists, at `query-transactions.ts:50` and `:235`.

## The fix

A code point comparison, which is identical on every runtime and locale.

## Correcting an earlier claim

I first reported this as ICU treating punctuation as variable, so that identifiers differing only by `-` or `_` would compare equal and ordering would fall back to database order. That is wrong. Measured on this runtime, `"ab-cd".localeCompare("abcd")` returns `-1`, not `0`, and no test pair produced a tie. The real defect is the locale dependence and the mixed case ordering described above, which is narrower than first stated.

## Verification

The new test fails on the old source and passes on the new one:

```
old source, test kept:  Tests: 1 failed, 12 passed, 13 total
                        Expected: 34n   Received: 33n
with the fix:           Tests: 13 passed, 13 total
```

Full backend suite, lint, format and typecheck all pass: `3555 passed, 3557 total`.
