### PR TITLE
fix(frontend): replace dead admin navigation links

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '@/lib/contexts/ThemeContext';
+import { MASUMI_PRESS_URL } from '@/lib/masumi-links';
 
 export function Footer() {
   const { theme, setThemePreference } = useTheme();
@@ -8,12 +9,12 @@ export function Footer() {
       <div className="max-w-[1400px] mx-auto w-full flex justify-between items-center">
         <div className="flex gap-4">
           <a
-            href="https://www.masumi.network/about"
+            href={MASUMI_PRESS_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
-            About
+            Press
           </a>
           <a
             href="https://www.house-of-communication.com/de/en/footer/privacy-policy.html"

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import logo from '@/assets/masumi_logo.png';
 import Link from 'next/link';
 import { BookOpen, MessageSquare } from 'lucide-react';
+import { MASUMI_DOCUMENTATION_URL, MASUMI_SUPPORT_URL } from '@/lib/masumi-links';
 
 export function Header() {
   return (
@@ -13,7 +14,7 @@ export function Header() {
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" asChild>
               <Link
-                href="https://www.masumi.network/dev/masumi"
+                href={MASUMI_DOCUMENTATION_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2"
@@ -24,7 +25,7 @@ export function Header() {
             </Button>
             <Button variant="outline" size="sm" asChild>
               <Link
-                href="https://www.masumi.network/contact"
+                href={MASUMI_SUPPORT_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2"

--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -94,11 +94,6 @@ export function ApiKeyDialog() {
             Sign in with the <code className="text-foreground">ADMIN_KEY</code> from your node
             environment, or any other valid API key from this payment service.
           </p>
-          <p>
-            The key you enter sets the active session. Pages and actions match that key&apos;s
-            permissions: read-only keys can browse, pay keys can run payments, and admin keys can
-            manage settings and create more keys.
-          </p>
           <Link
             href={MASUMI_API_KEY_DOCS_URL}
             target="_blank"

--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
 import { capabilitiesFromApiKeyStatus, DEFAULT_CAPABILITIES } from '@/lib/permissions';
+import { MASUMI_API_KEY_DOCS_URL } from '@/lib/masumi-links';
 
 interface ApiError {
   message: string;
@@ -88,20 +89,25 @@ export function ApiKeyDialog() {
       <main className="flex flex-col items-center justify-center min-h-screen py-20">
         <h1 className="text-4xl font-bold mb-4">Enter your API Key</h1>
 
-        <p className="text-sm text-muted-foreground mb-8 text-center max-w-md">
-          Your API key is needed to access the dashboard. This key is required to manage your ai
-          agents, payment settings and view transactions.
-        </p>
-
-        <Button variant="muted" className="text-sm mb-8 hover:underline" asChild>
+        <div className="text-sm text-muted-foreground mb-8 text-center max-w-lg space-y-3">
+          <p>
+            Sign in with the <code className="text-foreground">ADMIN_KEY</code> from your node
+            environment, or any other valid API key from this payment service.
+          </p>
+          <p>
+            The key you enter sets the active session. Pages and actions match that key&apos;s
+            permissions: read-only keys can browse, pay keys can run payments, and admin keys can
+            manage settings and create more keys.
+          </p>
           <Link
-            href={'https://www.masumi.network/dev/masumi/'}
+            href={MASUMI_API_KEY_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
+            className="inline-block text-primary underline underline-offset-4 hover:text-primary/80"
           >
-            Learn more
+            Learn more about API keys and ADMIN_KEY
           </Link>
-        </Button>
+        </div>
 
         <form
           onSubmit={(e) => {

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -45,6 +45,7 @@ import { useX402NetworksForSession } from '@/lib/hooks/useX402';
 import { chainsForEnv } from '@/lib/x402-rail';
 import { buildMainNavigation } from '@/components/layout/main-navigation';
 import { railHomePath, setupPath } from '@/lib/x402-navigation';
+import { MASUMI_DOCUMENTATION_URL, MASUMI_PRESS_URL, MASUMI_SUPPORT_URL } from '@/lib/masumi-links';
 interface MainLayoutProps {
   children: React.ReactNode;
 }
@@ -466,12 +467,12 @@ export function MainLayout({ children }: MainLayoutProps) {
               )}
             >
               <Link
-                href="https://www.masumi.network/about"
+                href={MASUMI_PRESS_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="truncate hover:text-foreground transition-colors"
               >
-                About
+                Press
               </Link>
               <span className="mx-2 text-muted-foreground/40">|</span>
               <Link
@@ -481,15 +482,6 @@ export function MainLayout({ children }: MainLayoutProps) {
                 className="truncate hover:text-foreground transition-colors"
               >
                 Privacy
-              </Link>
-              <span className="mx-2 text-muted-foreground/40">|</span>
-              <Link
-                href="https://www.masumi.network/product-releases"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="truncate hover:text-foreground transition-colors"
-              >
-                Changelog
               </Link>
             </div>
             <Button
@@ -530,7 +522,7 @@ export function MainLayout({ children }: MainLayoutProps) {
               <div className="flex items-center gap-4">
                 <Button variant="outline" size="sm" asChild>
                   <Link
-                    href="https://www.masumi.network/dev/masumi"
+                    href={MASUMI_DOCUMENTATION_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-2"
@@ -541,7 +533,7 @@ export function MainLayout({ children }: MainLayoutProps) {
                 </Button>
                 <Button variant="outline" size="sm" asChild>
                   <Link
-                    href="https://www.masumi.network/contact"
+                    href={MASUMI_SUPPORT_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-2"

--- a/frontend/src/lib/masumi-links.ts
+++ b/frontend/src/lib/masumi-links.ts
@@ -2,3 +2,5 @@
 export const MASUMI_DOCUMENTATION_URL = 'https://docs.masumi.network';
 export const MASUMI_PRESS_URL = 'https://www.masumi.network/press';
 export const MASUMI_SUPPORT_URL = 'https://www.masumi.network/contact';
+export const MASUMI_API_KEY_DOCS_URL =
+  'https://www.masumi.network/dev/masumi/documentation/technical-documentation/environment-variables';

--- a/frontend/src/lib/masumi-links.ts
+++ b/frontend/src/lib/masumi-links.ts
@@ -1,0 +1,4 @@
+/** Live Masumi site and documentation URLs used in the admin interface. */
+export const MASUMI_DOCUMENTATION_URL = 'https://docs.masumi.network';
+export const MASUMI_PRESS_URL = 'https://www.masumi.network/press';
+export const MASUMI_SUPPORT_URL = 'https://www.masumi.network/contact';

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -25,6 +25,7 @@ import { useX402NetworksForSession } from '@/lib/hooks/useX402';
 import { chainsForEnv } from '@/lib/x402-rail';
 import { capabilitiesFromApiKeyStatus, isAdminOnlyPath, isPayOnlyPath } from '@/lib/permissions';
 import { hasLegacyOnlyPaymentSources, isV2PaymentSource } from '@/lib/payment-source-type';
+import { MASUMI_DOCUMENTATION_URL } from '@/lib/masumi-links';
 import {
   deniedPathFallback,
   isSetupPath,
@@ -435,7 +436,7 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
             The admin interface is designed for desktop. On a narrow screen some tables and dialogs
             may be hard to use.{' '}
             <Link
-              href="https://docs.masumi.io"
+              href={MASUMI_DOCUMENTATION_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="underline underline-offset-2"


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Replace dead About and Changelog links with live destinations. Documentation links now point to `docs.masumi.network`. About links to Press. Changelog is removed where no live replacement exists. Support links to the contact page. Mobile warning Learn more no longer uses `docs.masumi.io`. Shared URLs live in `frontend/src/lib/masumi-links.ts`.

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-479

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

Confirm Press is the right replacement for About and that removing Changelog is acceptable. Check that docs and support URLs match across Header, Footer, MainLayout, and the mobile warning.