### PR TITLE
fix(frontend): redirect legacy sync-quarantine route (MAS-490)

### DIFF
--- a/frontend/src/lib/quarantine-redirect.test.ts
+++ b/frontend/src/lib/quarantine-redirect.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildQuarantineRedirectTarget,
+  QUARANTINE_CANONICAL_PATH,
+  QUARANTINE_LEGACY_PATH,
+} from './quarantine-redirect.js';
+
+test('buildQuarantineRedirectTarget points at the canonical quarantine page', () => {
+  assert.equal(buildQuarantineRedirectTarget().pathname, QUARANTINE_CANONICAL_PATH);
+});
+
+test('buildQuarantineRedirectTarget preserves query parameters', () => {
+  assert.deepEqual(buildQuarantineRedirectTarget({ network: 'Preprod', page: '2' }), {
+    pathname: QUARANTINE_CANONICAL_PATH,
+    query: { network: 'Preprod', page: '2' },
+  });
+});
+
+test('legacy and canonical paths differ', () => {
+  assert.notEqual(QUARANTINE_LEGACY_PATH, QUARANTINE_CANONICAL_PATH);
+});

--- a/frontend/src/lib/quarantine-redirect.ts
+++ b/frontend/src/lib/quarantine-redirect.ts
@@ -1,0 +1,12 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+export const QUARANTINE_CANONICAL_PATH = '/tx-sync-quarantine';
+export const QUARANTINE_LEGACY_PATH = '/sync-quarantine';
+
+/** Build the client redirect target for the legacy quarantine route. */
+export function buildQuarantineRedirectTarget(query: ParsedUrlQuery = {}) {
+  return {
+    pathname: QUARANTINE_CANONICAL_PATH,
+    query,
+  };
+}

--- a/frontend/src/pages/sync-quarantine.tsx
+++ b/frontend/src/pages/sync-quarantine.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import { buildQuarantineRedirectTarget } from '@/lib/quarantine-redirect';
+
+/** Legacy static-export route: /admin/sync-quarantine → /admin/tx-sync-quarantine */
+export default function SyncQuarantineRedirectPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    void router.replace(buildQuarantineRedirectTarget(router.query));
+  }, [router]);
+
+  return null;
+}


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Add a page at `/admin/sync-quarantine` that redirects to `/admin/tx-sync-quarantine` and keeps query parameters. Static export does not support Next.js redirect config, so this uses a client redirect page instead.

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-490

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**
