### PR TITLE
feat(frontend): add a review step to agent registration (MAS-496)

### DIFF
--- a/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
+++ b/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
@@ -42,6 +42,14 @@ import { PaymentOptionsSection } from './PaymentOptionsSection';
 import { RegisterAgentDetailsSection } from './RegisterAgentDetailsSection';
 import { RegisterAgentWalletSection } from './RegisterAgentWalletSection';
 import { RegisterAgentAdditionalSection } from './RegisterAgentAdditionalSection';
+import { RegisterAgentReviewSection } from './RegisterAgentReviewSection';
+import {
+  getRegisterAgentConfirmButtonLabel,
+  getRegisterAgentReviewStepButtonLabel,
+  getRegisterAgentReviewTitle,
+  type RegisterAgentDialogStep,
+} from '@/lib/register-agent-review';
+import { Spinner } from '@/components/ui/spinner';
 
 interface RegisterAIAgentDialogProps {
   open: boolean;
@@ -92,6 +100,8 @@ export function RegisterAIAgentDialog({
   const isReRegisterMode = !isUpdateMode && !!prefillAgent;
   const sourceAgent = editingAgent ?? prefillAgent ?? null;
   const [isLoading, setIsLoading] = useState(false);
+  const [step, setStep] = useState<RegisterAgentDialogStep>('form');
+  const [reviewValues, setReviewValues] = useState<AgentFormValues | null>(null);
   // Author/legal/capability/example-output fields are all optional, so collapse
   // them by default to shorten the form; auto-expand when editing/re-registering
   // an existing agent (below) so its saved values are visible.
@@ -157,6 +167,7 @@ export function RegisterAIAgentDialog({
   const selectedWalletVkey = watch('selectedWallet');
   const selectedRecipientWalletAddress = watch('recipientWalletAddress');
   const selectedSendFundingAda = watch('sendFundingAda');
+  const pricingType = watch('pricingType');
   useEffect(() => {
     setSellingWallets(
       wallets
@@ -217,6 +228,8 @@ export function RegisterAIAgentDialog({
 
   useEffect(() => {
     if (!open) return;
+    setStep('form');
+    setReviewValues(null);
     // Expanded when there's an agent to review (update/re-register), collapsed
     // for a fresh registration.
     setShowAdditional(Boolean(sourceAgent));
@@ -607,6 +620,47 @@ export function RegisterAIAgentDialog({
     ],
   );
 
+  const mintingWalletLabel = useMemo(() => {
+    if (isUpdateMode) {
+      return editingAgent?.SmartContractWallet?.walletAddress
+        ? editingAgent.SmartContractWallet.walletAddress
+        : 'Current holder wallet';
+    }
+    const match = sellingWallets.find((w) => w.wallet.walletVkey === selectedWalletVkey);
+    if (!match) return '—';
+    return match.wallet.note
+      ? `${match.wallet.note} (${match.wallet.walletAddress})`
+      : match.wallet.walletAddress;
+  }, [isUpdateMode, editingAgent, sellingWallets, selectedWalletVkey]);
+
+  const holdingWalletLabel = useMemo(() => {
+    if (!selectedRecipientWalletAddress) return 'Use minting wallet (default)';
+    const match = recipientWalletOptions.find(
+      (w) => w.walletAddress === selectedRecipientWalletAddress,
+    );
+    if (!match) return selectedRecipientWalletAddress;
+    return match.note ? `${match.note} (${match.walletAddress})` : match.walletAddress;
+  }, [selectedRecipientWalletAddress, recipientWalletOptions]);
+
+  const pricingSummary = useMemo(() => {
+    if (isV2Target) {
+      return masumiOptions.length > 0 || x402Options.length > 0
+        ? 'Per payment-source options (V2)'
+        : 'No payment options selected';
+    }
+    return pricingType;
+  }, [isV2Target, masumiOptions.length, x402Options.length, pricingType]);
+
+  const goToReview = handleSubmit((data) => {
+    setReviewValues(data);
+    setStep('review');
+  });
+
+  const handleConfirm = useCallback(async () => {
+    if (!reviewValues) return;
+    await onSubmit(reviewValues);
+  }, [onSubmit, reviewValues]);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent size="lg" className="overflow-y-auto" elevatedChildStack={elevatedChildStack}>
@@ -626,92 +680,133 @@ export function RegisterAIAgentDialog({
                 : 'This registers your agent on the Masumi Network, making it visible to everyone.'}
           </p>
         </DialogHeader>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-          <RegisterAgentDetailsSection
-            register={register}
-            errors={errors}
-            watch={watch}
-            setValue={setValue}
-            typeLocked={isUpdateMode}
-          />
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (step === 'review') {
+              void handleConfirm();
+            }
+          }}
+          className="space-y-6"
+        >
+          {step === 'form' ? (
+            <>
+              <RegisterAgentDetailsSection
+                register={register}
+                errors={errors}
+                watch={watch}
+                setValue={setValue}
+                typeLocked={isUpdateMode}
+              />
 
-          <RegisterAgentWalletSection
-            isUpdateMode={isUpdateMode}
-            editingAgentWalletAddress={editingAgent?.SmartContractWallet?.walletAddress}
-            control={control}
-            errors={errors}
-            register={register}
-            isLoadingWallets={isLoadingWallets}
-            sellingWallets={sellingWallets}
-            hasSelectedWallet={!!selectedWallet}
-            recipientWalletOptions={recipientWalletOptions}
-            selectedRecipientWalletAddress={selectedRecipientWalletAddress}
-          />
+              <RegisterAgentWalletSection
+                isUpdateMode={isUpdateMode}
+                editingAgentWalletAddress={editingAgent?.SmartContractWallet?.walletAddress}
+                control={control}
+                errors={errors}
+                register={register}
+                isLoadingWallets={isLoadingWallets}
+                sellingWallets={sellingWallets}
+                hasSelectedWallet={!!selectedWallet}
+                recipientWalletOptions={recipientWalletOptions}
+                selectedRecipientWalletAddress={selectedRecipientWalletAddress}
+              />
 
-          <PaymentOptionsSection
-            rows={paymentOptionRows}
-            masumiOptions={masumiOptions}
-            x402Options={x402Options}
-            masumiError={masumiError}
-            x402Error={x402Error}
-            isV2Target={isV2Target}
-            network={network}
-            stablecoinUnit={stablecoinUnit}
-            defaultPriceUnit={defaultPriceUnit}
-            x402Networks={x402Networks}
-            x402Wallets={x402Wallets}
-            isLoadingX402Wallets={isLoadingX402Wallets}
-            onAddOption={addPaymentOption}
-            onChangeOptionType={changePaymentOptionType}
-            onRemoveOption={removePaymentOption}
-            onMasumiOptionChange={changeMasumiOption}
-            onX402OptionChange={changeX402Option}
-            control={control}
-            watch={watch}
-            errors={errors}
-            register={register}
-            priceFields={priceFields}
-            appendPrice={appendPrice}
-            removePrice={removePrice}
-            replacePrices={replacePrices}
-          />
+              <PaymentOptionsSection
+                rows={paymentOptionRows}
+                masumiOptions={masumiOptions}
+                x402Options={x402Options}
+                masumiError={masumiError}
+                x402Error={x402Error}
+                isV2Target={isV2Target}
+                network={network}
+                stablecoinUnit={stablecoinUnit}
+                defaultPriceUnit={defaultPriceUnit}
+                x402Networks={x402Networks}
+                x402Wallets={x402Wallets}
+                isLoadingX402Wallets={isLoadingX402Wallets}
+                onAddOption={addPaymentOption}
+                onChangeOptionType={changePaymentOptionType}
+                onRemoveOption={removePaymentOption}
+                onMasumiOptionChange={changeMasumiOption}
+                onX402OptionChange={changeX402Option}
+                control={control}
+                watch={watch}
+                errors={errors}
+                register={register}
+                priceFields={priceFields}
+                appendPrice={appendPrice}
+                removePrice={removePrice}
+                replacePrices={replacePrices}
+              />
 
-          {isV2Target && (
-            <VerificationsSection
-              verifications={verifications}
-              onChange={setVerifications}
-              error={verificationsError}
-            />
+              {isV2Target && (
+                <VerificationsSection
+                  verifications={verifications}
+                  onChange={setVerifications}
+                  error={verificationsError}
+                />
+              )}
+
+              <RegisterAgentAdditionalSection
+                show={showAdditional}
+                onToggle={() => setShowAdditional((v) => !v)}
+                register={register}
+                errors={errors}
+                exampleOutputFields={exampleOutputFields}
+                appendExampleOutput={appendExampleOutput}
+                removeExampleOutput={removeExampleOutput}
+              />
+            </>
+          ) : (
+            reviewValues && (
+              <RegisterAgentReviewSection
+                values={reviewValues}
+                mintingWalletLabel={mintingWalletLabel}
+                holdingWalletLabel={holdingWalletLabel}
+                masumiOptionCount={masumiOptions.length}
+                x402OptionCount={x402Options.length}
+                verificationCount={verifications.length}
+                pricingSummary={String(pricingSummary)}
+              />
+            )
           )}
-
-          <RegisterAgentAdditionalSection
-            show={showAdditional}
-            onToggle={() => setShowAdditional((v) => !v)}
-            register={register}
-            errors={errors}
-            exampleOutputFields={exampleOutputFields}
-            appendExampleOutput={appendExampleOutput}
-            removeExampleOutput={removeExampleOutput}
-          />
 
           <div className="flex justify-end items-center gap-2">
             <Button variant="outline" onClick={onClose} type="button">
               Cancel
             </Button>
             <div className="flex items-center gap-2">
-              <Button type="submit" disabled={isLoading || (isLoadingWallets && !isUpdateMode)}>
-                {isLoading
-                  ? isUpdateMode
-                    ? 'Updating...'
-                    : isReRegisterMode
-                      ? 'Re-registering...'
-                      : 'Registering...'
-                  : isUpdateMode
-                    ? 'Update'
-                    : isReRegisterMode
-                      ? 'Re-register'
-                      : 'Register'}
-              </Button>
+              {step === 'review' && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setStep('form')}
+                  disabled={isLoading}
+                >
+                  Back
+                </Button>
+              )}
+              {step === 'form' ? (
+                <Button
+                  type="button"
+                  className="gap-2"
+                  disabled={isLoadingWallets && !isUpdateMode}
+                  onClick={() => void goToReview()}
+                >
+                  {isLoadingWallets && !isUpdateMode && <Spinner size={14} />}
+                  {getRegisterAgentReviewStepButtonLabel({ isUpdateMode, isReRegisterMode })}
+                </Button>
+              ) : (
+                <Button type="submit" className="gap-2" disabled={isLoading || !reviewValues}>
+                  {isLoading && <Spinner size={14} />}
+                  {getRegisterAgentConfirmButtonLabel({
+                    isSubmitting: isLoading,
+                    isUpdateMode,
+                    isReRegisterMode,
+                  })}
+                </Button>
+              )}
             </div>
           </div>
         </form>

--- a/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
+++ b/frontend/src/components/ai-agents/RegisterAIAgentDialog.tsx
@@ -45,11 +45,15 @@ import { RegisterAgentAdditionalSection } from './RegisterAgentAdditionalSection
 import { RegisterAgentReviewSection } from './RegisterAgentReviewSection';
 import {
   getRegisterAgentConfirmButtonLabel,
+  getRegisterAgentFormDescription,
+  getRegisterAgentReviewDescription,
   getRegisterAgentReviewStepButtonLabel,
   getRegisterAgentReviewTitle,
   type RegisterAgentDialogStep,
 } from '@/lib/register-agent-review';
 import { Spinner } from '@/components/ui/spinner';
+import { ArrowRight } from 'lucide-react';
+import { shortenAddress } from '@/lib/utils';
 
 interface RegisterAIAgentDialogProps {
   open: boolean;
@@ -357,6 +361,10 @@ export function RegisterAIAgentDialog({
 
   const onSubmit = useCallback(
     async (data: AgentFormValues) => {
+      const returnToFormForFieldFix = () => {
+        setStep('form');
+      };
+
       try {
         setIsLoading(true);
         const selectedWalletVkey = data.selectedWallet;
@@ -374,6 +382,7 @@ export function RegisterAIAgentDialog({
             selectedWalletBalance <= MIN_MINT_BALANCE_LOVELACE
           ) {
             toast.error('Insufficient balance in selected wallet');
+            returnToFormForFieldFix();
             return;
           }
           // The picker only offers wallets from the active payment source, so a
@@ -402,6 +411,7 @@ export function RegisterAIAgentDialog({
           if ('error' in masumiValidation) {
             setMasumiError(masumiValidation.error);
             toast.error(masumiValidation.error.message);
+            returnToFormForFieldFix();
             return;
           }
           masumiPricingByOptionId = masumiValidation.pricingByOptionId;
@@ -414,6 +424,7 @@ export function RegisterAIAgentDialog({
             'x402 payment options require an active Web3 Cardano V2 payment source';
           setX402Error({ message: unavailableMessage });
           toast.error(unavailableMessage);
+          returnToFormForFieldFix();
           return;
         }
         if (x402Options.length > 0) {
@@ -430,6 +441,7 @@ export function RegisterAIAgentDialog({
               optionId: x402Options[x402ValidationError.index]?.id,
             });
             toast.error(x402ValidationError.message);
+            returnToFormForFieldFix();
             return;
           }
         }
@@ -439,6 +451,7 @@ export function RegisterAIAgentDialog({
           if (verificationsValidationError) {
             setVerificationsError(verificationsValidationError);
             toast.error(verificationsValidationError);
+            returnToFormForFieldFix();
             return;
           }
         }
@@ -622,15 +635,14 @@ export function RegisterAIAgentDialog({
 
   const mintingWalletLabel = useMemo(() => {
     if (isUpdateMode) {
-      return editingAgent?.SmartContractWallet?.walletAddress
-        ? editingAgent.SmartContractWallet.walletAddress
-        : 'Current holder wallet';
+      const address = editingAgent?.SmartContractWallet?.walletAddress;
+      return address ? shortenAddress(address, 8) : 'Current holder wallet';
     }
     const match = sellingWallets.find((w) => w.wallet.walletVkey === selectedWalletVkey);
     if (!match) return '—';
     return match.wallet.note
-      ? `${match.wallet.note} (${match.wallet.walletAddress})`
-      : match.wallet.walletAddress;
+      ? `${match.wallet.note} (${shortenAddress(match.wallet.walletAddress, 8)})`
+      : shortenAddress(match.wallet.walletAddress, 8);
   }, [isUpdateMode, editingAgent, sellingWallets, selectedWalletVkey]);
 
   const holdingWalletLabel = useMemo(() => {
@@ -638,9 +650,15 @@ export function RegisterAIAgentDialog({
     const match = recipientWalletOptions.find(
       (w) => w.walletAddress === selectedRecipientWalletAddress,
     );
-    if (!match) return selectedRecipientWalletAddress;
-    return match.note ? `${match.note} (${match.walletAddress})` : match.walletAddress;
+    if (!match) return shortenAddress(selectedRecipientWalletAddress, 8);
+    return match.note
+      ? `${match.note} (${shortenAddress(match.walletAddress, 8)})`
+      : shortenAddress(match.walletAddress, 8);
   }, [selectedRecipientWalletAddress, recipientWalletOptions]);
+
+  const returnToForm = useCallback(() => {
+    setStep('form');
+  }, []);
 
   const pricingSummary = useMemo(() => {
     if (isV2Target) {
@@ -653,7 +671,9 @@ export function RegisterAIAgentDialog({
 
   const goToReview = handleSubmit((data) => {
     setReviewValues(data);
-    setStep('review');
+    // Defer the step swap so the Review click cannot fall through onto the
+    // Confirm button that replaces it in the same screen position.
+    queueMicrotask(() => setStep('review'));
   });
 
   const handleConfirm = useCallback(async () => {
@@ -663,29 +683,41 @@ export function RegisterAIAgentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent size="lg" className="overflow-y-auto" elevatedChildStack={elevatedChildStack}>
+      <DialogContent
+        size="lg"
+        className="overflow-y-auto"
+        elevatedChildStack={elevatedChildStack}
+        hideClose={step === 'review'}
+        onInteractOutside={(event) => {
+          if (step !== 'review' || isLoading) return;
+          event.preventDefault();
+          returnToForm();
+        }}
+        onEscapeKeyDown={(event) => {
+          if (step !== 'review' || isLoading) return;
+          event.preventDefault();
+          returnToForm();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>
-            {isUpdateMode
-              ? 'Update AI Agent'
-              : isReRegisterMode
-                ? 'Re-register AI Agent'
-                : 'Register AI Agent'}
+            {step === 'review'
+              ? getRegisterAgentReviewTitle({ isUpdateMode, isReRegisterMode })
+              : isUpdateMode
+                ? 'Update AI Agent'
+                : isReRegisterMode
+                  ? 'Re-register AI Agent'
+                  : 'Register AI Agent'}
           </DialogTitle>
           <p className="text-sm text-muted-foreground mt-2">
-            {isUpdateMode
-              ? 'Updating the on-chain metadata issues an UpdateAction on the V2 registry contract: the existing asset is burned and a new asset with the incremented version is minted in a single transaction.'
-              : isReRegisterMode
-                ? 'This mints a brand-new registration from the previous agent’s details. It is issued a new agent identifier; the old, deregistered one is not reused. Review the fields and wallet below, then mint.'
-                : 'This registers your agent on the Masumi Network, making it visible to everyone.'}
+            {step === 'review'
+              ? getRegisterAgentReviewDescription({ isUpdateMode, isReRegisterMode })
+              : getRegisterAgentFormDescription({ isUpdateMode, isReRegisterMode })}
           </p>
         </DialogHeader>
         <form
           onSubmit={(event) => {
             event.preventDefault();
-            if (step === 'review') {
-              void handleConfirm();
-            }
           }}
           className="space-y-6"
         >
@@ -764,41 +796,49 @@ export function RegisterAIAgentDialog({
                 values={reviewValues}
                 mintingWalletLabel={mintingWalletLabel}
                 holdingWalletLabel={holdingWalletLabel}
-                masumiOptionCount={masumiOptions.length}
-                x402OptionCount={x402Options.length}
-                verificationCount={verifications.length}
+                paymentOptionRows={paymentOptionRows}
+                masumiOptions={masumiOptions}
+                x402Options={x402Options}
+                verifications={verifications}
+                isV2Target={isV2Target}
+                network={network}
                 pricingSummary={String(pricingSummary)}
               />
             )
           )}
 
           <div className="flex justify-end items-center gap-2">
-            <Button variant="outline" onClick={onClose} type="button">
-              Cancel
-            </Button>
+            {step === 'form' ? (
+              <Button variant="outline" onClick={onClose} type="button">
+                Cancel
+              </Button>
+            ) : (
+              <Button type="button" variant="outline" onClick={returnToForm} disabled={isLoading}>
+                Back
+              </Button>
+            )}
             <div className="flex items-center gap-2">
-              {step === 'review' && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setStep('form')}
-                  disabled={isLoading}
-                >
-                  Back
-                </Button>
-              )}
               {step === 'form' ? (
                 <Button
                   type="button"
-                  className="gap-2"
+                  className="gap-2 btn-hover-lift group"
                   disabled={isLoadingWallets && !isUpdateMode}
                   onClick={() => void goToReview()}
                 >
                   {isLoadingWallets && !isUpdateMode && <Spinner size={14} />}
                   {getRegisterAgentReviewStepButtonLabel({ isUpdateMode, isReRegisterMode })}
+                  <ArrowRight
+                    className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                    aria-hidden
+                  />
                 </Button>
               ) : (
-                <Button type="submit" className="gap-2" disabled={isLoading || !reviewValues}>
+                <Button
+                  type="button"
+                  className="gap-2 btn-hover-lift group"
+                  disabled={isLoading || !reviewValues}
+                  onClick={() => void handleConfirm()}
+                >
                   {isLoading && <Spinner size={14} />}
                   {getRegisterAgentConfirmButtonLabel({
                     isSubmitting: isLoading,

--- a/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
+++ b/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
@@ -1,13 +1,52 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ReactNode } from 'react';
 import { getAgentTypeLabel } from '@/lib/agent-type';
+import type { MasumiOptionDraft, PaymentOptionRow } from '@/lib/agent-registration';
+import type { NetworkType } from '@/lib/contexts/AppContext';
+import { formatFundUnit } from '@/lib/utils';
+import { formatPaymentOptionReviewLine } from '@/lib/register-agent-review';
+import type { X402OptionDraft } from '@/lib/x402-registration';
+import type { VerificationDraft } from './VerificationsSection';
 import type { AgentFormValues } from './register-agent-schema';
 
-function SummaryRow({ label, value }: { label: string; value: string }) {
+function ReviewSection({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div className="flex items-start justify-between gap-3 py-2 border-b last:border-b-0">
-      <span className="text-sm text-muted-foreground shrink-0">{label}</span>
-      <span className="text-sm text-right break-words">{value}</span>
+    <section className="overflow-hidden rounded-lg border bg-card">
+      <div className="border-b bg-muted/20 px-4 py-3">
+        <h3 className="text-sm font-medium">{title}</h3>
+      </div>
+      <div className="divide-y px-4">{children}</div>
+    </section>
+  );
+}
+
+function SummaryRow({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div className="py-3 first:pt-3 last:pb-3">
+      <div className="flex items-start justify-between gap-4">
+        <span className="text-sm text-muted-foreground shrink-0">{label}</span>
+        <span className="text-sm text-right break-words min-w-0">{value}</span>
+      </div>
+      {detail ? (
+        <p className="mt-1 text-xs text-muted-foreground text-right break-all">{detail}</p>
+      ) : null}
     </div>
+  );
+}
+
+function hasAdditionalDetails(values: AgentFormValues): boolean {
+  return Boolean(
+    values.authorName.trim() ||
+    values.authorEmail.trim() ||
+    values.organization.trim() ||
+    values.contactOther.trim() ||
+    values.termsOfUseUrl.trim() ||
+    values.privacyPolicyUrl.trim() ||
+    values.otherUrl.trim() ||
+    values.capabilityName.trim() ||
+    values.capabilityVersion.trim() ||
+    values.exampleOutputs.some(
+      (example) => example.name.trim() || example.url.trim() || example.mimeType.trim(),
+    ),
   );
 }
 
@@ -15,62 +54,138 @@ export function RegisterAgentReviewSection({
   values,
   mintingWalletLabel,
   holdingWalletLabel,
-  masumiOptionCount,
-  x402OptionCount,
-  verificationCount,
+  paymentOptionRows,
+  masumiOptions,
+  x402Options,
+  verifications,
+  isV2Target,
+  network,
   pricingSummary,
 }: {
   values: AgentFormValues;
   mintingWalletLabel: string;
   holdingWalletLabel: string;
-  masumiOptionCount: number;
-  x402OptionCount: number;
-  verificationCount: number;
+  paymentOptionRows: PaymentOptionRow[];
+  masumiOptions: MasumiOptionDraft[];
+  x402Options: X402OptionDraft[];
+  verifications: VerificationDraft[];
+  isV2Target: boolean;
+  network: NetworkType;
   pricingSummary: string;
 }) {
-  return (
-    <div className="space-y-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">Agent details</CardTitle>
-        </CardHeader>
-        <CardContent className="px-3 bg-muted/40 border rounded-md mx-6 mb-4">
-          <SummaryRow label="Name" value={values.name} />
-          <SummaryRow label="Type" value={getAgentTypeLabel(values.agentType)} />
-          <SummaryRow label="Description" value={values.description || '—'} />
-          {values.agentType === 'Standard' && values.apiUrl && (
-            <SummaryRow label="API URL" value={values.apiUrl} />
-          )}
-          {values.agentType === 'OpenApi' && values.openApiSpecUrl && (
-            <SummaryRow label="OpenAPI spec" value={values.openApiSpecUrl} />
-          )}
-          {values.agentType === 'X402' && values.x402ResourcesUrl && (
-            <SummaryRow label="x402 resources" value={values.x402ResourcesUrl} />
-          )}
-          <SummaryRow label="Tags" value={values.tags.length ? values.tags.join(', ') : '—'} />
-        </CardContent>
-      </Card>
+  const legacyPriceSummary =
+    !isV2Target && values.pricingType === 'Fixed'
+      ? values.prices
+          .filter((price) => price.amount.trim())
+          .map((price) => `${price.amount} ${formatFundUnit(price.unit, network)}`)
+          .join(', ') || 'Fixed pricing (no amount set)'
+      : null;
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">Wallets & pricing</CardTitle>
-        </CardHeader>
-        <CardContent className="px-3 bg-muted/40 border rounded-md mx-6 mb-4">
-          <SummaryRow label="Minting wallet" value={mintingWalletLabel} />
-          <SummaryRow label="Holding wallet" value={holdingWalletLabel} />
-          {values.sendFundingAda ? (
-            <SummaryRow label="Holding wallet funding" value={`${values.sendFundingAda} ADA`} />
+  return (
+    <div className="space-y-3">
+      <ReviewSection title="Agent details">
+        <SummaryRow label="Name" value={values.name} />
+        <SummaryRow label="Type" value={getAgentTypeLabel(values.agentType)} />
+        <SummaryRow label="Description" value={values.description || '—'} />
+        {values.agentType === 'Standard' && values.apiUrl ? (
+          <SummaryRow label="API URL" value={values.apiUrl} />
+        ) : null}
+        {values.agentType === 'OpenApi' && values.openApiSpecUrl ? (
+          <SummaryRow label="OpenAPI spec" value={values.openApiSpecUrl} />
+        ) : null}
+        {values.agentType === 'X402' && values.x402ResourcesUrl ? (
+          <SummaryRow label="x402 resources" value={values.x402ResourcesUrl} />
+        ) : null}
+        <SummaryRow label="Tags" value={values.tags.length ? values.tags.join(', ') : '—'} />
+      </ReviewSection>
+
+      <ReviewSection title="Wallets & pricing">
+        <SummaryRow label="Minting wallet" value={mintingWalletLabel} />
+        <SummaryRow label="Holding wallet" value={holdingWalletLabel} />
+        {values.sendFundingAda ? (
+          <SummaryRow label="Holding wallet funding" value={`${values.sendFundingAda} ADA`} />
+        ) : null}
+        <SummaryRow label="Pricing" value={legacyPriceSummary ?? pricingSummary} />
+      </ReviewSection>
+
+      {paymentOptionRows.length > 0 ? (
+        <ReviewSection title="Payment options">
+          {paymentOptionRows.map((optionRow, optionIndex) => {
+            const masumiOption =
+              optionRow.type === 'Masumi'
+                ? masumiOptions.find((option) => option.id === optionRow.id)
+                : undefined;
+            const x402Option =
+              optionRow.type === 'x402'
+                ? x402Options.find((option) => option.id === optionRow.id)
+                : undefined;
+            const line = formatPaymentOptionReviewLine({
+              optionRow,
+              optionIndex,
+              masumiOption,
+              x402Option,
+              network,
+            });
+            return (
+              <SummaryRow
+                key={optionRow.id}
+                label={line.title}
+                value={line.summary}
+                detail={line.detail}
+              />
+            );
+          })}
+        </ReviewSection>
+      ) : null}
+
+      {verifications.length > 0 ? (
+        <ReviewSection title="Verifications">
+          {verifications.map((verification, index) => (
+            <SummaryRow
+              key={verification.id}
+              label={`Verification ${index + 1}`}
+              value={verification.method}
+              detail={verification.issuerAid ? `Issuer ${verification.issuerAid}` : undefined}
+            />
+          ))}
+        </ReviewSection>
+      ) : null}
+
+      {hasAdditionalDetails(values) ? (
+        <ReviewSection title="Additional details">
+          {values.authorName.trim() ? (
+            <SummaryRow label="Author" value={values.authorName} />
           ) : null}
-          <SummaryRow label="Pricing" value={pricingSummary} />
-          <SummaryRow
-            label="Payment options"
-            value={`${masumiOptionCount} Masumi · ${x402OptionCount} x402`}
-          />
-          {verificationCount > 0 ? (
-            <SummaryRow label="Verifications" value={`${verificationCount} configured`} />
+          {values.authorEmail.trim() ? (
+            <SummaryRow label="Author email" value={values.authorEmail} />
           ) : null}
-        </CardContent>
-      </Card>
+          {values.organization.trim() ? (
+            <SummaryRow label="Organization" value={values.organization} />
+          ) : null}
+          {values.contactOther.trim() ? (
+            <SummaryRow label="Contact" value={values.contactOther} />
+          ) : null}
+          {values.termsOfUseUrl.trim() ? (
+            <SummaryRow label="Terms of use" value={values.termsOfUseUrl} />
+          ) : null}
+          {values.privacyPolicyUrl.trim() ? (
+            <SummaryRow label="Privacy policy" value={values.privacyPolicyUrl} />
+          ) : null}
+          {values.otherUrl.trim() ? <SummaryRow label="Other URL" value={values.otherUrl} /> : null}
+          {values.capabilityName.trim() || values.capabilityVersion.trim() ? (
+            <SummaryRow
+              label="Capability"
+              value={[values.capabilityName, values.capabilityVersion].filter(Boolean).join(' · ')}
+            />
+          ) : null}
+          {values.exampleOutputs.some((example) => example.name.trim() || example.url.trim()) ? (
+            <SummaryRow
+              label="Example outputs"
+              value={`${values.exampleOutputs.filter((example) => example.name.trim() || example.url.trim()).length} configured`}
+            />
+          ) : null}
+        </ReviewSection>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
+++ b/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
@@ -34,17 +34,18 @@ function SummaryRow({ label, value, detail }: { label: string; value: string; de
 }
 
 function hasAdditionalDetails(values: AgentFormValues): boolean {
+  const exampleOutputs = values.exampleOutputs ?? [];
   return Boolean(
-    values.authorName.trim() ||
-    values.authorEmail.trim() ||
-    values.organization.trim() ||
-    values.contactOther.trim() ||
-    values.termsOfUseUrl.trim() ||
-    values.privacyPolicyUrl.trim() ||
-    values.otherUrl.trim() ||
-    values.capabilityName.trim() ||
-    values.capabilityVersion.trim() ||
-    values.exampleOutputs.some(
+    values.authorName?.trim() ||
+    values.authorEmail?.trim() ||
+    values.organization?.trim() ||
+    values.contactOther?.trim() ||
+    values.termsOfUseUrl?.trim() ||
+    values.privacyPolicyUrl?.trim() ||
+    values.otherUrl?.trim() ||
+    values.capabilityName?.trim() ||
+    values.capabilityVersion?.trim() ||
+    exampleOutputs.some(
       (example) => example.name.trim() || example.url.trim() || example.mimeType.trim(),
     ),
   );
@@ -153,35 +154,39 @@ export function RegisterAgentReviewSection({
 
       {hasAdditionalDetails(values) ? (
         <ReviewSection title="Additional details">
-          {values.authorName.trim() ? (
+          {values.authorName?.trim() ? (
             <SummaryRow label="Author" value={values.authorName} />
           ) : null}
-          {values.authorEmail.trim() ? (
+          {values.authorEmail?.trim() ? (
             <SummaryRow label="Author email" value={values.authorEmail} />
           ) : null}
-          {values.organization.trim() ? (
+          {values.organization?.trim() ? (
             <SummaryRow label="Organization" value={values.organization} />
           ) : null}
-          {values.contactOther.trim() ? (
+          {values.contactOther?.trim() ? (
             <SummaryRow label="Contact" value={values.contactOther} />
           ) : null}
-          {values.termsOfUseUrl.trim() ? (
+          {values.termsOfUseUrl?.trim() ? (
             <SummaryRow label="Terms of use" value={values.termsOfUseUrl} />
           ) : null}
-          {values.privacyPolicyUrl.trim() ? (
+          {values.privacyPolicyUrl?.trim() ? (
             <SummaryRow label="Privacy policy" value={values.privacyPolicyUrl} />
           ) : null}
-          {values.otherUrl.trim() ? <SummaryRow label="Other URL" value={values.otherUrl} /> : null}
-          {values.capabilityName.trim() || values.capabilityVersion.trim() ? (
+          {values.otherUrl?.trim() ? (
+            <SummaryRow label="Other URL" value={values.otherUrl} />
+          ) : null}
+          {values.capabilityName?.trim() || values.capabilityVersion?.trim() ? (
             <SummaryRow
               label="Capability"
               value={[values.capabilityName, values.capabilityVersion].filter(Boolean).join(' · ')}
             />
           ) : null}
-          {values.exampleOutputs.some((example) => example.name.trim() || example.url.trim()) ? (
+          {(values.exampleOutputs ?? []).some(
+            (example) => example.name.trim() || example.url.trim(),
+          ) ? (
             <SummaryRow
               label="Example outputs"
-              value={`${values.exampleOutputs.filter((example) => example.name.trim() || example.url.trim()).length} configured`}
+              value={`${(values.exampleOutputs ?? []).filter((example) => example.name.trim() || example.url.trim()).length} configured`}
             />
           ) : null}
         </ReviewSection>

--- a/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
+++ b/frontend/src/components/ai-agents/RegisterAgentReviewSection.tsx
@@ -1,0 +1,76 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getAgentTypeLabel } from '@/lib/agent-type';
+import type { AgentFormValues } from './register-agent-schema';
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 py-2 border-b last:border-b-0">
+      <span className="text-sm text-muted-foreground shrink-0">{label}</span>
+      <span className="text-sm text-right break-words">{value}</span>
+    </div>
+  );
+}
+
+export function RegisterAgentReviewSection({
+  values,
+  mintingWalletLabel,
+  holdingWalletLabel,
+  masumiOptionCount,
+  x402OptionCount,
+  verificationCount,
+  pricingSummary,
+}: {
+  values: AgentFormValues;
+  mintingWalletLabel: string;
+  holdingWalletLabel: string;
+  masumiOptionCount: number;
+  x402OptionCount: number;
+  verificationCount: number;
+  pricingSummary: string;
+}) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Agent details</CardTitle>
+        </CardHeader>
+        <CardContent className="px-3 bg-muted/40 border rounded-md mx-6 mb-4">
+          <SummaryRow label="Name" value={values.name} />
+          <SummaryRow label="Type" value={getAgentTypeLabel(values.agentType)} />
+          <SummaryRow label="Description" value={values.description || '—'} />
+          {values.agentType === 'Standard' && values.apiUrl && (
+            <SummaryRow label="API URL" value={values.apiUrl} />
+          )}
+          {values.agentType === 'OpenApi' && values.openApiSpecUrl && (
+            <SummaryRow label="OpenAPI spec" value={values.openApiSpecUrl} />
+          )}
+          {values.agentType === 'X402' && values.x402ResourcesUrl && (
+            <SummaryRow label="x402 resources" value={values.x402ResourcesUrl} />
+          )}
+          <SummaryRow label="Tags" value={values.tags.length ? values.tags.join(', ') : '—'} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Wallets & pricing</CardTitle>
+        </CardHeader>
+        <CardContent className="px-3 bg-muted/40 border rounded-md mx-6 mb-4">
+          <SummaryRow label="Minting wallet" value={mintingWalletLabel} />
+          <SummaryRow label="Holding wallet" value={holdingWalletLabel} />
+          {values.sendFundingAda ? (
+            <SummaryRow label="Holding wallet funding" value={`${values.sendFundingAda} ADA`} />
+          ) : null}
+          <SummaryRow label="Pricing" value={pricingSummary} />
+          <SummaryRow
+            label="Payment options"
+            value={`${masumiOptionCount} Masumi · ${x402OptionCount} x402`}
+          />
+          {verificationCount > 0 ? (
+            <SummaryRow label="Verifications" value={`${verificationCount} configured`} />
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -38,6 +38,9 @@ const DialogContent = React.forwardRef<
     isPushedBack?: boolean;
     hideOverlay?: boolean;
     onBack?: () => void;
+    /** Where the back control renders when `onBack` is set. Default: leading (top-left). */
+    onBackPosition?: 'leading' | 'trailing';
+    backDisabled?: boolean;
     /**
      * Standard modal width scale. Prefer this over ad-hoc `max-w-[...]` classes
      * so dialogs stay visually consistent: sm=480 (compact forms/confirms),
@@ -61,6 +64,8 @@ const DialogContent = React.forwardRef<
       isPushedBack,
       hideOverlay,
       onBack,
+      onBackPosition = 'leading',
+      backDisabled,
       size,
       elevatedStack,
       elevatedChildStack,
@@ -117,17 +122,30 @@ const DialogContent = React.forwardRef<
             variantClass,
             isPushedBack !== undefined && 'dialog-content-stackable',
             isPushedBack && 'is-pushed-back',
-            onBack && 'pt-12',
+            onBack && onBackPosition === 'leading' && 'pt-12',
             sizeClass,
             className,
           )}
           {...props}
         >
           {children}
-          {onBack && (
+          {onBack && onBackPosition === 'leading' && (
             <button
+              type="button"
               onClick={onBack}
-              className="absolute left-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              disabled={backDisabled}
+              className="absolute left-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              <span className="sr-only">Back</span>
+            </button>
+          )}
+          {onBack && onBackPosition === 'trailing' && (
+            <button
+              type="button"
+              onClick={onBack}
+              disabled={backDisabled}
+              className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-40"
             >
               <ArrowLeft className="h-4 w-4" />
               <span className="sr-only">Back</span>

--- a/frontend/src/lib/register-agent-review.test.ts
+++ b/frontend/src/lib/register-agent-review.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  formatMasumiOptionReviewSummary,
+  formatPaymentOptionReviewLine,
+  formatX402OptionReviewSummary,
   getRegisterAgentConfirmButtonLabel,
+  getRegisterAgentFormDescription,
+  getRegisterAgentReviewDescription,
   getRegisterAgentReviewStepButtonLabel,
   getRegisterAgentReviewTitle,
 } from './register-agent-review';
@@ -9,7 +14,11 @@ import {
 test('register review labels vary by dialog mode', () => {
   assert.equal(
     getRegisterAgentReviewStepButtonLabel({ isUpdateMode: false, isReRegisterMode: false }),
-    'Review',
+    'Continue',
+  );
+  assert.equal(
+    getRegisterAgentReviewStepButtonLabel({ isUpdateMode: true, isReRegisterMode: false }),
+    'Continue',
   );
   assert.equal(
     getRegisterAgentReviewTitle({ isUpdateMode: true, isReRegisterMode: false }),
@@ -30,5 +39,60 @@ test('register review labels vary by dialog mode', () => {
       isReRegisterMode: false,
     }),
     'Updating...',
+  );
+});
+
+test('register review descriptions are step-aware', () => {
+  assert.match(
+    getRegisterAgentFormDescription({ isUpdateMode: false, isReRegisterMode: false }),
+    /registers your agent/i,
+  );
+  assert.match(
+    getRegisterAgentReviewDescription({ isUpdateMode: false, isReRegisterMode: false }),
+    /Use Back/i,
+  );
+  assert.doesNotMatch(
+    getRegisterAgentReviewDescription({ isUpdateMode: false, isReRegisterMode: true }),
+    /below, then mint/i,
+  );
+});
+
+test('register review payment summaries include concrete pricing', () => {
+  assert.equal(
+    formatMasumiOptionReviewSummary(
+      {
+        id: 'masumi-1',
+        pricingType: 'Fixed',
+        prices: [{ unit: 'lovelace', amount: '5' }],
+      },
+      'Preprod',
+    ),
+    '5 tADA',
+  );
+  assert.match(
+    formatX402OptionReviewSummary({
+      id: 'x402-1',
+      pricingType: 'Fixed',
+      caip2Network: 'eip155:84532',
+      asset: '0x036CbD53842c542663c0287200f0f0f0f0f0f0f0',
+      amount: '1.25',
+      decimals: '6',
+      payTo: '0x1234567890123456789012345678901234567890',
+      resource: 'https://example.com/resource',
+    }),
+    /1\.25 0x036C\.\.\..* on eip155:84532/,
+  );
+  assert.match(
+    formatPaymentOptionReviewLine({
+      optionRow: { id: 'masumi-1', type: 'Masumi' },
+      optionIndex: 0,
+      masumiOption: {
+        id: 'masumi-1',
+        pricingType: 'Free',
+        prices: [],
+      },
+      network: 'Mainnet',
+    }).summary,
+    /Masumi · Free/,
   );
 });

--- a/frontend/src/lib/register-agent-review.test.ts
+++ b/frontend/src/lib/register-agent-review.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  getRegisterAgentConfirmButtonLabel,
+  getRegisterAgentReviewStepButtonLabel,
+  getRegisterAgentReviewTitle,
+} from './register-agent-review';
+
+test('register review labels vary by dialog mode', () => {
+  assert.equal(
+    getRegisterAgentReviewStepButtonLabel({ isUpdateMode: false, isReRegisterMode: false }),
+    'Review',
+  );
+  assert.equal(
+    getRegisterAgentReviewTitle({ isUpdateMode: true, isReRegisterMode: false }),
+    'Review update',
+  );
+  assert.equal(
+    getRegisterAgentConfirmButtonLabel({
+      isSubmitting: false,
+      isUpdateMode: false,
+      isReRegisterMode: true,
+    }),
+    'Confirm re-registration',
+  );
+  assert.equal(
+    getRegisterAgentConfirmButtonLabel({
+      isSubmitting: true,
+      isUpdateMode: true,
+      isReRegisterMode: false,
+    }),
+    'Updating...',
+  );
+});

--- a/frontend/src/lib/register-agent-review.ts
+++ b/frontend/src/lib/register-agent-review.ts
@@ -1,0 +1,34 @@
+export type RegisterAgentDialogStep = 'form' | 'review';
+
+export function getRegisterAgentReviewStepButtonLabel(input: {
+  isUpdateMode: boolean;
+  isReRegisterMode: boolean;
+}): string {
+  if (input.isUpdateMode) return 'Review update';
+  if (input.isReRegisterMode) return 'Review re-registration';
+  return 'Review';
+}
+
+export function getRegisterAgentReviewTitle(input: {
+  isUpdateMode: boolean;
+  isReRegisterMode: boolean;
+}): string {
+  if (input.isUpdateMode) return 'Review update';
+  if (input.isReRegisterMode) return 'Review re-registration';
+  return 'Review registration';
+}
+
+export function getRegisterAgentConfirmButtonLabel(input: {
+  isSubmitting: boolean;
+  isUpdateMode: boolean;
+  isReRegisterMode: boolean;
+}): string {
+  if (input.isSubmitting) {
+    if (input.isUpdateMode) return 'Updating...';
+    if (input.isReRegisterMode) return 'Re-registering...';
+    return 'Registering...';
+  }
+  if (input.isUpdateMode) return 'Confirm update';
+  if (input.isReRegisterMode) return 'Confirm re-registration';
+  return 'Confirm registration';
+}

--- a/frontend/src/lib/register-agent-review.ts
+++ b/frontend/src/lib/register-agent-review.ts
@@ -1,12 +1,15 @@
+import type { MasumiOptionDraft, PaymentOptionRow } from '@/lib/agent-registration';
+import type { X402OptionDraft } from '@/lib/x402-registration';
+import { formatFundUnit, shortenAddress } from '@/lib/utils';
+import type { NetworkType } from '@/lib/contexts/AppContext';
+
 export type RegisterAgentDialogStep = 'form' | 'review';
 
-export function getRegisterAgentReviewStepButtonLabel(input: {
+export function getRegisterAgentReviewStepButtonLabel(_input: {
   isUpdateMode: boolean;
   isReRegisterMode: boolean;
 }): string {
-  if (input.isUpdateMode) return 'Review update';
-  if (input.isReRegisterMode) return 'Review re-registration';
-  return 'Review';
+  return 'Continue';
 }
 
 export function getRegisterAgentReviewTitle(input: {
@@ -16,6 +19,32 @@ export function getRegisterAgentReviewTitle(input: {
   if (input.isUpdateMode) return 'Review update';
   if (input.isReRegisterMode) return 'Review re-registration';
   return 'Review registration';
+}
+
+export function getRegisterAgentFormDescription(input: {
+  isUpdateMode: boolean;
+  isReRegisterMode: boolean;
+}): string {
+  if (input.isUpdateMode) {
+    return 'Updating the on-chain metadata issues an UpdateAction on the V2 registry contract: the existing asset is burned and a new asset with the incremented version is minted in a single transaction.';
+  }
+  if (input.isReRegisterMode) {
+    return 'This mints a brand-new registration from the previous agent’s details. It is issued a new agent identifier; the old, deregistered one is not reused.';
+  }
+  return 'This registers your agent on the Masumi Network, making it visible to everyone.';
+}
+
+export function getRegisterAgentReviewDescription(input: {
+  isUpdateMode: boolean;
+  isReRegisterMode: boolean;
+}): string {
+  if (input.isUpdateMode) {
+    return 'Check everything below before confirming the update. Use Back to change any field.';
+  }
+  if (input.isReRegisterMode) {
+    return 'Check everything below before minting the new registration. Use Back to change any field.';
+  }
+  return 'Check everything below before registering. Use Back to change any field.';
 }
 
 export function getRegisterAgentConfirmButtonLabel(input: {
@@ -31,4 +60,58 @@ export function getRegisterAgentConfirmButtonLabel(input: {
   if (input.isUpdateMode) return 'Confirm update';
   if (input.isReRegisterMode) return 'Confirm re-registration';
   return 'Confirm registration';
+}
+
+export function formatMasumiOptionReviewSummary(
+  option: MasumiOptionDraft,
+  network: NetworkType,
+): string {
+  if (option.pricingType === 'Free') return 'Free';
+  if (option.pricingType === 'Dynamic') return 'Dynamic pricing';
+  const priceParts = option.prices
+    .filter((price) => price.amount.trim().length > 0)
+    .map((price) => {
+      const unitLabel = formatFundUnit(
+        price.unit === 'lovelace' ? 'lovelace' : price.unit,
+        network,
+      );
+      return `${price.amount} ${unitLabel}`;
+    });
+  return priceParts.length > 0 ? priceParts.join(', ') : 'Fixed pricing (no amount set)';
+}
+
+export function formatX402OptionReviewSummary(option: X402OptionDraft): string {
+  if (option.pricingType === 'Free') return 'Free';
+  if (option.pricingType === 'Dynamic') {
+    return option.caip2Network ? `Dynamic on ${option.caip2Network}` : 'Dynamic pricing';
+  }
+  const assetLabel = option.asset ? shortenAddress(option.asset, 6) : 'native asset';
+  const amountLabel = option.amount.trim() ? option.amount : 'no amount set';
+  const networkLabel = option.caip2Network || 'unknown network';
+  return `${amountLabel} ${assetLabel} on ${networkLabel}`;
+}
+
+export function formatPaymentOptionReviewLine(input: {
+  optionRow: PaymentOptionRow;
+  optionIndex: number;
+  masumiOption?: MasumiOptionDraft;
+  x402Option?: X402OptionDraft;
+  network: NetworkType;
+}): { title: string; summary: string; detail?: string } {
+  const title = `Payment option ${input.optionIndex + 1}`;
+  if (input.optionRow.type === 'Masumi' && input.masumiOption) {
+    return {
+      title,
+      summary: `Masumi · ${formatMasumiOptionReviewSummary(input.masumiOption, input.network)}`,
+    };
+  }
+  if (input.optionRow.type === 'x402' && input.x402Option) {
+    const payTo = input.x402Option.payTo.trim();
+    return {
+      title,
+      summary: `x402 · ${formatX402OptionReviewSummary(input.x402Option)}`,
+      detail: payTo ? `Pay to ${shortenAddress(payTo, 8)}` : undefined,
+    };
+  }
+  return { title, summary: '—' };
 }


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[ ] Bug fix  
[X] New feature  
[ ] Other:

## **Overview of Changes**

Add a review step before agent registration submits. Users fill the form, see a summary on Review, can go back to edit, then confirm to submit.

## **Screenshot**

<img width="745" height="803" alt="image" src="https://github.com/user-attachments/assets/930c053e-20d0-4f15-9f5b-0d1bb5a390f4" />


## **Issue Addressed**

https://linear.app/masumi/issue/MAS-496

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**
