### PR TITLE
fix(frontend): route earnings users to per-agent views

### DIFF
--- a/frontend/src/pages/earnings.tsx
+++ b/frontend/src/pages/earnings.tsx
@@ -33,7 +33,9 @@ export default function EarningsPage() {
               <h2 className="text-sm font-medium">How to view agent earnings</h2>
               <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
                 <li>Open AI Agents.</li>
-                <li>Select an agent and open its details, or choose the earnings action on a row.</li>
+                <li>
+                  Select an agent and open its details, or choose the earnings action on a row.
+                </li>
                 <li>Open the Earnings tab to see totals and transactions for that agent.</li>
               </ol>
               <Button asChild>

--- a/frontend/src/pages/earnings.tsx
+++ b/frontend/src/pages/earnings.tsx
@@ -1,0 +1,52 @@
+import { MainLayout } from '@/components/layout/MainLayout';
+import { AnimatedPage } from '@/components/ui/animated-page';
+import { Button } from '@/components/ui/button';
+import { Bot, ArrowRight } from 'lucide-react';
+import { GetStaticProps } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {},
+  };
+};
+
+export default function EarningsPage() {
+  return (
+    <>
+      <Head>
+        <title>Earnings | Admin Interface</title>
+      </Head>
+      <MainLayout>
+        <AnimatedPage>
+          <div className="max-w-2xl space-y-6">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">Earnings</h1>
+              <p className="text-sm text-muted-foreground mt-2">
+                Earnings are available per registered agent. This node does not show one combined
+                earnings total on this page.
+              </p>
+            </div>
+
+            <div className="rounded-lg border bg-card p-6 space-y-4">
+              <h2 className="text-sm font-medium">How to view agent earnings</h2>
+              <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+                <li>Open AI Agents.</li>
+                <li>Select an agent and open its details, or choose the earnings action on a row.</li>
+                <li>Open the Earnings tab to see totals and transactions for that agent.</li>
+              </ol>
+              <Button asChild>
+                <Link href="/ai-agents" className="gap-2">
+                  <Bot className="h-4 w-4" />
+                  Go to AI Agents
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </AnimatedPage>
+      </MainLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Add a static `/admin/earnings` page so direct navigation no longer 404s. The page explains that earnings are shown per agent, not as a global total, and guides users to AI Agents to open an agent details dialog on the Earnings tab.

## **Screenshot**

![Local QA screenshot](https://raw.githubusercontent.com/masumi-network/masumi-payment-service/chore/pr-review-screenshots/docs/pr-screenshots/MAS-480-earnings-per-agent.png)

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-480

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

Confirm the copy and navigation path match how earnings work today in the agent details dialog. No global earnings total is introduced.