### PR TITLE
docs: admin setup, migrations, and Blockfrost configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,28 @@ cd masumi-payment-service
 pnpm install                    # installs deps + generates the Prisma client
 
 cp .env.example .env            # then fill in DATABASE_URL, ENCRYPTION_KEY,
-                                # Blockfrost keys, ... (see docs/configuration.md)
+                                # BLOCKFROST_API_KEY_PREPROD, ... (see docs/configuration.md)
 
-pnpm run prisma:migrate:dev     # apply database migrations
+pnpm run prisma:migrate         # apply checked-in migrations (no shadow DB required)
 pnpm run prisma:seed            # seed initial data (admin key, payment source)
 
+pnpm -C frontend run build      # build the admin UI into frontend/dist (required for /admin/)
 pnpm run dev                    # start the API server on http://localhost:3001
 ```
 
-Once the API server is up, open **<http://localhost:3001/>** — browser requests
-to `/` are redirected to the admin interface at `/admin/`. API clients, health
-probes and `curl` are unaffected: the redirect only fires for requests that
-actually ask for HTML.
+`pnpm run dev` starts the API only. It serves `/admin/` when `frontend/dist` exists
+(from the build step above). The root `pnpm run build` command builds the **backend**
+only — it does not build the frontend.
 
-The admin interface served under `/admin/` is the **built** Next.js bundle
-(`frontend/dist`), so it only exists after the frontend has been built. To work
-on the dashboard itself, run it as its own dev server instead — that gives you
-hot reload on <http://localhost:3000/>:
+Once the API server is up **and** the frontend is built, open
+**<http://localhost:3001/admin/>** — browser requests to `/` redirect there.
+API clients, health probes and `curl` are unaffected: the redirect only fires for
+requests that actually ask for HTML.
+
+### Frontend development (separate from built `/admin/`)
+
+To work on the dashboard with hot reload, run the frontend dev server on
+<http://localhost:3000/> instead of using the built bundle:
 
 ```bash
 cd frontend
@@ -69,6 +74,19 @@ NEXT_PUBLIC_PAYMENT_API_BASE_URL=http://localhost:3001/api/v1
 The admin interface is designed for desktop. Narrow screens now show a
 dismissible warning rather than being blocked outright, but tables and dialogs
 are still cramped below ~1024px.
