### PR TITLE
fix(frontend): open invoices on current month (MAS-491)

### DIFF
--- a/frontend/src/lib/invoices-month.test.ts
+++ b/frontend/src/lib/invoices-month.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getCurrentMonth } from './invoices-month.js';
+
+test('getCurrentMonth returns the current calendar month', () => {
+  assert.equal(getCurrentMonth(new Date(2026, 7, 15)), '2026-08');
+});
+
+test('getCurrentMonth keeps January in the current year', () => {
+  assert.equal(getCurrentMonth(new Date(2026, 0, 10)), '2026-01');
+});
+
+test('getCurrentMonth pads single-digit months', () => {
+  assert.equal(getCurrentMonth(new Date(2026, 2, 1)), '2026-03');
+});

--- a/frontend/src/lib/invoices-month.ts
+++ b/frontend/src/lib/invoices-month.ts
@@ -1,0 +1,4 @@
+/** Returns the current local calendar month as YYYY-MM. */
+export function getCurrentMonth(now = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}

--- a/frontend/src/pages/invoices.tsx
+++ b/frontend/src/pages/invoices.tsx
@@ -21,13 +21,8 @@ import { useUninvoicedPayments, type UninvoicedPayment } from '@/lib/hooks/useUn
 import { InvoiceDetailsDialog } from '@/components/invoices/InvoiceDetailsDialog';
 import { GenerateInvoiceDialog } from '@/components/invoices/GenerateInvoiceDialog';
 import { extractApiErrorMessage } from '@/lib/api-error';
+import { getCurrentMonth } from '@/lib/invoices-month';
 import { toast } from 'react-toastify';
-
-function getPreviousMonth(): string {
-  const now = new Date();
-  const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-  return `${prev.getFullYear()}-${String(prev.getMonth() + 1).padStart(2, '0')}`;
-}
 
 function formatMonthLabel(month: string): string {
   const [yearStr, monthStr] = month.split('-');
@@ -118,7 +113,7 @@ export default function Invoices() {
   const { network, capabilities } = useAppContext();
 
   const [activeTab, setActiveTab] = useState('Generated Invoices');
-  const [selectedMonth, setSelectedMonth] = useState(getPreviousMonth);
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedInvoice, setSelectedInvoice] = useState<InvoiceSummary | null>(null);
   const [showGenerateDialog, setShowGenerateDialog] = useState(false);


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Default the Invoices month picker to the current calendar month instead of the previous month. Earlier months stay selectable and current-month generation rules are unchanged.

## **Screenshot**

<img width="1440" height="900" alt="MAS-491-invoices-current-month" src="https://github.com/user-attachments/assets/048e98bf-c3dd-44ac-83e7-88fb7b89b666" />


## **Issue Addressed**

https://linear.app/masumi/issue/MAS-491

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**
