### PR TITLE
fix(seed): make Web3CardanoV2 the default for new installations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,13 +51,17 @@ AUTO_WITHDRAW_REFUNDS="true" #should refunds be automatically withdrawn. If not 
 #The following data is only needed while seeding
 ADMIN_KEY="abcdef_this_should_be_very_secure" #The key of the admin user, this key will have all permissions, like doing payments, changing configurations and can also be used to create new (more limited) api_keys
 SEED_ONLY_IF_EMPTY=True #***Optionally*** Will skip seeding if there are entries in the db
+SEED_V1_LEGACY="" #***Optionally*** Set to true to also seed legacy Web3CardanoV1 payment sources. When true and seeding both V1 and V2, set the PURCHASE/SELLING_WALLET_V2_* mnemonics to wallets distinct from the V1 mnemonics below.
 
 #The following data is only needed for preprod seeding
 BLOCKFROST_API_KEY_PREPROD="" #Your blockfrost api key. It is required to interact with the blockchain. Receive a free key at https://blockfrost.io/ for the network you are using (e.g. preprod)
 
-PURCHASE_WALLET_PREPROD_MNEMONIC="" #***OPTIONAL*** The mnemonic of the wallet used to purchase any agent requests. This needs to have sufficient funds to pay, or be topped up. If you do not provide a mnemonic, a new one will be generated. Please ensure you export them immediately after creation and store them securely.
-SELLING_WALLET_PREPROD_MNEMONIC="" #***OPTIONAL*** The mnemonic of the wallet used to interact with the smart contract. This only needs minimal funds, to cover the CARDANO Network fees. If you do not provide a mnemonic, a new one will be generated. Please ensure you export them immediately after creation and store them securely.
+PURCHASE_WALLET_PREPROD_MNEMONIC="" #***OPTIONAL*** Used for the default Web3CardanoV2 purchasing hot wallet on Preprod. If blank, a new mnemonic is generated and printed once after seeding.
+SELLING_WALLET_PREPROD_MNEMONIC="" #***OPTIONAL*** Used for the default Web3CardanoV2 selling hot wallet on Preprod. If blank, a new mnemonic is generated and printed once after seeding.
+PURCHASE_WALLET_V2_PREPROD_MNEMONIC="" #***OPTIONAL*** Override V2 purchasing wallet when SEED_V1_LEGACY=true (must differ from PURCHASE_WALLET_PREPROD_MNEMONIC to avoid HotWallet collisions).
+SELLING_WALLET_V2_PREPROD_MNEMONIC="" #***OPTIONAL*** Override V2 selling wallet when SEED_V1_LEGACY=true (must differ from SELLING_WALLET_PREPROD_MNEMONIC).
 COLLECTION_WALLET_PREPROD_ADDRESS="" #***OPTIONAL*** The wallet address of the collection wallet. It will receive all payments after a successful and completed purchase (not refund). It does not need any funds, however it is strongly recommended to create it via a hardware wallet or ensure its secret is stored securely. If you do not provide an address, the SELLING_WALLET will be used.
+COLLECTION_WALLET_V2_PREPROD_ADDRESS="" #***OPTIONAL*** Collection address for the V2 selling wallet. Defaults to COLLECTION_WALLET_PREPROD_ADDRESS.
 
 COINGECKO_API_KEY="CG-demo-key" #Works with either a demo or normal key
 IS_COINGECKO_DEMO="true" #In case it is a demo key set this to true
@@ -80,10 +84,13 @@ REGISTRY_POLICY_ID_PREPROD="customized registry policy id"
 #The following data is only needed for mainnet seeding
 BLOCKFROST_API_KEY_MAINNET="" #Your blockfrost api key. It is required to interact with the blockchain. Receive a free key at https://blockfrost.io/ for the network you are using (e.g. mainnet)
 
-#Used to configure payment and purchase wallets
-PURCHASE_WALLET_MAINNET_MNEMONIC="" #***OPTIONAL*** The mnemonic of the wallet used to purchase any agent requests. This needs to have sufficient funds to pay, or be topped up. If you do not provide a mnemonic, a new one will be generated. Please ensure you export them immediately after creation and store them securely.
-SELLING_WALLET_MAINNET_MNEMONIC="" #***OPTIONAL*** The mnemonic of the wallet used to interact with the smart contract. This only needs minimal funds, to cover the CARDANO Network fees. If you do not provide a mnemonic, a new one will be generated. Please ensure you export them immediately after creation and store them securely.
+#Used to configure payment and purchase wallets for the default Web3CardanoV2 source (and legacy V1 when SEED_V1_LEGACY=true)
+PURCHASE_WALLET_MAINNET_MNEMONIC="" #***OPTIONAL*** Default Web3CardanoV2 purchasing wallet on Mainnet. Brewed and printed if blank.
+SELLING_WALLET_MAINNET_MNEMONIC="" #***OPTIONAL*** Default Web3CardanoV2 selling wallet on Mainnet. Brewed and printed if blank.
+PURCHASE_WALLET_V2_MAINNET_MNEMONIC="" #***OPTIONAL*** Override V2 purchasing wallet when SEED_V1_LEGACY=true (must differ from the V1 mnemonic).
+SELLING_WALLET_V2_MAINNET_MNEMONIC="" #***OPTIONAL*** Override V2 selling wallet when SEED_V1_LEGACY=true (must differ from the V1 mnemonic).
 COLLECTION_WALLET_MAINNET_ADDRESS="" #***OPTIONAL BUT STRONGLY RECOMMENDED*** The wallet address of the collection wallet. It will receive all payments after a successful and completed purchase (not refund). It does not need any funds, however it is strongly recommended to create it via a hardware wallet or ensure its secret is stored securely. If you do not provide an address, the SELLING_WALLET will be used.