+
+### Database migrations for contributors
+
+Use `pnpm run prisma:migrate` to apply checked-in migrations when installing or
+deploying — it runs `prisma migrate deploy` and does **not** need a shadow
+database.
+
+Use `pnpm run prisma:migrate:dev` only when you **author or edit** migrations.
+That command runs `prisma migrate dev`, which creates a temporary shadow
+database. The PostgreSQL user needs superuser or `CREATEDB` permission, or you
+can set **`SHADOW_DATABASE_URL`** to a separate database the user is allowed
+to create/drop. See the [Prisma shadow database
+docs](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database).
 
 Useful commands: `pnpm run test` (unit tests — always via pnpm, not bare
 `npx jest`), `pnpm run lint`, `pnpm run format`, `pnpm run typecheck`. See the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,9 @@ If you run the service with Docker:
 
 - **DATABASE_URL**: The endpoint for a PostgreSQL database to be used
 - **ENCRYPTION_KEY**: The key for encrypting the wallets in the database (Please see the [Security](#security)
+  section for more details and security considerations)
 
 ## Advanced Configuration
-
-- If you need to seed a new database, you will also need to set the following:
-  - **BLOCKFROST_API_KEY**: An API Key from [https://blockfrost.io/](https://blockfrost.io/) for the correct blockchain
 
 - **DATABASE_URL**: The endpoint for a PostgreSQL database to be used
 - **PORT**: The port to run the server on (default is 3001)
@@ -51,24 +49,24 @@ If you run the service with Docker:
   - **LOW_BALANCE_CHECK_INTERVAL**: interval in seconds for monitored wallet low-balance checks
   - **CHECK_HYDRA_TX_INTERVAL**: interval in seconds for the Hydra L2 passes and deposit reconciliation (minimum 5, default 10)
 
-1. If you're setting up the database for the first time (or want to provide some initial data) you also need the
-   following variables:
-   - **BLOCKFROST_API_KEY_PREPROD**: An API Key from [https://blockfrost.io/](https://blockfrost.io/) for the correct blockchain
-     network, you can create this for free
-   - **BLOCKFROST_API_KEY_MAINNET**: An API Key from [https://blockfrost.io/](https://blockfrost.io/) for the correct blockchain
-     network, you can create this for free
-   - **ADMIN_KEY**: The key of the admin user, this key will have all permissions and can create new api_keys
-   - OPTIONAL Wallet data: Used to configure payment and purchase wallets, if you want to use existing wallets
-     - **PURCHASE_WALLET_PREPROD_MNEMONIC** and **PURCHASE_WALLET_MAINNET_MNEMONIC**: The mnemonic of the wallet used to purchase any agent requests. This needs to have
-       sufficient funds to pay, or be topped up. If you do not provide a mnemonic, a new one will be generated. Please
-       ensure you export them immediately after creation and store them securely.
-     - **SELLING_WALLET_PREPROD_MNEMONIC** and **SELLING_WALLET_MAINNET_MNEMONIC**: The mnemonic of the wallet used to interact with the smart contract. This only needs
-       minimal funds, to cover the CARDANO Network fees. If you do not provide a mnemonic, a new one will be
-       generated. Please ensure you export them immediately after creation and store them securely.
-     - **COLLECTION_WALLET_PREPROD_ADDRESS** and **COLLECTION_WALLET_MAINNET_ADDRESS**: The wallet address of the collection wallet. It will receive all payments after
-       a successful and completed purchase (not refund). It does not need any funds, however it is strongly recommended
-       to create it via a hardware wallet or ensure its secret is stored securely. If you do not provide an address,
-       the SELLING_WALLET will be used.
+### Seeding a new database
+
+The seed script reads **network-specific** Blockfrost keys — there is no generic `BLOCKFROST_API_KEY` variable.
+
+| Network | Required for seed | Variable |
+| ------- | ----------------- | -------- |
+| Preprod | Yes (default install path) | **BLOCKFROST_API_KEY_PREPROD** |
+| Mainnet | Only when mainnet payment sources are configured | **BLOCKFROST_API_KEY_MAINNET** |
+
+Obtain free API keys at [https://blockfrost.io/](https://blockfrost.io/) for the network you are using.
+
+When seeding, you also need:
+
+- **ADMIN_KEY**: The key of the admin user. This key has all permissions and can create new api_keys.
+- OPTIONAL wallet data — used to configure payment and purchase hot wallets, or leave blank to generate new mnemonics during seed (see `prisma/seed.ts`):
+  - **PURCHASE_WALLET_PREPROD_MNEMONIC** / **PURCHASE_WALLET_MAINNET_MNEMONIC**: Purchasing hot wallet mnemonics
+  - **SELLING_WALLET_PREPROD_MNEMONIC** / **SELLING_WALLET_MAINNET_MNEMONIC**: Selling hot wallet mnemonics
+  - **COLLECTION_WALLET_PREPROD_ADDRESS** / **COLLECTION_WALLET_MAINNET_ADDRESS**: Collection wallet addresses (strongly recommended via hardware wallet). If omitted, the selling wallet address is used.
 
 ## Frontend Build Variables
 


### PR DESCRIPTION
## **Purpose of this Pull Request**

[X] Documentation update  
[ ] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Documentation fixes for admin setup, migrations, and Blockfrost keys.

- Document `pnpm -C frontend run build` before `/admin/` works, and that root `pnpm run build` does not build the frontend
- Use `pnpm run prisma:migrate` in the install path; document `prisma:migrate:dev` for contributors who create migrations
- Remove unsupported `BLOCKFROST_API_KEY`; document `BLOCKFROST_API_KEY_PREPROD` and `BLOCKFROST_API_KEY_MAINNET`

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-475
https://linear.app/masumi/issue/MAS-476
https://linear.app/masumi/issue/MAS-478

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**
