### PR TITLE
fix(docker): copy the frontend scripts into the build context

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,7 +1,9 @@
 name: Docker Build Check
 
-# Builds the Docker `backend-builder` stage on PRs to `dev` (the entry point of
+# Builds the Docker `frontend-builder` stage on PRs to `dev` (the entry point of
 # the PR->dev->main flow), so build-context regressions are caught before merge.
+# `frontend-builder` copies from `backend-builder`, so this one target builds
+# both of the stages that compile code.
 #
 # Why a Docker build and not a plain `tsc`: the failures this guards against are
 # build-CONTEXT regressions (e.g. the Dockerfile not COPYing `packages/`), which
@@ -10,8 +12,9 @@ name: Docker Build Check
 # checkout (as in dev.yml/e2e.yml) cannot catch these, because the omitted files
 # are present on disk there — the error only exists inside the Docker context.
 #
-# `backend-builder` is the stage that runs `prisma generate && tsc && pkgroll`
-# plus swagger generation — i.e. the stage that fails on a context regression.
+# `backend-builder` runs `prisma generate && tsc && pkgroll` plus swagger
+# generation. `frontend-builder` runs the API codegen and `next build`. Both
+# fail on a context regression, so both are built here.
 on:
   pull_request:
     branches:
@@ -22,7 +25,7 @@ permissions:
 
 jobs:
   docker-build:
-    name: Build backend-builder stage
+    name: Build backend-builder and frontend-builder stages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,11 +34,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build backend-builder stage
+      - name: Build backend-builder and frontend-builder stages
         uses: docker/build-push-action@v6
         with:
           context: .
-          target: backend-builder
+          target: frontend-builder
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ARG NEXT_PUBLIC_PAYMENT_API_BASE_URL=/api/v1
 ENV NEXT_PUBLIC_PAYMENT_API_BASE_URL=${NEXT_PUBLIC_PAYMENT_API_BASE_URL}
 COPY frontend/package.json ./
 COPY frontend/openapi-ts.config.ts ./openapi-ts.config.ts
+# `openapi-ts` runs a post-generation patch script from here. Without this the
+# stage fails with ERR_MODULE_NOT_FOUND on the script path.
+COPY frontend/scripts ./scripts
 COPY frontend/src ./src
 COPY frontend/public ./public
 COPY frontend/next.config.ts ./


### PR DESCRIPTION
## The failure

The image build dies in the frontend stage:

```
> openapi-ts && node --import tsx scripts/patch-report-export-response-types.ts
...
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/usr/src/app/frontend/scripts/patch-report-export-response-types.ts' imported from /usr/src/app/frontend/
 ELIFECYCLE  Command failed with exit code 1.
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```

## Cause

The `frontend-builder` stage copies a fixed list of files out of the build context. `frontend/scripts` was never on that list. `frontend/package.json` now runs a post-generation patch script from that directory:

```
"openapi-ts": "openapi-ts && node --import tsx scripts/patch-report-export-response-types.ts"
```

The script exists in the repo and the command works on a full checkout, so nothing outside Docker could see the gap. The file first appeared in `a13a010ae chore(reports): regenerate the API artifacts`.

## Why CI did not catch it

`docker-build-check.yml` built `target: backend-builder`. The frontend stage was never built by any job, so a frontend build-context regression could only fail at deployment.

## The change

1. `COPY frontend/scripts ./scripts` in the frontend stage.
2. The docker build check now targets `frontend-builder`. That stage begins with `COPY --from=backend-builder`, so this one target still builds the backend stage and adds the frontend stage. No extra job, no second build.

## Proof

Both directions run locally with Docker 29.4.0, against this branch's tree.

- With the `COPY` line: `docker build --target frontend-builder .` → `exit=0`, image written (`sha256:446b4110be0d…`), `next build` finished. VERIFIED
- With the `COPY` line removed and nothing else changed: `exit=1`, and the log carries the same error as the deployment: `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/usr/src/app/frontend/scripts/patch-report-export-response-types.ts'`. VERIFIED

The rename of the job and step is safe for branch protection: the `dev` ruleset's only required status check is `Build and Test`.

## Not touched

The `Transformers warning: schema … is too complex` lines from `openapi-ts` are warnings, present before this change, and do not affect the exit code.