+COLLECTION_WALLET_V2_MAINNET_ADDRESS="" #***OPTIONAL*** Collection address for the V2 selling wallet. Defaults to COLLECTION_WALLET_MAINNET_ADDRESS.
 
 
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,9 +185,14 @@ jobs:
         # are present (the seed gates V2 separately and skips cleanly when the
         # V2 env vars are missing). Downstream V1 and V2 suites run against
         # this one DB + one API server.
+        #
+        # Web3CardanoV2 is the default for new installs (MAS-487), so V1 is
+        # opt-in via SEED_V1_LEGACY. CI still runs V1 and V2 e2e in parallel,
+        # so the seed step must enable legacy V1 here.
         run: pnpm exec prisma db seed --config prisma/prisma.config.ts
         env:
           DATABASE_URL: '${{ steps.create-branch.outputs.connection_uri }}'
+          SEED_V1_LEGACY: 'true'
           PURCHASE_WALLET_PREPROD_MNEMONIC: '${{ secrets.PURCHASE_WALLET_PREPROD_MNEMONIC }}'
           SELLING_WALLET_PREPROD_MNEMONIC: '${{ secrets.SELLING_WALLET_PREPROD_MNEMONIC }}'
           # Optional extra selling wallets. globalSetup registers one agent per

--- a/README.md
+++ b/README.md
@@ -33,9 +33,13 @@ cd masumi-payment-service
 pnpm install                    # installs deps + generates the Prisma client
 
 cp .env.example .env            # then fill in DATABASE_URL, ENCRYPTION_KEY,
-                                # Blockfrost keys, ... (see docs/configuration.md)
+                                # BLOCKFROST_API_KEY_PREPROD, ... (see docs/configuration.md)
 
 pnpm run prisma:migrate:dev     # apply database migrations
+
+# Required before seeding Preprod payment sources (minimum for a new install):
+#   DATABASE_URL, ENCRYPTION_KEY, BLOCKFROST_API_KEY_PREPROD
+# Recommended: ADMIN_KEY (a secure value; the seed falls back to a public default if unset)
 pnpm run prisma:seed            # seed initial data (admin key, payment source)
 
 pnpm run dev                    # start the API server on http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ pnpm run prisma:migrate:dev     # apply database migrations
 # Required before seeding Preprod payment sources (minimum for a new install):
 #   DATABASE_URL, ENCRYPTION_KEY, BLOCKFROST_API_KEY_PREPROD
 # Recommended: ADMIN_KEY (a secure value; the seed falls back to a public default if unset)
