### PR TITLE
fix(frontend): explain how API keys set admin interface context

### DIFF
--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -94,11 +94,6 @@ export function ApiKeyDialog() {
             Sign in with the <code className="text-foreground">ADMIN_KEY</code> from your node
             environment, or any other valid API key from this payment service.
           </p>
-          <p>
-            The key you enter sets the active session. Pages and actions match that key&apos;s
-            permissions: read-only keys can browse, pay keys can run payments, and admin keys can
-            manage settings and create more keys.
-          </p>
           <Link
             href={MASUMI_API_KEY_DOCS_URL}
             target="_blank"

--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
 import { capabilitiesFromApiKeyStatus, DEFAULT_CAPABILITIES } from '@/lib/permissions';
+import { MASUMI_API_KEY_DOCS_URL } from '@/lib/masumi-links';
 
 interface ApiError {
   message: string;
@@ -88,20 +89,25 @@ export function ApiKeyDialog() {
       <main className="flex flex-col items-center justify-center min-h-screen py-20">
         <h1 className="text-4xl font-bold mb-4">Enter your API Key</h1>
 
-        <p className="text-sm text-muted-foreground mb-8 text-center max-w-md">
-          Your API key is needed to access the dashboard. This key is required to manage your ai
-          agents, payment settings and view transactions.
-        </p>
-
-        <Button variant="muted" className="text-sm mb-8 hover:underline" asChild>
+        <div className="text-sm text-muted-foreground mb-8 text-center max-w-lg space-y-3">
+          <p>
+            Sign in with the <code className="text-foreground">ADMIN_KEY</code> from your node
+            environment, or any other valid API key from this payment service.
+          </p>
+          <p>
+            The key you enter sets the active session. Pages and actions match that key&apos;s
+            permissions: read-only keys can browse, pay keys can run payments, and admin keys can
+            manage settings and create more keys.
+          </p>
           <Link
-            href={'https://www.masumi.network/dev/masumi/'}
+            href={MASUMI_API_KEY_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
+            className="inline-block text-primary underline underline-offset-4 hover:text-primary/80"
           >
-            Learn more
+            Learn more about API keys and ADMIN_KEY
           </Link>
-        </Button>
+        </div>
 
         <form
           onSubmit={(e) => {

--- a/frontend/src/lib/masumi-links.ts
+++ b/frontend/src/lib/masumi-links.ts
@@ -2,3 +2,5 @@
 export const MASUMI_DOCUMENTATION_URL = 'https://docs.masumi.network';
 export const MASUMI_PRESS_URL = 'https://www.masumi.network/press';
 export const MASUMI_SUPPORT_URL = 'https://www.masumi.network/contact';
+export const MASUMI_API_KEY_DOCS_URL =
+  'https://www.masumi.network/dev/masumi/documentation/technical-documentation/environment-variables';


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Update the API key sign-in dialog to explain that operators can sign in with `ADMIN_KEY` or any valid API key. Clarify that the submitted key sets session permissions and controls which pages and actions are available. Render Learn more as a text link to the environment variables documentation instead of a muted button.

## **Screenshot**

![Local QA screenshot](https://raw.githubusercontent.com/masumi-network/masumi-payment-service/chore/pr-review-screenshots/docs/pr-screenshots/MAS-477-api-key-sign-in-dialog.png)

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-477

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

Merge after #796. Confirm the sign-in copy is clear for new operators and that the Learn more link target is the right doc page.