-pnpm run prisma:seed            # seed initial data (admin key, payment source)
+# Optional wallet mnemonics: PURCHASE_WALLET_* / SELLING_WALLET_* (brewed and printed if blank)
+# Legacy V1 sources: set SEED_V1_LEGACY=true (requires separate PURCHASE/SELLING_WALLET_V2_* when seeding both types)
+pnpm run prisma:seed            # seed initial data (admin key, Web3CardanoV2 payment source)
 
 pnpm run dev                    # start the API server on http://localhost:3001
 ```

--- a/docs/migrations/web3-cardano-v2.md
+++ b/docs/migrations/web3-cardano-v2.md
@@ -47,16 +47,17 @@ Reverting after Migration B requires accepting:
 
 ## Seed behaviour
 
-`prisma/seed.ts` creates one `PaymentSource` per network per Type (V1 + V2 = 2 sources per network). Set `SEED_ONLY_IF_EMPTY=true` for production-safe re-runs — the guard now checks both `apiKey.count()` and `paymentSource.count()` and bails if either is non-empty.
+`prisma/seed.ts` creates **Web3CardanoV2** payment sources by default for each configured network. Set `SEED_ONLY_IF_EMPTY=true` for production-safe re-runs — per-type gating skips a network/type pair when a source of that type already exists, so a V1-only deployment can receive V2 sources on re-seed without duplicating either type.
 
-V2 wallet mnemonics are required via environment variables and the seed will throw if any are missing:
+Legacy **Web3CardanoV1** sources are opt-in: set `SEED_V1_LEGACY=true`. When seeding both V1 and V2 in the same run, supply distinct `PURCHASE_WALLET_V2_*` / `SELLING_WALLET_V2_*` mnemonics so HotWallet vkeys do not collide with the V1 wallets.
 
-- `PURCHASE_WALLET_V2_PREPROD_MNEMONIC`
-- `SELLING_WALLET_V2_PREPROD_MNEMONIC`
-- `PURCHASE_WALLET_V2_MAINNET_MNEMONIC`
-- `SELLING_WALLET_V2_MAINNET_MNEMONIC`
+For a normal new installation, configure:
 
-The seed refuses to brew random V2 mnemonics because contract addresses are derived from wallet identities — a brewed mnemonic would produce a V2 PaymentSource whose deployed contract you don't actually control. V1 retains the brew fallback for backwards compatibility.
+- `PURCHASE_WALLET_PREPROD_MNEMONIC` / `SELLING_WALLET_PREPROD_MNEMONIC` (and mainnet equivalents when mainnet seeding is configured)
+- `BLOCKFROST_API_KEY_PREPROD` (required — see MAS-474 validation)
+- `DATABASE_URL`, `ENCRYPTION_KEY`
+
+Blank wallet mnemonics are treated as missing: the seed brews new phrases and prints each generated mnemonic once after the payment source transaction succeeds. Supplied mnemonics are never logged.
 
 ## Mesh-SDK version policy
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,7 +29,7 @@ const config: Config.InitialOptions = {
 	// continuations don't fire a `require` after the env is torn down (which
 	// crashes the worker with an UnhandledPromiseRejection). See the setup file.
 	setupFilesAfterEnv: ['<rootDir>/jest.setup.libsodium.ts'],
-	roots: ['<rootDir>/src', '<rootDir>/packages'],
+	roots: ['<rootDir>/src', '<rootDir>/packages', '<rootDir>/prisma'],
 	extensionsToTreatAsEsm: ['.ts'],
 	transform: {
 		'^.+\\.tsx?$': [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -25,9 +25,11 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import {
 	formatMissingEnvError,
 	isMissingEnvValue,
+	isSeedV1LegacyEnabled,
 	printGeneratedMnemonics,
 	resolveMnemonic,
 	validatePreprodSeedPrerequisites,
+	type ResolvedMnemonic,
 } from './seed.validation';
 
 dotenv.config();
@@ -40,16 +42,15 @@ function brewMnemonic(): string {
 	return (MeshWallet.brew(false) as string[]).join(' ');
 }
 
-// V2 wallets must be supplied via env: contract addresses are derived from these
-// mnemonics and re-seeding with a brewed mnemonic would orphan any V2 funds. V1
-// keeps the brew fallback for backwards compatibility with the original seed UX.
-function requireMnemonic(mnemonic: string | undefined, envName: string): string {
-	if (isMissingEnvValue(mnemonic)) {
-		throw new Error(
-			`${envName} is required for V2 seeding. Set it in your .env to a 24-word mnemonic that is distinct from your V1 wallets.`,
-		);
+function resolveV2WalletMnemonic(
+	v2Raw: string | undefined,
+	v2EnvName: string,
+	defaultResolved: ResolvedMnemonic,
+): ResolvedMnemonic {
+	if (!isMissingEnvValue(v2Raw)) {
+		return resolveMnemonic(v2Raw, v2EnvName, brewMnemonic);
 	}
-	return mnemonic!.trim();
+	return defaultResolved;
 }
 
 /**
@@ -95,6 +96,7 @@ async function queryLatestTxHash(blockfrostApiKey: string, smartContractAddress:
 
 export const seed = async (prisma: PrismaClient) => {
 	const seedOnlyIfEmpty = process.env.SEED_ONLY_IF_EMPTY;
+	const seedV1Legacy = isSeedV1LegacyEnabled(process.env.SEED_V1_LEGACY);
 
 	// Per-type gating: V2 was bolted on after V1 deployments existed in the
 	// wild, so a global "any PaymentSource exists" check (the previous
@@ -203,10 +205,19 @@ export const seed = async (prisma: PrismaClient) => {
 	);
 	const purchaseWalletPreprodMnemonic = purchaseWalletPreprodResolved.mnemonic;
 	const sellingWalletPreprodMnemonic = sellingWalletPreprodResolved.mnemonic;
-	// V2 mnemonics validated lazily at the V2 source creation site so that V1-only
-	// deployments (no BLOCKFROST_API_KEY_PREPROD) don't fail on missing V2 env.
-	const purchaseWalletV2PreprodMnemonicRaw = process.env.PURCHASE_WALLET_V2_PREPROD_MNEMONIC;
-	const sellingWalletV2PreprodMnemonicRaw = process.env.SELLING_WALLET_V2_PREPROD_MNEMONIC;
+	const purchaseWalletV2PreprodResolved = resolveV2WalletMnemonic(
+		process.env.PURCHASE_WALLET_V2_PREPROD_MNEMONIC,
+		'PURCHASE_WALLET_V2_PREPROD_MNEMONIC',
+		purchaseWalletPreprodResolved,
+	);
+	const sellingWalletV2PreprodResolved = resolveV2WalletMnemonic(
+		process.env.SELLING_WALLET_V2_PREPROD_MNEMONIC,
+		'SELLING_WALLET_V2_PREPROD_MNEMONIC',
+		sellingWalletPreprodResolved,
+	);
+	const hasDistinctV2PreprodMnemonics =
+		!isMissingEnvValue(process.env.PURCHASE_WALLET_V2_PREPROD_MNEMONIC) &&
+		!isMissingEnvValue(process.env.SELLING_WALLET_V2_PREPROD_MNEMONIC);
 	if (!collectionWalletPreprodAddress) {
 		collectionWalletPreprodAddress = null;
 	}
@@ -226,8 +237,19 @@ export const seed = async (prisma: PrismaClient) => {
 	);
 	const purchaseWalletMainnetMnemonic = purchaseWalletMainnetResolved.mnemonic;
 	const sellingWalletMainnetMnemonic = sellingWalletMainnetResolved.mnemonic;
-	const purchaseWalletV2MainnetMnemonicRaw = process.env.PURCHASE_WALLET_V2_MAINNET_MNEMONIC;
-	const sellingWalletV2MainnetMnemonicRaw = process.env.SELLING_WALLET_V2_MAINNET_MNEMONIC;
+	const purchaseWalletV2MainnetResolved = resolveV2WalletMnemonic(
+		process.env.PURCHASE_WALLET_V2_MAINNET_MNEMONIC,
+		'PURCHASE_WALLET_V2_MAINNET_MNEMONIC',
+		purchaseWalletMainnetResolved,
+	);
+	const sellingWalletV2MainnetResolved = resolveV2WalletMnemonic(
+		process.env.SELLING_WALLET_V2_MAINNET_MNEMONIC,
+		'SELLING_WALLET_V2_MAINNET_MNEMONIC',
+		sellingWalletMainnetResolved,
+	);
+	const hasDistinctV2MainnetMnemonics =
+		!isMissingEnvValue(process.env.PURCHASE_WALLET_V2_MAINNET_MNEMONIC) &&
+		!isMissingEnvValue(process.env.SELLING_WALLET_V2_MAINNET_MNEMONIC);
 	if (!collectionWalletMainnetAddress) {
 		collectionWalletMainnetAddress = null;
 	}
@@ -284,6 +306,8 @@ export const seed = async (prisma: PrismaClient) => {
 
 		if (shouldSkipV1) {
 			console.log('V1 preprod seeding skipped (per-type gating).');
+		} else if (!seedV1Legacy) {
+			console.log('V1 preprod seeding skipped (Web3CardanoV2 is the default; set SEED_V1_LEGACY=true for legacy V1).');
 		} else
 			try {
 				const purchasingWallet = new MeshWallet({
@@ -419,34 +443,20 @@ export const seed = async (prisma: PrismaClient) => {
 				throw error;
 			}
 
-		// V2 preprod seeding is opt-in via dedicated mnemonic env vars. We
-		// deliberately do NOT fall back to the V1 mnemonics here because:
-		//   (a) the wallets derived from V1 mnemonics would collide with the
-		//       V1 HotWallet rows on the global `walletVkey` unique constraint;
-		//   (b) sharing a single on-chain preprod wallet between V1 and V2
-		//       e2e jobs causes UTxO contention in parallel runs.
-		// If V2 mnemonics are not configured, skip V2 seeding entirely. V2 e2e
-		// will then fail fast with a clear "No active Web3CardanoV2
-		// PaymentSource" message in globalSetup, which is the intended signal
-		// to configure the secrets.
+		// V2 is the default payment source for new installations. When
+		// SEED_V1_LEGACY=true, V2 requires distinct PURCHASE/SELLING_WALLET_V2_*
+		// mnemonics so HotWallet vkeys do not collide with the V1 source.
 		if (shouldSkipV2) {
 			console.log('V2 preprod seeding skipped (per-type gating).');
-		} else if (!purchaseWalletV2PreprodMnemonicRaw || !sellingWalletV2PreprodMnemonicRaw) {
+		} else if (seedV1Legacy && !hasDistinctV2PreprodMnemonics) {
 			console.log(
-				'V2 preprod seeding skipped: set PURCHASE_WALLET_V2_PREPROD_MNEMONIC and ' +
-					'SELLING_WALLET_V2_PREPROD_MNEMONIC (distinct from V1 mnemonics, funded on preprod) ' +
-					'to enable V2 e2e.',
+				'V2 preprod seeding skipped in legacy mode: set PURCHASE_WALLET_V2_PREPROD_MNEMONIC and ' +
+					'SELLING_WALLET_V2_PREPROD_MNEMONIC (distinct from V1 mnemonics) to seed both types.',
 			);
 		} else
 			try {
-				const purchaseWalletV2PreprodMnemonic = requireMnemonic(
-					purchaseWalletV2PreprodMnemonicRaw,
-					'PURCHASE_WALLET_V2_PREPROD_MNEMONIC',
-				);
-				const sellingWalletV2PreprodMnemonic = requireMnemonic(
-					sellingWalletV2PreprodMnemonicRaw,
-					'SELLING_WALLET_V2_PREPROD_MNEMONIC',
-				);
+				const purchaseWalletV2PreprodMnemonic = purchaseWalletV2PreprodResolved.mnemonic;
+				const sellingWalletV2PreprodMnemonic = sellingWalletV2PreprodResolved.mnemonic;
 				const purchasingWallet = new MeshWallet({
 					networkId: 0,
 					key: {
@@ -550,16 +560,9 @@ export const seed = async (prisma: PrismaClient) => {
 				console.log(
 					'V2 contract seeded on preprod: ' + smartContractAddress + ' added. Registry policyId: ' + policyId,
 				);
+				printGeneratedMnemonics([purchaseWalletV2PreprodResolved, sellingWalletV2PreprodResolved]);
 
-				// Hydra heads are not seeded.
-				//
-				// They used to be, from HYDRA_* environment variables, and the block wrote
-				// participant columns (`nodeUrl`, `nodeHttpUrl`) that the Host-only
-				// migration removed, so every run threw into a caught log line and seeded
-				// nothing. Removed rather than repaired: a head is created by the invite
-				// handshake now — reserve a node on a Host, issue an invite, have the
-				// counterparty redeem it — and half a head assembled by hand has no node
-				// behind it and no way to open.
+				// Hydra heads are not seeded — see docs/hydra-operations.md.
 			} catch (error) {
 				console.error(
 					'Error when seeding preprod V2, ensure you succeed with seeding, the following error occurred: ',
@@ -609,6 +612,8 @@ export const seed = async (prisma: PrismaClient) => {
 		const latestTxHash = await queryLatestTxHash(blockfrostApiKeyMainnet, smartContractAddress, 'mainnet');
 		if (shouldSkipV1) {
 			console.log('V1 mainnet seeding skipped (per-type gating).');
+		} else if (!seedV1Legacy) {
+			console.log('V1 mainnet seeding skipped (Web3CardanoV2 is the default; set SEED_V1_LEGACY=true for legacy V1).');
 		} else
 			try {
 				const purchasingWallet = new MeshWallet({
@@ -707,26 +712,17 @@ export const seed = async (prisma: PrismaClient) => {
 				throw error;
 			}
 
-		// V2 mainnet seeding is opt-in via dedicated mnemonic env vars. Mirror
-		// the preprod gate: skip BEFORE creating any wallet secrets so a
-		// missing-env-var run does not leave orphan WalletSecret rows behind.
 		if (shouldSkipV2) {
 			console.log('V2 mainnet seeding skipped (per-type gating).');
-		} else if (!purchaseWalletV2MainnetMnemonicRaw || !sellingWalletV2MainnetMnemonicRaw) {
+		} else if (seedV1Legacy && !hasDistinctV2MainnetMnemonics) {
 			console.log(
-				'V2 mainnet seeding skipped: set PURCHASE_WALLET_V2_MAINNET_MNEMONIC and ' +
-					'SELLING_WALLET_V2_MAINNET_MNEMONIC to enable.',
+				'V2 mainnet seeding skipped in legacy mode: set PURCHASE_WALLET_V2_MAINNET_MNEMONIC and ' +
+					'SELLING_WALLET_V2_MAINNET_MNEMONIC (distinct from V1 mnemonics) to seed both types.',
 			);
 		} else
 			try {
-				const purchaseWalletV2MainnetMnemonic = requireMnemonic(
-					purchaseWalletV2MainnetMnemonicRaw,
-					'PURCHASE_WALLET_V2_MAINNET_MNEMONIC',
-				);
-				const sellingWalletV2MainnetMnemonic = requireMnemonic(
-					sellingWalletV2MainnetMnemonicRaw,
-					'SELLING_WALLET_V2_MAINNET_MNEMONIC',
-				);
+				const purchaseWalletV2MainnetMnemonic = purchaseWalletV2MainnetResolved.mnemonic;
+				const sellingWalletV2MainnetMnemonic = sellingWalletV2MainnetResolved.mnemonic;
 				const purchasingWallet = new MeshWallet({
 					networkId: 1,
 					key: {
@@ -827,6 +823,7 @@ export const seed = async (prisma: PrismaClient) => {
 				console.log(
 					'V2 contract seeded on mainnet: ' + smartContractAddress + ' added. Registry policyId: ' + policyId,
 				);
+				printGeneratedMnemonics([purchaseWalletV2MainnetResolved, sellingWalletV2MainnetResolved]);
 			} catch (error) {
 				console.error(
 					'Error when seeding mainnet V2, ensure you succeed with seeding, the following error occurred: ',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,6 +22,13 @@ import { MeshWallet } from '@meshsdk/core';
 
 import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
+import {
+	formatMissingEnvError,
+	isMissingEnvValue,
+	printGeneratedMnemonics,
+	resolveMnemonic,
+	validatePreprodSeedPrerequisites,
+} from './seed.validation';
 
 dotenv.config();
 const connectionString = process.env.DATABASE_URL;
@@ -29,20 +36,20 @@ const pool = new Pool({ connectionString });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 
-function createMnemonicIfMissing(mnemonic: string | undefined) {
-	return mnemonic ?? (MeshWallet.brew(false) as string[]).join(' ');
+function brewMnemonic(): string {
+	return (MeshWallet.brew(false) as string[]).join(' ');
 }
 
 // V2 wallets must be supplied via env: contract addresses are derived from these
 // mnemonics and re-seeding with a brewed mnemonic would orphan any V2 funds. V1
 // keeps the brew fallback for backwards compatibility with the original seed UX.
 function requireMnemonic(mnemonic: string | undefined, envName: string): string {
-	if (!mnemonic) {
+	if (isMissingEnvValue(mnemonic)) {
 		throw new Error(
 			`${envName} is required for V2 seeding. Set it in your .env to a 24-word mnemonic that is distinct from your V1 wallets.`,
 		);
 	}
-	return mnemonic;
+	return mnemonic!.trim();
 }
 
 /**
@@ -184,8 +191,18 @@ export const seed = async (prisma: PrismaClient) => {
 	}
 
 	let collectionWalletPreprodAddress: string | null | undefined = process.env.COLLECTION_WALLET_PREPROD_ADDRESS;
-	const purchaseWalletPreprodMnemonic = createMnemonicIfMissing(process.env.PURCHASE_WALLET_PREPROD_MNEMONIC);
-	const sellingWalletPreprodMnemonic = createMnemonicIfMissing(process.env.SELLING_WALLET_PREPROD_MNEMONIC);
+	const purchaseWalletPreprodResolved = resolveMnemonic(
+		process.env.PURCHASE_WALLET_PREPROD_MNEMONIC,
+		'PURCHASE_WALLET_PREPROD_MNEMONIC',
+		brewMnemonic,
+	);
+	const sellingWalletPreprodResolved = resolveMnemonic(
+		process.env.SELLING_WALLET_PREPROD_MNEMONIC,
+		'SELLING_WALLET_PREPROD_MNEMONIC',
+		brewMnemonic,
+	);
+	const purchaseWalletPreprodMnemonic = purchaseWalletPreprodResolved.mnemonic;
+	const sellingWalletPreprodMnemonic = sellingWalletPreprodResolved.mnemonic;
 	// V2 mnemonics validated lazily at the V2 source creation site so that V1-only
 	// deployments (no BLOCKFROST_API_KEY_PREPROD) don't fail on missing V2 env.
 	const purchaseWalletV2PreprodMnemonicRaw = process.env.PURCHASE_WALLET_V2_PREPROD_MNEMONIC;
@@ -197,8 +214,18 @@ export const seed = async (prisma: PrismaClient) => {
 		process.env.COLLECTION_WALLET_V2_PREPROD_ADDRESS ?? collectionWalletPreprodAddress;
 
 	let collectionWalletMainnetAddress: string | null | undefined = process.env.COLLECTION_WALLET_MAINNET_ADDRESS;
-	const purchaseWalletMainnetMnemonic = createMnemonicIfMissing(process.env.PURCHASE_WALLET_MAINNET_MNEMONIC);
-	const sellingWalletMainnetMnemonic = createMnemonicIfMissing(process.env.SELLING_WALLET_MAINNET_MNEMONIC);
+	const purchaseWalletMainnetResolved = resolveMnemonic(
+		process.env.PURCHASE_WALLET_MAINNET_MNEMONIC,
+		'PURCHASE_WALLET_MAINNET_MNEMONIC',
+		brewMnemonic,
+	);
+	const sellingWalletMainnetResolved = resolveMnemonic(
+		process.env.SELLING_WALLET_MAINNET_MNEMONIC,
+		'SELLING_WALLET_MAINNET_MNEMONIC',
+		brewMnemonic,
+	);
+	const purchaseWalletMainnetMnemonic = purchaseWalletMainnetResolved.mnemonic;
+	const sellingWalletMainnetMnemonic = sellingWalletMainnetResolved.mnemonic;
 	const purchaseWalletV2MainnetMnemonicRaw = process.env.PURCHASE_WALLET_V2_MAINNET_MNEMONIC;
 	const sellingWalletV2MainnetMnemonicRaw = process.env.SELLING_WALLET_V2_MAINNET_MNEMONIC;
 	if (!collectionWalletMainnetAddress) {
@@ -207,9 +234,17 @@ export const seed = async (prisma: PrismaClient) => {
 	const collectionWalletV2MainnetAddress =
 		process.env.COLLECTION_WALLET_V2_MAINNET_ADDRESS ?? collectionWalletMainnetAddress;
 
-	const blockfrostApiKeyPreprod = process.env.BLOCKFROST_API_KEY_PREPROD;
+	const preprodValidation = validatePreprodSeedPrerequisites({
+		DATABASE_URL: process.env.DATABASE_URL,
+		ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+		BLOCKFROST_API_KEY_PREPROD: process.env.BLOCKFROST_API_KEY_PREPROD,
+	});
+	if (!preprodValidation.ok) {
+		throw new Error(formatMissingEnvError(preprodValidation.missing));
+	}
 
-	const encryptionKey = process.env.ENCRYPTION_KEY;
+	const blockfrostApiKeyPreprod = process.env.BLOCKFROST_API_KEY_PREPROD!.trim();
+	const encryptionKey = process.env.ENCRYPTION_KEY!.trim();
 
 	const adminWallet1AddressPreprod = DEFAULTS.ADMIN_WALLET1_PREPROD;
 	const adminWallet2AddressPreprod = DEFAULTS.ADMIN_WALLET2_PREPROD;
@@ -220,7 +255,8 @@ export const seed = async (prisma: PrismaClient) => {
 	const cooldownTimePreprod = DEFAULTS.COOLDOWN_TIME_PREPROD;
 	const cooldownTimeMainnet = DEFAULTS.COOLDOWN_TIME_MAINNET;
 
-	if (encryptionKey != null && blockfrostApiKeyPreprod != null && blockfrostApiKeyPreprod != '') {
+	// Preprod seed path — DATABASE_URL, ENCRYPTION_KEY, and BLOCKFROST_API_KEY_PREPROD validated above.
+	{
 		const fee = feePermillePreprod;
 		if (fee < 0 || fee > 1000) {
 			console.error('Fee permille is not valid, must be between 0 and 1000 (0.0% and 100.0%)');
@@ -374,6 +410,7 @@ export const seed = async (prisma: PrismaClient) => {
 				});
 
 				console.log('Contract seeded on preprod: ' + smartContractAddress + ' added. Registry policyId: ' + policyId);
+				printGeneratedMnemonics([purchaseWalletPreprodResolved, sellingWalletPreprodResolved]);
 			} catch (error) {
 				console.error(
 					'Error when seeding preprod, ensure you succeed with seeding, the following error occurred: ',
@@ -535,10 +572,6 @@ export const seed = async (prisma: PrismaClient) => {
 				// PaymentSource" error that hides this root-cause stack.
 				throw error;
 			}
-	} else {
-		console.log(
-			'Smart contract preprod to monitor is not seeded. Provide ENCRYPTION_KEY and BLOCKFROST_API_KEY_PREPROD in .env',
-		);
 	}
 
 	const blockfrostApiKeyMainnet = process.env.BLOCKFROST_API_KEY_MAINNET;
@@ -665,6 +698,7 @@ export const seed = async (prisma: PrismaClient) => {
 				});
 
 				console.log('Contract seeded on mainnet: ' + smartContractAddress + ' added. Registry policyId: ' + policyId);
+				printGeneratedMnemonics([purchaseWalletMainnetResolved, sellingWalletMainnetResolved]);
 			} catch (error) {
 				console.error(
 					'Error when seeding mainnet, ensure you succeed with seeding, the following error occurred: ',

--- a/prisma/seed.validation.test.ts
+++ b/prisma/seed.validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import {
 	formatMissingEnvError,
 	isMissingEnvValue,
+	isSeedV1LegacyEnabled,
 	printGeneratedMnemonics,
 	resolveMnemonic,
 	validatePreprodSeedPrerequisites,
@@ -62,6 +63,15 @@ describe('seed.validation', () => {
 			expect(formatMissingEnvError(['DATABASE_URL', 'BLOCKFROST_API_KEY_PREPROD'])).toBe(
 				'Seed aborted: missing required environment variable(s): DATABASE_URL, BLOCKFROST_API_KEY_PREPROD',
 			);
+		});
+	});
+
+	describe('isSeedV1LegacyEnabled', () => {
+		it('enables legacy V1 seeding only when explicitly true', () => {
+			expect(isSeedV1LegacyEnabled('true')).toBe(true);
+			expect(isSeedV1LegacyEnabled('TRUE')).toBe(true);
+			expect(isSeedV1LegacyEnabled('false')).toBe(false);
+			expect(isSeedV1LegacyEnabled(undefined)).toBe(false);
 		});
 	});
 

--- a/prisma/seed.validation.test.ts
+++ b/prisma/seed.validation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+	formatMissingEnvError,
+	isMissingEnvValue,
+	printGeneratedMnemonics,
+	resolveMnemonic,
+	validatePreprodSeedPrerequisites,
+	type ResolvedMnemonic,
+} from './seed.validation.js';
+
+describe('seed.validation', () => {
+	describe('isMissingEnvValue', () => {
+		it('treats undefined, empty, and whitespace-only values as missing', () => {
+			expect(isMissingEnvValue(undefined)).toBe(true);
+			expect(isMissingEnvValue('')).toBe(true);
+			expect(isMissingEnvValue('   ')).toBe(true);
+			expect(isMissingEnvValue('\t\n')).toBe(true);
+		});
+
+		it('treats non-empty strings as present', () => {
+			expect(isMissingEnvValue('abc')).toBe(false);
+			expect(isMissingEnvValue(' abc ')).toBe(false);
+		});
+	});
+
+	describe('validatePreprodSeedPrerequisites', () => {
+		it('passes when all required variables are set', () => {
+			expect(
+				validatePreprodSeedPrerequisites({
+					DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+					ENCRYPTION_KEY: '12345678901234567890123456789012',
+					BLOCKFROST_API_KEY_PREPROD: 'preprod123',
+				}),
+			).toEqual({ ok: true });
+		});
+
+		it('lists every missing required variable', () => {
+			expect(
+				validatePreprodSeedPrerequisites({
+					DATABASE_URL: '',
+					ENCRYPTION_KEY: '   ',
+					BLOCKFROST_API_KEY_PREPROD: undefined,
+				}),
+			).toEqual({
+				ok: false,
+				missing: ['DATABASE_URL', 'ENCRYPTION_KEY', 'BLOCKFROST_API_KEY_PREPROD'],
+			});
+		});
+
+		it('names a blank Blockfrost key as missing', () => {
+			const result = validatePreprodSeedPrerequisites({
+				DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+				ENCRYPTION_KEY: '12345678901234567890123456789012',
+				BLOCKFROST_API_KEY_PREPROD: '',
+			});
+			expect(result).toEqual({ ok: false, missing: ['BLOCKFROST_API_KEY_PREPROD'] });
+		});
+	});
+
+	describe('formatMissingEnvError', () => {
+		it('includes each missing variable name', () => {
+			expect(formatMissingEnvError(['DATABASE_URL', 'BLOCKFROST_API_KEY_PREPROD'])).toBe(
+				'Seed aborted: missing required environment variable(s): DATABASE_URL, BLOCKFROST_API_KEY_PREPROD',
+			);
+		});
+	});
+
+	describe('resolveMnemonic', () => {
+		it('generates a mnemonic when the env value is empty or whitespace', () => {
+			const brewed = 'word '.repeat(23).trim() + ' last';
+			const purchase = resolveMnemonic('   ', 'PURCHASE_WALLET_PREPROD_MNEMONIC', () => brewed);
+			expect(purchase).toEqual({
+				mnemonic: brewed,
+				wasGenerated: true,
+				envName: 'PURCHASE_WALLET_PREPROD_MNEMONIC',
+			});
+		});
+
+		it('uses a supplied mnemonic without marking it generated', () => {
+			const supplied = 'abandon '.repeat(23).trim() + ' about';
+			const selling = resolveMnemonic(supplied, 'SELLING_WALLET_PREPROD_MNEMONIC', () => 'brewed');
+			expect(selling).toEqual({
+				mnemonic: supplied,
+				wasGenerated: false,
+				envName: 'SELLING_WALLET_PREPROD_MNEMONIC',
+			});
+		});
+	});
+
+	describe('printGeneratedMnemonics', () => {
+		it('prints only generated mnemonics once', () => {
+			const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+			const generated: ResolvedMnemonic[] = [
+				{
+					mnemonic: 'generated purchase phrase',
+					wasGenerated: true,
+					envName: 'PURCHASE_WALLET_PREPROD_MNEMONIC',
+				},
+				{
+					mnemonic: 'supplied selling phrase',
+					wasGenerated: false,
+					envName: 'SELLING_WALLET_PREPROD_MNEMONIC',
+				},
+			];
+
+			printGeneratedMnemonics(generated);
+
+			const output = warnSpy.mock.calls.map((call) => call[0]).join('\n');
+			expect(output).toContain('PURCHASE_WALLET_PREPROD_MNEMONIC=generated purchase phrase');
+			expect(output).not.toContain('SELLING_WALLET_PREPROD_MNEMONIC=supplied selling phrase');
+			warnSpy.mockRestore();
+		});
+	});
+});

--- a/prisma/seed.validation.ts
+++ b/prisma/seed.validation.ts
@@ -1,0 +1,67 @@
+/** Pure helpers for prisma/seed.ts — exported for unit tests. */
+
+export function isMissingEnvValue(value: string | undefined): boolean {
+	return value == null || value.trim() === '';
+}
+
+export type PreprodSeedPrerequisites = {
+	DATABASE_URL?: string;
+	ENCRYPTION_KEY?: string;
+	BLOCKFROST_API_KEY_PREPROD?: string;
+};
+
+export function validatePreprodSeedPrerequisites(
+	env: PreprodSeedPrerequisites,
+): { ok: true } | { ok: false; missing: string[] } {
+	const missing: string[] = [];
+	if (isMissingEnvValue(env.DATABASE_URL)) {
+		missing.push('DATABASE_URL');
+	}
+	if (isMissingEnvValue(env.ENCRYPTION_KEY)) {
+		missing.push('ENCRYPTION_KEY');
+	}
+	if (isMissingEnvValue(env.BLOCKFROST_API_KEY_PREPROD)) {
+		missing.push('BLOCKFROST_API_KEY_PREPROD');
+	}
+	if (missing.length > 0) {
+		return { ok: false, missing };
+	}
+	return { ok: true };
+}
+
+export function formatMissingEnvError(missing: string[]): string {
+	return `Seed aborted: missing required environment variable(s): ${missing.join(', ')}`;
+}
+
+export type ResolvedMnemonic = {
+	mnemonic: string;
+	wasGenerated: boolean;
+	envName: string;
+};
+
+export function resolveMnemonic(
+	raw: string | undefined,
+	envName: string,
+	brew: () => string,
+): ResolvedMnemonic {
+	if (!isMissingEnvValue(raw)) {
+		return { mnemonic: raw!.trim(), wasGenerated: false, envName };
+	}
+	return { mnemonic: brew(), wasGenerated: true, envName };
+}
+
+export function printGeneratedMnemonics(generated: ResolvedMnemonic[]): void {
+	const toShow = generated.filter((entry) => entry.wasGenerated);
+	if (toShow.length === 0) {
+		return;
+	}
+
+	console.warn('****************************************************');
+	console.warn('**  GENERATED WALLET MNEMONICS — SAVE THESE NOW!   **');
+	console.warn('**  These were not in your .env. Store them securely.**');
+	console.warn('****************************************************');
+	for (const entry of toShow) {
+		console.warn(`${entry.envName}=${entry.mnemonic}`);
+	}
+	console.warn('****************************************************');
+}

--- a/prisma/seed.validation.ts
+++ b/prisma/seed.validation.ts
@@ -50,6 +50,10 @@ export function resolveMnemonic(
 	return { mnemonic: brew(), wasGenerated: true, envName };
 }
 
+export function isSeedV1LegacyEnabled(raw: string | undefined): boolean {
+	return raw?.toLowerCase() === 'true';
+}
+
 export function printGeneratedMnemonics(generated: ResolvedMnemonic[]): void {
 	const toShow = generated.filter((entry) => entry.wasGenerated);
 	if (toShow.length === 0) {


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Seed Web3CardanoV2 payment sources by default on new installs. Legacy Web3CardanoV1 seeding requires `SEED_V1_LEGACY=true`. When both types seed in legacy mode, V2 mnemonics must differ from V1 to avoid wallet collisions. Updates `.env.example`, README, and migration docs.

Merge after #788.

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-487

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**
