### PR TITLE
feat(api-keys): make usage credits context aware and editable

### DIFF
--- a/docs/migrations/x402-key-scoped-spend-caps.md
+++ b/docs/migrations/x402-key-scoped-spend-caps.md
@@ -51,8 +51,9 @@ nothing at upgrade time. Restore the cap yourself with step 2 below.
    SELECT "apiKeyId", "evmWalletId" FROM "ApiKeyX402WalletScope" WHERE "id" LIKE 'mig_%';
    ```
 
-A usage-limited key with no `eip155:` credit row at all stays uncapped and logs a
-warning on each payment. This is deliberate: it keeps Cardano-only keys working.
+A usage-limited key needs enough credit in the exact
+`eip155:<chainId>:<asset>` unit. A missing or insufficient balance returns HTTP 402. Set `usageLimited` to false only when the key must spend without this
+ledger limit.
 
 ## Rollback
 

--- a/docs/x402.md
+++ b/docs/x402.md
@@ -12,13 +12,13 @@ dashboard, the HTTP API, and a first-run setup walkthrough.
 
 ## Concepts
 
-| Term                             | Meaning                                                                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Managed EVM wallet**           | An EVM keypair created (or imported) through the service. The private key is encrypted at rest; a generated key is returned once for backup, while an imported key is never echoed. It signs outbound payments and settles inbound ones.                                                                                                                                          |
-| **Chain / network**              | An EVM chain identified by its CAIP-2 id (`eip155:8453` = Base mainnet). Base mainnet and Base Sepolia are seeded. A chain needs either an owned facilitator wallet or a remote facilitator endpoint before it can settle inbound payments.                                                                                                                                       |
-| **Facilitator**                  | The owned Selling wallet or remote HTTPS service that verifies and settles inbound x402 payments. An owned wallet pays gas locally; a remote facilitator manages its own signer. This is the **sell side**.                                                                                                                                                                       |
-| **Usage credits**                | The per-API-key spend cap, shared with the Cardano rail (`ADR 0016`). EVM credits use `eip155:<chainId>:<asset>` units. When the key is usage limited, the buy side debits them atomically at signing. A usage-limited key with no `eip155:` credit row at all is not capped: the node logs a warning and signs, which keeps Cardano-only keys working. This is the **buy side**. |
-| **Payment attempt / settlement** | Audit records of every verify / settle / sign, and the on-chain settlement result.                                                                                                                                                                                                                                                                                                |
+| Term                             | Meaning                                                                                                                                                                                                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Managed EVM wallet**           | An EVM keypair created (or imported) through the service. The private key is encrypted at rest; a generated key is returned once for backup, while an imported key is never echoed. It signs outbound payments and settles inbound ones.                                                                |
+| **Chain / network**              | An EVM chain identified by its CAIP-2 id (`eip155:8453` = Base mainnet). Base mainnet and Base Sepolia are seeded. A chain needs either an owned facilitator wallet or a remote facilitator endpoint before it can settle inbound payments.                                                             |
+| **Facilitator**                  | The owned Selling wallet or remote HTTPS service that verifies and settles inbound x402 payments. An owned wallet pays gas locally; a remote facilitator manages its own signer. This is the **sell side**.                                                                                             |
+| **Usage credits**                | The per-API-key spend cap, shared with the Cardano rail (`ADR 0016`). EVM credits use exact `eip155:<chainId>:<asset>` units. When the key is usage limited, the buy side debits the matching unit atomically at signing. A missing or insufficient balance returns HTTP 402. This is the **buy side**. |
+| **Payment attempt / settlement** | Audit records of every verify / settle / sign, and the on-chain settlement result.                                                                                                                                                                                                                      |
 
 ### Two sides
 
@@ -106,9 +106,9 @@ The response includes `xPaymentHeader` — replay it as the `X-PAYMENT` header o
 your agent's retried request to the resource. For a usage-limited key, the usage
 credits are debited at signing time (a signature is a spendable authorization);
 they are **not** refunded if your agent abandons the request.
-A usage-limited key that holds no `eip155:` credit row is uncapped: the node
-logs a warning and signs anyway. Grant EVM credits to that key to activate the
-cap.
+A usage-limited key needs enough credit in the exact
+`eip155:<chainId>:<asset>` unit. A missing or insufficient balance returns HTTP 402. Set `usageLimited` to false only when the key must spend without this
+ledger limit.
 
 ### Example — sell side (`/x402/verify` then `/x402/settle`)
 

--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/lib/constants/defaultWallets';
 import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
 import type { ApiKey, PostApiKeyData } from '@/lib/api/generated';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 interface AddApiKeyDialogProps {
   open: boolean;
@@ -69,6 +70,20 @@ const apiKeySchema = z
     x402WalletScopeIds: z.array(z.string()),
   })
   .superRefine((val, ctx) => {
+    // Create can reach the same deny-all as update: tick the restriction, pick
+    // nothing, save. The key is then born reaching no wallet.
+    const walletScope = walletScopeProblem(val.walletScopeEnabled, val.walletScopeIds);
+    if (walletScope !== undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: walletScope, path: ['walletScopeIds'] });
+    }
+    const x402Scope = walletScopeProblem(val.x402WalletScopeEnabled, val.x402WalletScopeIds);
+    if (x402Scope !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: x402Scope,
+        path: ['x402WalletScopeIds'],
+      });
+    }
     if (
       val.canPay &&
       !val.canAdmin &&
@@ -600,12 +615,10 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                           <Checkbox
                             aria-label="Restrict to specific wallets"
                             checked={field.value}
-                            onCheckedChange={(checked) => {
-                              field.onChange(checked);
-                              if (!checked) {
-                                setValue('walletScopeIds', []);
-                              }
-                            }}
+                            // The selection survives an untick, as in the update
+                            // dialog: clearing it here let a net-zero tick save the
+                            // scope with an empty list, which reaches no wallet.
+                            onCheckedChange={(checked) => field.onChange(checked)}
                           />
                         )}
                       />
@@ -664,10 +677,14 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                           ))
                         )}
                       </div>
-                      {walletScopeIds.length > 0 && (
+                      {walletScopeIds.length > 0 ? (
                         <p className="text-xs text-muted-foreground">
                           {walletScopeIds.length} wallet{walletScopeIds.length !== 1 ? 's' : ''}{' '}
                           selected
+                        </p>
+                      ) : (
+                        <p className="text-xs text-destructive">
+                          {walletScopeProblem(true, walletScopeIds)}
                         </p>
                       )}
                     </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -616,7 +616,10 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                     <p className="text-xs text-destructive">
                       A usage-limited key needs at least one funded unit. With none, every Cardano
                       purchase is rejected as &quot;Insufficient funds&quot; before a payment is
-                      written, and x402 spending is not capped at all.
+                      written, and{' '}
+                      {hasEvmCreditRow
+                        ? 'x402 payments are refused as well: removing an EVM row zeroes it on the server rather than deleting it, and a zeroed row still binds the cap.'
+                        : 'x402 spending is not capped at all.'}
                     </p>
                   )}
                   {/* The gap that makes a key look capped while it is not. pay.ts

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -266,7 +266,13 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     name: 'evmChains',
     defaultValue: apiKey.ChainIdLimit.filter((chainId) => chainId.startsWith('eip155:')),
   });
-  const evmChainsGranted = evmChains.length > 0;
+  // The SAVED grant, not the watched one. creditOptions is derived from
+  // apiKey.ChainIdLimit and cannot depend on a useWatch without a cycle (options feed
+  // initialCreditRows, which feed useForm, which yields control). Warning off the form
+  // therefore told the operator to fund a chain the picker below could not offer,
+  // because that chain existed only in the unsaved form. It appears once the grant is
+  // saved, which is also when it becomes actionable.
+  const evmChainsGranted = apiKey.ChainIdLimit.some((chainId) => chainId.startsWith('eip155:'));
   // What the ledger will hold after this save. Removing a row does not remove it: the
   // server zeroes it and keeps it, and pay.ts counts rows. Reading only the form
   // inverted the warning on a removal, claiming wallet-bounded spending in the one

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -267,10 +267,13 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     defaultValue: apiKey.ChainIdLimit.filter((chainId) => chainId.startsWith('eip155:')),
   });
   const evmChainsGranted = evmChains.length > 0;
-  // Saved rows, not the edited ones: pay.ts counts what the ledger holds. Reading the
-  // form inverted the warning on a removed row, claiming wallet-bounded spending in the
-  // one state where the row still exists and every EVM payment is refused.
-  const hasEvmCreditRow = currentCredits.some((credit) => credit.unit.startsWith('eip155:'));
+  // What the ledger will hold after this save. Removing a row does not remove it: the
+  // server zeroes it and keeps it, and pay.ts counts rows. Reading only the form
+  // inverted the warning on a removal, claiming wallet-bounded spending in the one
+  // state where the row still exists and every EVM payment is refused.
+  const hasEvmCreditRow =
+    currentCredits.some((credit) => credit.unit.startsWith('eip155:')) ||
+    creditRows.some((row) => row.unit.startsWith('eip155:'));
 
   // The EVM chain list loads after first paint, so the defaults above fall back to base
   // units for any chain-qualified unit. Re-seed once the real decimals are known, but
@@ -611,9 +614,9 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       array-root error, so the reason a save is blocked is always visible. */}
                   {creditRows.length === 0 && (
                     <p className="text-xs text-destructive">
-                      A usage-limited key needs at least one funded unit. With none, the node
-                      rejects every purchase with &quot;Insufficient funds&quot; before it writes a
-                      payment.
+                      A usage-limited key needs at least one funded unit. With none, every Cardano
+                      purchase is rejected as &quot;Insufficient funds&quot; before a payment is
+                      written, and x402 spending is not capped at all.
                     </p>
                   )}
                   {/* The gap that makes a key look capped while it is not. pay.ts
@@ -624,8 +627,8 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       server keeps it rather than deleting it. */}
                   {creditRows.length > 0 && evmChainsGranted && !hasEvmCreditRow && (
                     <p className="text-xs text-amber-600 dark:text-amber-500">
-                      x402 payments on this key&apos;s EVM chains are not capped yet. Saving a
-                      credit row for one of them starts the limit, even at zero.
+                      x402 payments on this key&apos;s EVM chains are not capped yet. Fund one of
+                      them to start the limit; it then binds every chain above.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { patchApiKey } from '@/lib/api/generated';
@@ -28,10 +28,17 @@ import { X402WalletScopeField } from '@/components/api-keys/X402WalletScopeField
 import { useAllWallets } from '@/lib/queries/useWallets';
 import { shortenAddress } from '@/lib/utils';
 import {
-  getActiveStablecoinConfig,
-  getActiveStablecoinSymbol,
-} from '@/lib/constants/defaultWallets';
-import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
+  convertBaseUnitsToDecimal,
+  convertDecimalToBaseUnits,
+  isValidDecimalAmount,
+} from '@/lib/convertDecimalToBaseUnits';
+import {
+  consolidateCreditRows,
+  creditDeltas,
+  creditUnitOptionsForKey,
+} from '@/lib/api-key-credit-units';
+import { UsageCreditsField, type CreditRow } from '@/components/api-keys/UsageCreditsField';
+import { Switch } from '@/components/ui/switch';
 
 interface UpdateApiKeyDialogProps {
   open: boolean;
@@ -49,6 +56,7 @@ interface UpdateApiKeyDialogProps {
     NetworkLimit: Array<'Preprod' | 'Mainnet'>;
     ChainIdLimit: string[];
     usageLimited: boolean;
+    RemainingUsageCredits: Array<{ unit: string; amount: string }>;
     status: 'Active' | 'Revoked';
     walletScopeEnabled: boolean;
     WalletScopes: Array<{ hotWalletId: string }>;
@@ -65,10 +73,8 @@ const updateApiKeySchema = z
       .optional()
       .or(z.literal('')),
     status: z.enum(['Active', 'Revoked']),
-    credits: z.object({
-      lovelace: z.string().optional(),
-      usdcx: z.string().optional(),
-    }),
+    usageLimited: z.boolean(),
+    credits: z.array(z.object({ unit: z.string(), amount: z.string(), decimals: z.number() })),
     walletScopeEnabled: z.boolean(),
     walletScopeIds: z.array(z.string()),
     x402WalletScopeEnabled: z.boolean(),
@@ -76,21 +82,36 @@ const updateApiKeySchema = z
     evmChains: z.array(z.string()),
   })
   .superRefine((val, ctx) => {
-    if (
-      val.credits?.lovelace &&
-      !isValidDecimalAmount(val.credits.lovelace, { allowNegative: true })
-    ) {
+    val.credits.forEach((credit, index) => {
+      if (credit.amount.trim() === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Enter a balance, or remove this unit',
+          path: ['credits', index, 'amount'],
+        });
+        return;
+      }
+      // Balances, not deltas: a negative balance is meaningless and the server
+      // rejects it anyway. Precision is checked against the unit's own decimals so
+      // an over-precise entry is refused instead of silently truncated on convert.
+      if (!isValidDecimalAmount(credit.amount, { decimals: credit.decimals })) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Enter a positive amount with at most ${credit.decimals} decimals`,
+          path: ['credits', index, 'amount'],
+        });
+      }
+    });
+    // The exact state that broke every purchase on this deployment: a key flagged
+    // usage-limited whose ledger has no row for the unit it pays in fails the credit
+    // gate with `Credit unit not found`, surfaced to the buyer as a bare 400
+    // 'Insufficient funds' with no purchase ever created.
+    if (val.usageLimited && val.credits.length === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Invalid ADA amount',
-        path: ['credits', 'lovelace'],
-      });
-    }
-    if (val.credits?.usdcx && !isValidDecimalAmount(val.credits.usdcx, { allowNegative: true })) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Invalid USDCx amount',
-        path: ['credits', 'usdcx'],
+        message:
+          'A usage-limited key needs at least one funded unit, or every payment it makes is rejected.',
+        path: ['credits'],
       });
     }
   });
@@ -109,7 +130,7 @@ function getPermissionLabel(_canRead: boolean, canPay: boolean, canAdmin: boolea
 export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateApiKeyDialogProps) {
   const [showToken, setShowToken] = useState(false);
   const tokenInputRef = useRef<HTMLInputElement | null>(null);
-  const { apiClient, network } = useAppContext();
+  const { apiClient } = useAppContext();
 
   const updateApiKey = useApiMutation({
     mutationFn: (body: NonNullable<PatchApiKeyData['body']>) =>
@@ -139,19 +160,59 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     }));
   }, [managedWallets, paymentSources]);
 
+  // One editable row per unit, not per stored row: the ledger can hold duplicates for
+  // the same unit and every consumer below assumes a unit appears once.
+  const currentCredits = useMemo(
+    () => consolidateCreditRows(apiKey.RemainingUsageCredits),
+    [apiKey.RemainingUsageCredits],
+  );
+
+  // Offer the units this key can actually spend. The form used to hard-code ADA plus
+  // the "active stablecoin", which on Mainnet is USDCx: a key paying in USDM could not
+  // be funded for the asset it spends, and an EVM key could not be funded at all.
+  const creditOptions = useMemo(
+    () =>
+      creditUnitOptionsForKey({
+        networkLimit: apiKey.NetworkLimit,
+        chainIdLimit: apiKey.ChainIdLimit,
+        evmNetworks: evmChainOptions,
+        existingUnits: currentCredits.map((credit) => credit.unit),
+      }),
+    [apiKey.NetworkLimit, apiKey.ChainIdLimit, currentCredits, evmChainOptions],
+  );
+
+  // Seed with the key's stored balances so the dialog shows the ledger it edits. The
+  // old fields were always blank deltas, so the form could never say whether a key was
+  // funded at all.
+  const initialCreditRows = useMemo<CreditRow[]>(
+    () =>
+      currentCredits.map((credit) => {
+        const decimals = creditOptions.find((option) => option.unit === credit.unit)?.decimals ?? 6;
+        let amount = credit.amount;
+        try {
+          amount = convertBaseUnitsToDecimal(credit.amount, decimals);
+        } catch {
+          // Leave an unparseable stored value visible rather than dropping the row.
+        }
+        return { unit: credit.unit, amount, decimals };
+      }),
+    [currentCredits, creditOptions],
+  );
+
   const {
     register,
     handleSubmit,
     control,
     reset,
     setValue,
-    formState: { errors },
+    formState: { errors, isDirty },
   } = useForm<UpdateApiKeyFormValues>({
     resolver: zodResolver(updateApiKeySchema),
     defaultValues: {
       newToken: '',
       status: apiKey.status,
-      credits: { lovelace: '', usdcx: '' },
+      usageLimited: apiKey.usageLimited,
+      credits: initialCreditRows,
       walletScopeEnabled: apiKey.walletScopeEnabled,
       walletScopeIds: apiKey.WalletScopes.map((ws) => ws.hotWalletId),
       x402WalletScopeEnabled: apiKey.x402WalletScopeEnabled,
@@ -181,20 +242,49 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     defaultValue: apiKey.X402WalletScopes.map((ws) => ws.evmWalletId),
   });
 
+  const usageLimited = useWatch({
+    control,
+    name: 'usageLimited',
+    defaultValue: apiKey.usageLimited,
+  });
+  const creditRows = useWatch({ control, name: 'credits', defaultValue: initialCreditRows });
+
+  // The EVM chain list loads after first paint, so the defaults above fall back to 6
+  // decimals for any chain-qualified unit. Re-seed once the real decimals are known, but
+  // only while the operator has not started editing, so this can never eat their input.
+  const seededCreditsRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (isDirty) return;
+    const signature = initialCreditRows.map((row) => `${row.unit}:${row.decimals}`).join('|');
+    if (signature === seededCreditsRef.current) return;
+    seededCreditsRef.current = signature;
+    setValue('credits', initialCreditRows);
+  }, [initialCreditRows, isDirty, setValue]);
+
+  // react-hook-form nests array errors as errors.credits[index].amount; flatten them to
+  // the index map the field component renders.
+  const creditRowErrors = useMemo<Record<number, string | undefined>>(() => {
+    const creditErrors = errors.credits;
+    if (!Array.isArray(creditErrors)) return {};
+    const flattened: Record<number, string | undefined> = {};
+    creditErrors.forEach((entry, index) => {
+      const message = entry?.amount?.message;
+      if (typeof message === 'string') flattened[index] = message;
+    });
+    return flattened;
+  }, [errors.credits]);
+
   const onSubmit = async (data: UpdateApiKeyFormValues) => {
-    const usageCredits: Array<{ unit: string; amount: string }> = [];
-    if (data.credits.lovelace) {
-      usageCredits.push({
-        unit: 'lovelace',
-        amount: convertDecimalToBaseUnits(data.credits.lovelace),
-      });
-    }
-    if (data.credits.usdcx) {
-      usageCredits.push({
-        unit: getActiveStablecoinConfig(network).fullAssetId,
-        amount: convertDecimalToBaseUnits(data.credits.usdcx),
-      });
-    }
+    // The endpoint takes deltas, not absolute balances, so diff the edited balances
+    // against the stored ones and send only what moved. An unchanged unit is omitted;
+    // a zero delta for a unit with no row is a 400 ('Invalid amount').
+    const usageCredits = creditDeltas(
+      currentCredits,
+      data.credits.map((credit) => ({
+        unit: credit.unit,
+        amount: convertDecimalToBaseUnits(credit.amount, credit.decimals),
+      })),
+    );
 
     const walletScopeChanged =
       data.walletScopeEnabled !== apiKey.walletScopeEnabled ||
@@ -217,6 +307,9 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
         ...(data.status !== apiKey.status && { status: data.status }),
         ...(usageCredits.length > 0 && {
           UsageCreditsToAddOrRemove: usageCredits,
+        }),
+        ...(data.usageLimited !== apiKey.usageLimited && {
+          usageLimited: data.usageLimited,
         }),
         ...(walletScopeChanged && {
           walletScopeEnabled: data.walletScopeEnabled,
@@ -388,42 +481,62 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
             )}
           </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Add/Remove Credits</label>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <Label htmlFor="credits-ada" className="text-xs text-muted-foreground">
-                  ADA
-                </Label>
-                <Input
-                  id="credits-ada"
-                  type="number"
-                  placeholder="0.00"
-                  {...register('credits.lovelace')}
+          {!apiKey.canAdmin && (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2">
+                <Controller
+                  control={control}
+                  name="usageLimited"
+                  render={({ field }) => (
+                    <Switch
+                      aria-label="Limit usage credits"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  )}
                 />
-                {errors.credits && 'lovelace' in errors.credits && errors.credits.lovelace && (
-                  <p className="text-xs text-destructive">
-                    {(errors.credits.lovelace as any).message}
+                <div className="space-y-0.5">
+                  <Label className="text-sm font-medium">Limit usage credits</Label>
+                  <p className="text-xs text-muted-foreground">
+                    On, the key may only spend the balances below, and a purchase in any other unit
+                    is rejected. Off, the key spends freely from its wallets.
                   </p>
-                )}
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="credits-usdcx" className="text-xs text-muted-foreground">
-                  {getActiveStablecoinSymbol(network)}
-                </Label>
-                <Input
-                  id="credits-usdcx"
-                  type="number"
-                  placeholder="0.00"
-                  {...register('credits.usdcx')}
-                />
-                {errors.credits && 'usdcx' in errors.credits && errors.credits.usdcx && (
-                  <p className="text-xs text-destructive">
-                    {(errors.credits.usdcx as any).message}
-                  </p>
-                )}
+                </div>
               </div>
             </div>
+          )}
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Usage credits</label>
+            {apiKey.canAdmin ? (
+              <p className="text-xs text-muted-foreground">
+                Admin keys are never usage limited, so they hold no credit balances.
+              </p>
+            ) : (
+              <>
+                <Controller
+                  control={control}
+                  name="credits"
+                  render={({ field }) => (
+                    <UsageCreditsField
+                      options={creditOptions}
+                      rows={field.value}
+                      current={currentCredits}
+                      onChange={field.onChange}
+                      rowErrors={creditRowErrors}
+                    />
+                  )}
+                />
+                {/* Shown from the watched values rather than read out of the resolver's
+                    array-root error, so the reason a save is blocked is always visible. */}
+                {usageLimited && creditRows.length === 0 && (
+                  <p className="text-xs text-destructive">
+                    A usage-limited key needs at least one funded unit. With none, the node rejects
+                    every purchase with &quot;Insufficient funds&quot; before it writes a payment.
+                  </p>
+                )}
+              </>
+            )}
           </div>
 
           {!apiKey.canAdmin && (

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -359,16 +359,22 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
           <DialogTitle>Update API key</DialogTitle>
         </DialogHeader>
 
-        <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2.5 text-sm">
-          <span className="text-muted-foreground">Permission:</span>
-          <Badge variant={apiKey.canAdmin ? 'default' : apiKey.canPay ? 'secondary' : 'outline'}>
+        {/* Wraps rather than shrinks: as one no-wrap flex row, a narrow dialog squeezed
+            every child below its content width and the badges broke mid-word
+            ("Read and / Pay", "Mainne / t"). */}
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 rounded-lg border bg-muted/50 px-3 py-2.5 text-sm">
+          <span className="shrink-0 text-muted-foreground">Permission:</span>
+          <Badge
+            variant={apiKey.canAdmin ? 'default' : apiKey.canPay ? 'secondary' : 'outline'}
+            className="whitespace-nowrap"
+          >
             {getPermissionLabel(apiKey.canRead, apiKey.canPay, apiKey.canAdmin)}
           </Badge>
-          <Separator orientation="vertical" className="mx-1 h-4" />
-          <span className="text-muted-foreground">Networks:</span>
-          <div className="flex gap-1">
+          <Separator orientation="vertical" className="mx-1 h-4 max-sm:hidden" />
+          <span className="shrink-0 text-muted-foreground">Networks:</span>
+          <div className="flex flex-wrap gap-1">
             {apiKey.NetworkLimit.map((net) => (
-              <Badge key={net} variant="outline" className="font-normal">
+              <Badge key={net} variant="outline" className="font-normal whitespace-nowrap">
                 {net}
               </Badge>
             ))}
@@ -430,6 +436,34 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                 name="evmChains"
                 render={({ field }) => (
                   <div className="flex flex-col gap-2">
+                    {/* Named for what it does. The node stores no "unlimited" state:
+                        an omitted ChainIdLimit is expanded to the configured chain list
+                        at creation (routes/api/api-key/index.ts), and on PATCH an omitted
+                        one means unchanged. So "all" is a snapshot of today's chains, and
+                        a chain configured later is not granted by it. */}
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        aria-label="Select all EVM chains"
+                        checked={
+                          field.value.length === evmChainOptions.length
+                            ? true
+                            : field.value.length === 0
+                              ? false
+                              : 'indeterminate'
+                        }
+                        onCheckedChange={() =>
+                          field.onChange(
+                            field.value.length === evmChainOptions.length
+                              ? []
+                              : evmChainOptions.map((chain) => chain.caip2Id),
+                          )
+                        }
+                      />
+                      <label className="text-sm font-medium">
+                        All EVM chains configured on this node
+                      </label>
+                    </div>
+                    <Separator className="my-1" />
                     {evmChainOptions.map((chain) => (
                       <div key={chain.id} className="flex items-center gap-2">
                         <Checkbox
@@ -481,9 +515,26 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
             )}
           </div>
 
-          {!apiKey.canAdmin && (
+          {apiKey.canAdmin ? (
             <div className="space-y-2">
-              <div className="flex items-start gap-2">
+              <label className="text-sm font-medium">Spending limit</label>
+              <p className="text-xs text-muted-foreground">
+                Admin keys are never usage limited, so they hold no credit balances.
+              </p>
+            </div>
+          ) : (
+            <>
+              {/* Same shape as every other switch in the app (ChainsTab,
+                  FundWalletSettingsForm): a bordered row, label left, control right. */}
+              <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">Limit usage credits</p>
+                  <p className="text-xs text-muted-foreground">
+                    {usageLimited
+                      ? 'Capped. The key spends only the balances below, and any other unit is rejected.'
+                      : 'Uncapped. The key spends whatever the wallets it can reach hold.'}
+                  </p>
+                </div>
                 <Controller
                   control={control}
                   name="usageLimited"
@@ -495,49 +546,39 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                     />
                   )}
                 />
-                <div className="space-y-0.5">
-                  <Label className="text-sm font-medium">Limit usage credits</Label>
-                  <p className="text-xs text-muted-foreground">
-                    On, the key may only spend the balances below, and a purchase in any other unit
-                    is rejected. Off, the key spends freely from its wallets.
-                  </p>
-                </div>
               </div>
-            </div>
-          )}
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Usage credits</label>
-            {apiKey.canAdmin ? (
-              <p className="text-xs text-muted-foreground">
-                Admin keys are never usage limited, so they hold no credit balances.
-              </p>
-            ) : (
-              <>
-                <Controller
-                  control={control}
-                  name="credits"
-                  render={({ field }) => (
-                    <UsageCreditsField
-                      options={creditOptions}
-                      rows={field.value}
-                      current={currentCredits}
-                      onChange={field.onChange}
-                      rowErrors={creditRowErrors}
-                    />
+              {/* Only meaningful while the cap is on: an uncapped key ignores these
+                  balances entirely, so showing them invites edits that do nothing. */}
+              {usageLimited && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Usage credits</label>
+                  <Controller
+                    control={control}
+                    name="credits"
+                    render={({ field }) => (
+                      <UsageCreditsField
+                        options={creditOptions}
+                        rows={field.value}
+                        current={currentCredits}
+                        onChange={field.onChange}
+                        rowErrors={creditRowErrors}
+                      />
+                    )}
+                  />
+                  {/* Shown from the watched values rather than read out of the resolver's
+                      array-root error, so the reason a save is blocked is always visible. */}
+                  {creditRows.length === 0 && (
+                    <p className="text-xs text-destructive">
+                      A usage-limited key needs at least one funded unit. With none, the node
+                      rejects every purchase with &quot;Insufficient funds&quot; before it writes a
+                      payment.
+                    </p>
                   )}
-                />
-                {/* Shown from the watched values rather than read out of the resolver's
-                    array-root error, so the reason a save is blocked is always visible. */}
-                {usageLimited && creditRows.length === 0 && (
-                  <p className="text-xs text-destructive">
-                    A usage-limited key needs at least one funded unit. With none, the node rejects
-                    every purchase with &quot;Insufficient funds&quot; before it writes a payment.
-                  </p>
-                )}
-              </>
-            )}
-          </div>
+                </div>
+              )}
+            </>
+          )}
 
           {!apiKey.canAdmin && (
             <>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -241,7 +241,7 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     control,
     reset,
     setValue,
-    formState: { errors, isDirty },
+    formState: { errors, dirtyFields },
   } = useForm<UpdateApiKeyFormValues>({
     resolver: zodResolver(updateApiKeySchema),
     defaultValues: {
@@ -285,17 +285,21 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
   });
   const creditRows = useWatch({ control, name: 'credits', defaultValue: initialCreditRows });
 
-  // The EVM chain list loads after first paint, so the defaults above fall back to 6
-  // decimals for any chain-qualified unit. Re-seed once the real decimals are known, but
+  // The EVM chain list loads after first paint, so the defaults above fall back to base
+  // units for any chain-qualified unit. Re-seed once the real decimals are known, but
   // only while the operator has not started editing, so this can never eat their input.
   const seededCreditsRef = useRef<string | null>(null);
+  const creditsDirty = dirtyFields.credits !== undefined;
   useEffect(() => {
-    if (isDirty) return;
+    // dirtyFields.credits, not isDirty: the latter is form-wide, so typing a new token
+    // before the chain list arrived froze every chain-qualified row at the base-unit
+    // fallback while the label resolved to the preset, showing 5000000 next to USDC.
+    if (creditsDirty) return;
     const signature = initialCreditRows.map((row) => `${row.unit}:${row.decimals}`).join('|');
     if (signature === seededCreditsRef.current) return;
     seededCreditsRef.current = signature;
     setValue('credits', initialCreditRows);
-  }, [initialCreditRows, isDirty, setValue]);
+  }, [initialCreditRows, creditsDirty, setValue]);
 
   // react-hook-form nests array errors as errors.credits[index].amount; flatten them to
   // the index map the field component renders.
@@ -314,13 +318,19 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     // The endpoint takes deltas, not absolute balances, so diff the edited balances
     // against the stored ones and send only what moved. An unchanged unit is omitted;
     // a zero delta for a unit with no row is a 400 ('Invalid amount').
-    const usageCredits = creditDeltas(
-      currentCredits,
-      data.credits.map((credit) => ({
-        unit: credit.unit,
-        amount: convertDecimalToBaseUnits(credit.amount, credit.decimals),
-      })),
-    );
+    // Only while the cap is on. With it off the balances are neither validated nor
+    // shown, so a half-typed row would throw here (convertDecimalToBaseUnits rejects
+    // an empty string and handleSubmit re-throws, leaving the button dead), and a
+    // cleared list would send deltas that zero the ledger from a hidden section.
+    const usageCredits = data.usageLimited
+      ? creditDeltas(
+          currentCredits,
+          data.credits.map((credit) => ({
+            unit: credit.unit,
+            amount: convertDecimalToBaseUnits(credit.amount, credit.decimals),
+          })),
+        )
+      : [];
 
     const walletScopeChanged =
       data.walletScopeEnabled !== apiKey.walletScopeEnabled ||

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -444,13 +444,10 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                     <div className="flex items-center gap-2">
                       <Checkbox
                         aria-label="Select all EVM chains"
-                        checked={
-                          field.value.length === evmChainOptions.length
-                            ? true
-                            : field.value.length === 0
-                              ? false
-                              : 'indeterminate'
-                        }
+                        // Not 'indeterminate': the shared Checkbox styles only
+                        // data-[state=checked] and always renders its Check icon, so a
+                        // partial state paints a tick with no fill and reads as checked.
+                        checked={field.value.length === evmChainOptions.length}
                         onCheckedChange={() =>
                           field.onChange(
                             field.value.length === evmChainOptions.length

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -20,25 +20,25 @@ import {
 import { PatchApiKeyData, PatchApiKeyResponse } from '@/lib/api/generated/types.gen';
 import { useApiMutation } from '@/lib/hooks/useApiMutation';
 import { useForm, Controller, useWatch } from 'react-hook-form';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Checkbox } from '@/components/ui/checkbox';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
 import { X402WalletScopeField } from '@/components/api-keys/X402WalletScopeField';
 import { useAllWallets } from '@/lib/queries/useWallets';
 import { shortenAddress } from '@/lib/utils';
-import {
-  convertBaseUnitsToDecimal,
-  convertDecimalToBaseUnits,
-} from '@/lib/convertDecimalToBaseUnits';
+import { convertBaseUnitsToDecimal } from '@/lib/convertDecimalToBaseUnits';
 import {
   consolidateCreditRows,
-  creditDeltas,
-  creditRowProblem,
+  creditUnitGroupsForKey,
   creditUnitOptionsForKey,
   type CreditUnitOption,
 } from '@/lib/api-key-credit-units';
 import { UsageCreditsField, type CreditRow } from '@/components/api-keys/UsageCreditsField';
+import {
+  buildUpdateApiKeySchema,
+  usageCreditDeltas,
+  type UpdateApiKeyFormValues,
+} from '@/components/api-keys/update-api-key-form';
 import { Switch } from '@/components/ui/switch';
 
 interface UpdateApiKeyDialogProps {
@@ -65,60 +65,6 @@ interface UpdateApiKeyDialogProps {
     X402WalletScopes: Array<{ evmWalletId: string }>;
   };
 }
-
-/**
- * Built per key rather than once at module scope, because two of its rules depend on
- * what the ledger already holds: a zero balance is only expressible for a unit that
- * already has a row.
- */
-function buildUpdateApiKeySchema(fundedUnits: Set<string>) {
-  return z
-    .object({
-      newToken: z
-        .string()
-        .min(15, 'Token must be at least 15 characters')
-        .optional()
-        .or(z.literal('')),
-      status: z.enum(['Active', 'Revoked']),
-      usageLimited: z.boolean(),
-      credits: z.array(z.object({ unit: z.string(), amount: z.string(), decimals: z.number() })),
-      walletScopeEnabled: z.boolean(),
-      walletScopeIds: z.array(z.string()),
-      x402WalletScopeEnabled: z.boolean(),
-      x402WalletScopeIds: z.array(z.string()),
-      evmChains: z.array(z.string()),
-    })
-    .superRefine((val, ctx) => {
-      // The balances are hidden while the cap is off, and an uncapped key ignores them.
-      // Validating them anyway blocked Update with an error rendered only inside the
-      // unmounted field, so the button looked dead and no request was made.
-      if (!val.usageLimited) return;
-      val.credits.forEach((credit, index) => {
-        const problem = creditRowProblem(credit, fundedUnits);
-        if (problem !== undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: problem,
-            path: ['credits', index, 'amount'],
-          });
-        }
-      });
-      // The exact state that broke every purchase on this deployment: a key flagged
-      // usage-limited whose ledger has no row for the unit it pays in fails the credit
-      // gate with `Credit unit not found`, surfaced to the buyer as a bare 400
-      // 'Insufficient funds' with no purchase ever created.
-      if (val.usageLimited && val.credits.length === 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'A usage-limited key needs at least one funded unit, or every payment it makes is rejected.',
-          path: ['credits'],
-        });
-      }
-    });
-}
-
-type UpdateApiKeyFormValues = z.infer<ReturnType<typeof buildUpdateApiKeySchema>>;
 
 /**
  * Get a human-readable permission label from flags.
@@ -182,6 +128,16 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
       }),
     [apiKey.NetworkLimit, apiKey.ChainIdLimit, currentCredits, evmChainOptions],
   );
+  const creditGroups = useMemo(
+    () =>
+      creditUnitGroupsForKey({
+        networkLimit: apiKey.NetworkLimit,
+        chainIdLimit: apiKey.ChainIdLimit,
+        evmNetworks: evmChainOptions,
+        existingUnits: currentCredits.map((credit) => credit.unit),
+      }),
+    [apiKey.NetworkLimit, apiKey.ChainIdLimit, currentCredits, evmChainOptions],
+  );
 
   // Seed with the key's stored balances so the dialog shows the ledger it edits. The
   // old fields were always blank deltas, so the form could never say whether a key was
@@ -208,7 +164,7 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
   const [customCreditOptions, setCustomCreditOptions] = useState<CreditUnitOption[]>([]);
 
   const updateApiKeySchema = useMemo(
-    () => buildUpdateApiKeySchema(new Set(currentCredits.map((credit) => credit.unit))),
+    () => buildUpdateApiKeySchema(currentCredits),
     [currentCredits],
   );
 
@@ -273,13 +229,6 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
   // because that chain existed only in the unsaved form. It appears once the grant is
   // saved, which is also when it becomes actionable.
   const evmChainsGranted = apiKey.ChainIdLimit.some((chainId) => chainId.startsWith('eip155:'));
-  // What the ledger will hold after this save. Removing a row does not remove it: the
-  // server zeroes it and keeps it, and pay.ts counts rows. Reading only the form
-  // inverted the warning on a removal, claiming wallet-bounded spending in the one
-  // state where the row still exists and every EVM payment is refused.
-  const hasEvmCreditRow =
-    currentCredits.some((credit) => credit.unit.startsWith('eip155:')) ||
-    creditRows.some((row) => row.unit.startsWith('eip155:'));
 
   // The EVM chain list loads after first paint, so the defaults above fall back to base
   // units for any chain-qualified unit. Re-seed once the real decimals are known, but
@@ -318,15 +267,7 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     // shown, so a half-typed row would throw here (convertDecimalToBaseUnits rejects
     // an empty string and handleSubmit re-throws, leaving the button dead), and a
     // cleared list would send deltas that zero the ledger from a hidden section.
-    const usageCredits = data.usageLimited
-      ? creditDeltas(
-          currentCredits,
-          data.credits.map((credit) => ({
-            unit: credit.unit,
-            amount: convertDecimalToBaseUnits(credit.amount, credit.decimals),
-          })),
-        )
-      : [];
+    const usageCredits = usageCreditDeltas(data.usageLimited, currentCredits, data.credits);
 
     const walletScopeChanged =
       data.walletScopeEnabled !== apiKey.walletScopeEnabled ||
@@ -567,7 +508,7 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
             <div className="space-y-2">
               <label className="text-sm font-medium">Spending limit</label>
               <p className="text-xs text-muted-foreground">
-                Admin keys are never usage limited, so they hold no credit balances.
+                Admin keys are never usage limited, so they ignore any stored credit balances.
               </p>
             </div>
           ) : (
@@ -607,37 +548,33 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                     render={({ field }) => (
                       <UsageCreditsField
                         options={creditOptions}
+                        groups={creditGroups}
                         rows={field.value}
                         current={currentCredits}
                         onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        inputRef={field.ref}
                         rowErrors={creditRowErrors}
                         customOptions={customCreditOptions}
                         onCustomOptionsChange={setCustomCreditOptions}
                       />
                     )}
                   />
-                  {/* Shown from the watched values rather than read out of the resolver's
-                      array-root error, so the reason a save is blocked is always visible. */}
                   {creditRows.length === 0 && (
-                    <p className="text-xs text-destructive">
-                      A usage-limited key needs at least one funded unit. With none, every Cardano
-                      purchase is rejected as &quot;Insufficient funds&quot; before a payment is
-                      written, and{' '}
-                      {hasEvmCreditRow
-                        ? 'x402 payments are refused as well: removing an EVM row zeroes it on the server rather than deleting it, and a zeroed row still binds the cap.'
-                        : 'x402 spending is not capped at all.'}
+                    <p className="text-xs text-muted-foreground">
+                      This key has no spending allowance. Payments remain blocked until you fund the
+                      matching unit.
                     </p>
                   )}
-                  {/* The gap that makes a key look capped while it is not. pay.ts
-                      grandfathers a usage-limited key with no eip155 row to its pre-cap
-                      behaviour, so its x402 spending is bounded only by the wallet. It
-                      counts ROWS, not amounts: the first such row makes the cap binding
-                      on every granted chain, and a zeroed row still counts because the
-                      server keeps it rather than deleting it. */}
-                  {creditRows.length > 0 && evmChainsGranted && !hasEvmCreditRow && (
-                    <p className="text-xs text-amber-600 dark:text-amber-500">
-                      x402 payments on this key&apos;s EVM chains are not capped yet. Fund one of
-                      them to start the limit; it then binds every chain above.
+                  {errors.credits?.root?.message && (
+                    <p role="alert" className="text-xs text-destructive">
+                      {errors.credits.root.message}
+                    </p>
+                  )}
+                  {evmChainsGranted && (
+                    <p className="text-xs text-muted-foreground">
+                      x402 usage limits apply to each chain and asset. A missing or insufficient
+                      balance for the exact chain and asset is rejected with HTTP 402.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -65,58 +65,87 @@ interface UpdateApiKeyDialogProps {
   };
 }
 
-const updateApiKeySchema = z
-  .object({
-    newToken: z
-      .string()
-      .min(15, 'Token must be at least 15 characters')
-      .optional()
-      .or(z.literal('')),
-    status: z.enum(['Active', 'Revoked']),
-    usageLimited: z.boolean(),
-    credits: z.array(z.object({ unit: z.string(), amount: z.string(), decimals: z.number() })),
-    walletScopeEnabled: z.boolean(),
-    walletScopeIds: z.array(z.string()),
-    x402WalletScopeEnabled: z.boolean(),
-    x402WalletScopeIds: z.array(z.string()),
-    evmChains: z.array(z.string()),
-  })
-  .superRefine((val, ctx) => {
-    val.credits.forEach((credit, index) => {
-      if (credit.amount.trim() === '') {
+/**
+ * Built per key rather than once at module scope, because two of its rules depend on
+ * what the ledger already holds: a zero balance is only expressible for a unit that
+ * already has a row.
+ */
+function buildUpdateApiKeySchema(fundedUnits: Set<string>) {
+  return z
+    .object({
+      newToken: z
+        .string()
+        .min(15, 'Token must be at least 15 characters')
+        .optional()
+        .or(z.literal('')),
+      status: z.enum(['Active', 'Revoked']),
+      usageLimited: z.boolean(),
+      credits: z.array(z.object({ unit: z.string(), amount: z.string(), decimals: z.number() })),
+      walletScopeEnabled: z.boolean(),
+      walletScopeIds: z.array(z.string()),
+      x402WalletScopeEnabled: z.boolean(),
+      x402WalletScopeIds: z.array(z.string()),
+      evmChains: z.array(z.string()),
+    })
+    .superRefine((val, ctx) => {
+      // The balances are hidden while the cap is off, and an uncapped key ignores them.
+      // Validating them anyway blocked Update with an error rendered only inside the
+      // unmounted field, so the button looked dead and no request was made.
+      if (!val.usageLimited) return;
+      val.credits.forEach((credit, index) => {
+        if (credit.amount.trim() === '') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Enter a balance, or remove this unit',
+            path: ['credits', index, 'amount'],
+          });
+          return;
+        }
+        // Balances, not deltas: a negative balance is meaningless and the server
+        // rejects it anyway. Precision is checked against the unit's own decimals so
+        // an over-precise entry is refused instead of silently truncated on convert.
+        if (!isValidDecimalAmount(credit.amount, { decimals: credit.decimals })) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              credit.decimals === 0
+                ? 'Enter a whole number of base units'
+                : `Enter a positive amount with at most ${credit.decimals} decimals`,
+            path: ['credits', index, 'amount'],
+          });
+          return;
+        }
+        // A zero balance for a unit the ledger has no row for sends no delta at all
+        // (creditDeltas skips it) and the server refuses to create one (400 'Invalid
+        // amount'). The save would report success and leave the unit uncapped, which
+        // for x402 means the key keeps spending with no ceiling.
+        if (
+          !fundedUnits.has(credit.unit) &&
+          convertDecimalToBaseUnits(credit.amount, credit.decimals) === '0'
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Enter an amount above zero. The node cannot store a new unit at zero.',
+            path: ['credits', index, 'amount'],
+          });
+        }
+      });
+      // The exact state that broke every purchase on this deployment: a key flagged
+      // usage-limited whose ledger has no row for the unit it pays in fails the credit
+      // gate with `Credit unit not found`, surfaced to the buyer as a bare 400
+      // 'Insufficient funds' with no purchase ever created.
+      if (val.usageLimited && val.credits.length === 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: 'Enter a balance, or remove this unit',
-          path: ['credits', index, 'amount'],
-        });
-        return;
-      }
-      // Balances, not deltas: a negative balance is meaningless and the server
-      // rejects it anyway. Precision is checked against the unit's own decimals so
-      // an over-precise entry is refused instead of silently truncated on convert.
-      if (!isValidDecimalAmount(credit.amount, { decimals: credit.decimals })) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Enter a positive amount with at most ${credit.decimals} decimals`,
-          path: ['credits', index, 'amount'],
+          message:
+            'A usage-limited key needs at least one funded unit, or every payment it makes is rejected.',
+          path: ['credits'],
         });
       }
     });
-    // The exact state that broke every purchase on this deployment: a key flagged
-    // usage-limited whose ledger has no row for the unit it pays in fails the credit
-    // gate with `Credit unit not found`, surfaced to the buyer as a bare 400
-    // 'Insufficient funds' with no purchase ever created.
-    if (val.usageLimited && val.credits.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'A usage-limited key needs at least one funded unit, or every payment it makes is rejected.',
-        path: ['credits'],
-      });
-    }
-  });
+}
 
-type UpdateApiKeyFormValues = z.infer<typeof updateApiKeySchema>;
+type UpdateApiKeyFormValues = z.infer<ReturnType<typeof buildUpdateApiKeySchema>>;
 
 /**
  * Get a human-readable permission label from flags.
@@ -187,7 +216,9 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
   const initialCreditRows = useMemo<CreditRow[]>(
     () =>
       currentCredits.map((credit) => {
-        const decimals = creditOptions.find((option) => option.unit === credit.unit)?.decimals ?? 6;
+        // 0 for anything no preset describes, so the stored value round-trips exactly
+        // instead of being rescaled by an assumed 6dp.
+        const decimals = creditOptions.find((option) => option.unit === credit.unit)?.decimals ?? 0;
         let amount = credit.amount;
         try {
           amount = convertBaseUnitsToDecimal(credit.amount, decimals);
@@ -197,6 +228,11 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
         return { unit: credit.unit, amount, decimals };
       }),
     [currentCredits, creditOptions],
+  );
+
+  const updateApiKeySchema = useMemo(
+    () => buildUpdateApiKeySchema(new Set(currentCredits.map((credit) => credit.unit))),
+    [currentCredits],
   );
 
   const {
@@ -434,58 +470,67 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
               <Controller
                 control={control}
                 name="evmChains"
-                render={({ field }) => (
-                  <div className="flex flex-col gap-2">
-                    {/* Named for what it does. The node stores no "unlimited" state:
+                render={({ field }) => {
+                  // Membership, not count: ChainIdLimit can still name a chain this node
+                  // no longer configures, which makes the two counts match while the
+                  // boxes below disagree. Clicking "all" then took the already-all
+                  // branch and cleared every EVM grant on the key.
+                  const allEvmChainsSelected = evmChainOptions.every((chain) =>
+                    field.value.includes(chain.caip2Id),
+                  );
+                  return (
+                    <div className="flex flex-col gap-2">
+                      {/* Named for what it does. The node stores no "unlimited" state:
                         an omitted ChainIdLimit is expanded to the configured chain list
                         at creation (routes/api/api-key/index.ts), and on PATCH an omitted
                         one means unchanged. So "all" is a snapshot of today's chains, and
                         a chain configured later is not granted by it. */}
-                    <div className="flex items-center gap-2">
-                      <Checkbox
-                        aria-label="Select all EVM chains"
-                        // Not 'indeterminate': the shared Checkbox styles only
-                        // data-[state=checked] and always renders its Check icon, so a
-                        // partial state paints a tick with no fill and reads as checked.
-                        checked={field.value.length === evmChainOptions.length}
-                        onCheckedChange={() =>
-                          field.onChange(
-                            field.value.length === evmChainOptions.length
-                              ? []
-                              : evmChainOptions.map((chain) => chain.caip2Id),
-                          )
-                        }
-                      />
-                      <label className="text-sm font-medium">
-                        All EVM chains configured on this node
-                      </label>
-                    </div>
-                    <Separator className="my-1" />
-                    {evmChainOptions.map((chain) => (
-                      <div key={chain.id} className="flex items-center gap-2">
+                      <div className="flex items-center gap-2">
                         <Checkbox
-                          aria-label={chain.displayName}
-                          checked={field.value.includes(chain.caip2Id)}
-                          onCheckedChange={() => {
-                            if (field.value.includes(chain.caip2Id)) {
-                              field.onChange(
-                                field.value.filter((c: string) => c !== chain.caip2Id),
-                              );
-                            } else {
-                              field.onChange([...field.value, chain.caip2Id]);
-                            }
-                          }}
+                          aria-label="Select all EVM chains"
+                          // Not 'indeterminate': the shared Checkbox styles only
+                          // data-[state=checked] and always renders its Check icon, so a
+                          // partial state paints a tick with no fill and reads as checked.
+                          checked={allEvmChainsSelected}
+                          onCheckedChange={() =>
+                            field.onChange(
+                              allEvmChainsSelected
+                                ? []
+                                : evmChainOptions.map((chain) => chain.caip2Id),
+                            )
+                          }
                         />
-                        <label className="text-sm">
-                          {chain.displayName}{' '}
-                          <span className="font-mono text-xs text-muted-foreground">
-                            {chain.caip2Id}
-                          </span>
+                        <label className="text-sm font-medium">
+                          All EVM chains configured on this node
                         </label>
                       </div>
-                    ))}
-                  </div>
-                )}
+                      <Separator className="my-1" />
+                      {evmChainOptions.map((chain) => (
+                        <div key={chain.id} className="flex items-center gap-2">
+                          <Checkbox
+                            aria-label={chain.displayName}
+                            checked={field.value.includes(chain.caip2Id)}
+                            onCheckedChange={() => {
+                              if (field.value.includes(chain.caip2Id)) {
+                                field.onChange(
+                                  field.value.filter((c: string) => c !== chain.caip2Id),
+                                );
+                              } else {
+                                field.onChange([...field.value, chain.caip2Id]);
+                              }
+                            }}
+                          />
+                          <label className="text-sm">
+                            {chain.displayName}{' '}
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {chain.caip2Id}
+                            </span>
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                }}
               />
             </div>
           )}

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -30,12 +30,13 @@ import { shortenAddress } from '@/lib/utils';
 import {
   convertBaseUnitsToDecimal,
   convertDecimalToBaseUnits,
-  isValidDecimalAmount,
 } from '@/lib/convertDecimalToBaseUnits';
 import {
   consolidateCreditRows,
   creditDeltas,
+  creditRowProblem,
   creditUnitOptionsForKey,
+  type CreditUnitOption,
 } from '@/lib/api-key-credit-units';
 import { UsageCreditsField, type CreditRow } from '@/components/api-keys/UsageCreditsField';
 import { Switch } from '@/components/ui/switch';
@@ -93,39 +94,11 @@ function buildUpdateApiKeySchema(fundedUnits: Set<string>) {
       // unmounted field, so the button looked dead and no request was made.
       if (!val.usageLimited) return;
       val.credits.forEach((credit, index) => {
-        if (credit.amount.trim() === '') {
+        const problem = creditRowProblem(credit, fundedUnits);
+        if (problem !== undefined) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: 'Enter a balance, or remove this unit',
-            path: ['credits', index, 'amount'],
-          });
-          return;
-        }
-        // Balances, not deltas: a negative balance is meaningless and the server
-        // rejects it anyway. Precision is checked against the unit's own decimals so
-        // an over-precise entry is refused instead of silently truncated on convert.
-        if (!isValidDecimalAmount(credit.amount, { decimals: credit.decimals })) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message:
-              credit.decimals === 0
-                ? 'Enter a whole number of base units'
-                : `Enter a positive amount with at most ${credit.decimals} decimals`,
-            path: ['credits', index, 'amount'],
-          });
-          return;
-        }
-        // A zero balance for a unit the ledger has no row for sends no delta at all
-        // (creditDeltas skips it) and the server refuses to create one (400 'Invalid
-        // amount'). The save would report success and leave the unit uncapped, which
-        // for x402 means the key keeps spending with no ceiling.
-        if (
-          !fundedUnits.has(credit.unit) &&
-          convertDecimalToBaseUnits(credit.amount, credit.decimals) === '0'
-        ) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Enter an amount above zero. The node cannot store a new unit at zero.',
+            message: problem,
             path: ['credits', index, 'amount'],
           });
         }
@@ -230,6 +203,10 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     [currentCredits, creditOptions],
   );
 
+  // Held here, not in UsageCreditsField: that field is unmounted whenever the cap is
+  // switched off, so a custom asset's name would not survive a toggle.
+  const [customCreditOptions, setCustomCreditOptions] = useState<CreditUnitOption[]>([]);
+
   const updateApiKeySchema = useMemo(
     () => buildUpdateApiKeySchema(new Set(currentCredits.map((credit) => credit.unit))),
     [currentCredits],
@@ -284,6 +261,13 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     defaultValue: apiKey.usageLimited,
   });
   const creditRows = useWatch({ control, name: 'credits', defaultValue: initialCreditRows });
+  const evmChains = useWatch({
+    control,
+    name: 'evmChains',
+    defaultValue: apiKey.ChainIdLimit.filter((chainId) => chainId.startsWith('eip155:')),
+  });
+  const evmChainsGranted = evmChains.length > 0;
+  const hasEvmCreditRow = creditRows.some((row) => row.unit.startsWith('eip155:'));
 
   // The EVM chain list loads after first paint, so the defaults above fall back to base
   // units for any chain-qualified unit. Re-seed once the real decimals are known, but
@@ -583,7 +567,7 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                   <p className="text-sm font-medium">Limit usage credits</p>
                   <p className="text-xs text-muted-foreground">
                     {usageLimited
-                      ? 'Capped. The key spends only the balances below, and any other unit is rejected.'
+                      ? 'Capped. The key spends only the balances below.'
                       : 'Uncapped. The key spends whatever the wallets it can reach hold.'}
                   </p>
                 </div>
@@ -615,6 +599,8 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                         current={currentCredits}
                         onChange={field.onChange}
                         rowErrors={creditRowErrors}
+                        customOptions={customCreditOptions}
+                        onCustomOptionsChange={setCustomCreditOptions}
                       />
                     )}
                   />
@@ -625,6 +611,16 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       A usage-limited key needs at least one funded unit. With none, the node
                       rejects every purchase with &quot;Insufficient funds&quot; before it writes a
                       payment.
+                    </p>
+                  )}
+                  {/* The gap that makes a key look capped while it is not. pay.ts
+                      grandfathers a usage-limited key with no eip155 row to its pre-cap
+                      behaviour, so its x402 spending is bounded only by the wallet. The
+                      first such row makes the cap binding on every granted chain. */}
+                  {creditRows.length > 0 && evmChainsGranted && !hasEvmCreditRow && (
+                    <p className="text-xs text-amber-600 dark:text-amber-500">
+                      x402 payments on this key&apos;s EVM chains are not capped yet. The limit
+                      starts applying once the key holds a balance for one of them.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -39,6 +39,7 @@ import {
   usageCreditDeltas,
   type UpdateApiKeyFormValues,
 } from '@/components/api-keys/update-api-key-form';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 import { Switch } from '@/components/ui/switch';
 
 interface UpdateApiKeyDialogProps {
@@ -594,12 +595,11 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       <Checkbox
                         aria-label="Restrict to specific wallets"
                         checked={field.value}
-                        onCheckedChange={(checked) => {
-                          field.onChange(checked);
-                          if (!checked) {
-                            setValue('walletScopeIds', []);
-                          }
-                        }}
+                        // The selection survives an untick. Clearing it here made
+                        // untick-then-retick, a net-zero action on screen, save
+                        // walletScopeEnabled with an empty list: a deny-all key.
+                        // Submit already sends [] while the box is off.
+                        onCheckedChange={(checked) => field.onChange(checked)}
                       />
                     )}
                   />
@@ -655,10 +655,17 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       ))
                     )}
                   </div>
-                  {walletScopeIds.length > 0 && (
+                  {walletScopeIds.length > 0 ? (
                     <p className="text-xs text-muted-foreground">
                       {walletScopeIds.length} wallet{walletScopeIds.length !== 1 ? 's' : ''}{' '}
                       selected
+                    </p>
+                  ) : (
+                    // Shown from the watched value, like the credits rule, so the reason
+                    // Update is blocked is on screen. Nothing named this state before: the
+                    // count line hid itself at zero, so a deny-all read as a tidy list.
+                    <p className="text-xs text-destructive">
+                      {walletScopeProblem(true, walletScopeIds)}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -267,7 +267,10 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
     defaultValue: apiKey.ChainIdLimit.filter((chainId) => chainId.startsWith('eip155:')),
   });
   const evmChainsGranted = evmChains.length > 0;
-  const hasEvmCreditRow = creditRows.some((row) => row.unit.startsWith('eip155:'));
+  // Saved rows, not the edited ones: pay.ts counts what the ledger holds. Reading the
+  // form inverted the warning on a removed row, claiming wallet-bounded spending in the
+  // one state where the row still exists and every EVM payment is refused.
+  const hasEvmCreditRow = currentCredits.some((credit) => credit.unit.startsWith('eip155:'));
 
   // The EVM chain list loads after first paint, so the defaults above fall back to base
   // units for any chain-qualified unit. Re-seed once the real decimals are known, but
@@ -615,12 +618,14 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                   )}
                   {/* The gap that makes a key look capped while it is not. pay.ts
                       grandfathers a usage-limited key with no eip155 row to its pre-cap
-                      behaviour, so its x402 spending is bounded only by the wallet. The
-                      first such row makes the cap binding on every granted chain. */}
+                      behaviour, so its x402 spending is bounded only by the wallet. It
+                      counts ROWS, not amounts: the first such row makes the cap binding
+                      on every granted chain, and a zeroed row still counts because the
+                      server keeps it rather than deleting it. */}
                   {creditRows.length > 0 && evmChainsGranted && !hasEvmCreditRow && (
                     <p className="text-xs text-amber-600 dark:text-amber-500">
-                      x402 payments on this key&apos;s EVM chains are not capped yet. The limit
-                      starts applying once the key holds a balance for one of them.
+                      x402 payments on this key&apos;s EVM chains are not capped yet. Saving a
+                      credit row for one of them starts the limit, even at zero.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -18,7 +18,6 @@ import { convertBaseUnitsToDecimal } from '@/lib/convertDecimalToBaseUnits';
 import {
   buildCustomCreditUnit,
   shortenCreditUnit,
-  UNKNOWN_GROUP_ID,
   type CreditChain,
   type CreditUnitOption,
 } from '@/lib/api-key-credit-units';
@@ -171,12 +170,13 @@ export function UsageCreditsField({
 
       {rows.map((row, index) => {
         const option = optionFor(knownOptions, row.unit);
-        // A unit nothing describes has no symbol, only its own id, and repeating an
-        // elided id beside the amount and again in the balance hint says nothing the
-        // unit-id line below does not already say.
-        const named = option !== undefined && option.chain.kind !== 'unknown';
-        const symbol = named ? option.label : '';
         const heading = option?.label ?? shortenCreditUnit(row.unit);
+        // What the number beside the input is counted in. A 0dp row holds base units
+        // whatever the asset is called, so naming it after the asset would put "250"
+        // next to a symbol that means a million times more, which is the misread this
+        // field exists to prevent. A unit nothing describes has no symbol at all, only
+        // its own id, which the unit-id line below already shows.
+        const denomination = row.decimals === 0 ? 'base units' : heading;
         return (
           <div key={row.unit} className="flex items-end gap-2">
             <div className="min-w-0 flex-1 space-y-1.5">
@@ -184,7 +184,7 @@ export function UsageCreditsField({
                 <span className="font-medium text-foreground">{heading}</span>
                 <span className="ml-1 opacity-70">
                   {option ? option.group : 'unknown unit'} ·{' '}
-                  {currentBalanceLabel(current, row.unit, row.decimals, symbol)}
+                  {currentBalanceLabel(current, row.unit, row.decimals, denomination)}
                 </span>
               </Label>
               {/* The symbol sits against the amount because the identifier line below
@@ -205,7 +205,7 @@ export function UsageCreditsField({
                   }}
                 />
                 <span className="shrink-0 text-sm font-medium text-muted-foreground">
-                  {symbol || 'base units'}
+                  {denomination}
                 </span>
               </div>
               <p className="text-[0.6875rem] break-all text-muted-foreground">
@@ -325,7 +325,7 @@ export function UsageCreditsField({
               onChange={(event) => setCustomEntry({ ...customEntry, symbol: event.target.value })}
             />
             <p className="text-xs text-muted-foreground">
-              Shown next to the amount, so the balance reads as an asset and not as a raw id.
+              Names the row, so it does not read as a bare id. Optional.
             </p>
           </div>
           <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -17,8 +17,8 @@ import {
 import { convertBaseUnitsToDecimal } from '@/lib/convertDecimalToBaseUnits';
 import {
   buildCustomCreditUnit,
-  DEFAULT_CREDIT_DECIMALS,
   shortenCreditUnit,
+  UNKNOWN_GROUP_ID,
   type CreditChain,
   type CreditUnitOption,
 } from '@/lib/api-key-credit-units';
@@ -59,7 +59,7 @@ function currentBalanceLabel(
   const stored = current.find((row) => row.unit === unit);
   if (!stored) return 'not funded yet';
   try {
-    return `currently ${convertBaseUnitsToDecimal(stored.amount, decimals)} ${symbol}`;
+    return `currently ${convertBaseUnitsToDecimal(stored.amount, decimals)} ${symbol}`.trim();
   } catch {
     // A row the ledger holds in a shape this form cannot parse still has to be
     // visible; showing the raw value beats hiding the balance entirely.
@@ -68,16 +68,21 @@ function currentBalanceLabel(
 }
 
 /** The chain a group's units settle on, read off any option already in that group. */
-function chainForGroup(options: CreditUnitOption[], group: string): CreditChain {
-  return options.find((option) => option.group === group)?.chain ?? { kind: 'unknown' };
+function chainForGroup(options: CreditUnitOption[], groupId: string): CreditChain {
+  return options.find((option) => option.groupId === groupId)?.chain ?? { kind: 'unknown' };
+}
+
+/** The group's display name, which unlike its id is not guaranteed unique. */
+function nameForGroup(options: CreditUnitOption[], groupId: string): string {
+  return options.find((option) => option.groupId === groupId)?.group ?? groupId;
 }
 
 interface CustomEntry {
-  group: string;
+  groupId: string;
+  groupName: string;
   chain: CreditChain;
   value: string;
   symbol: string;
-  decimals: string;
   error?: string;
 }
 
@@ -104,14 +109,14 @@ export function UsageCreditsField({
     const groups = new Map<string, Array<{ option: CreditUnitOption; index: number }>>();
     options.forEach((option, index) => {
       if (taken.has(option.unit)) return;
-      const bucket = groups.get(option.group) ?? [];
+      const bucket = groups.get(option.groupId) ?? [];
       bucket.push({ option, index });
-      groups.set(option.group, bucket);
+      groups.set(option.groupId, bucket);
     });
     // A group whose presets are all taken still needs a row, because the custom
     // entry below lives inside it.
     for (const option of options) {
-      if (!groups.has(option.group)) groups.set(option.group, []);
+      if (!groups.has(option.groupId)) groups.set(option.groupId, []);
     }
     return Array.from(groups.entries());
   }, [options, rows]);
@@ -122,7 +127,8 @@ export function UsageCreditsField({
   // ledger, and those cannot take a custom asset. Once they are all placed as rows the
   // picker has nothing left to offer, so it is hidden rather than opened onto nothing.
   const hasSomethingToAdd = groupedAvailable.some(
-    ([group, entries]) => entries.length > 0 || chainForGroup(options, group).kind !== 'unknown',
+    ([groupId, entries]) =>
+      entries.length > 0 || chainForGroup(options, groupId).kind !== 'unknown',
   );
 
   function addCustomUnit(entry: CustomEntry) {
@@ -135,23 +141,22 @@ export function UsageCreditsField({
       setCustomEntry({ ...entry, error: 'That asset is already in the list' });
       return;
     }
-    const decimals = Number(entry.decimals);
-    if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
-      setCustomEntry({ ...entry, error: 'Decimals must be a whole number from 0 to 30' });
-      return;
-    }
     setCustomOptions((previous) => [
       ...previous,
       {
         unit: built.unit,
         label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,
-        group: entry.group,
+        groupId: entry.groupId,
+        group: entry.groupName,
         identifier: built.unit,
-        decimals,
+        // Base units, like every other unit nothing describes. PATCH carries only unit
+        // and amount, so decimals typed here would be gone on the next open and the
+        // same balance would read back rescaled.
+        decimals: 0,
         chain: entry.chain,
       },
     ]);
-    onChange([...rows, { unit: built.unit, amount: '', decimals }]);
+    onChange([...rows, { unit: built.unit, amount: '', decimals: 0 }]);
     setCustomEntry(null);
   }
 
@@ -166,12 +171,17 @@ export function UsageCreditsField({
 
       {rows.map((row, index) => {
         const option = optionFor(knownOptions, row.unit);
-        const symbol = option?.label ?? shortenCreditUnit(row.unit);
+        // A unit nothing describes has no symbol, only its own id, and repeating an
+        // elided id beside the amount and again in the balance hint says nothing the
+        // unit-id line below does not already say.
+        const named = option !== undefined && option.chain.kind !== 'unknown';
+        const symbol = named ? option.label : '';
+        const heading = option?.label ?? shortenCreditUnit(row.unit);
         return (
           <div key={row.unit} className="flex items-end gap-2">
             <div className="min-w-0 flex-1 space-y-1.5">
               <Label htmlFor={`credit-${index}`} className="text-xs text-muted-foreground">
-                <span className="font-medium text-foreground">{symbol}</span>
+                <span className="font-medium text-foreground">{heading}</span>
                 <span className="ml-1 opacity-70">
                   {option ? option.group : 'unknown unit'} ·{' '}
                   {currentBalanceLabel(current, row.unit, row.decimals, symbol)}
@@ -194,7 +204,9 @@ export function UsageCreditsField({
                     onChange(next);
                   }}
                 />
-                <span className="shrink-0 text-sm font-medium">{symbol}</span>
+                <span className="shrink-0 text-sm font-medium text-muted-foreground">
+                  {symbol || 'base units'}
+                </span>
               </div>
               <p className="text-[0.6875rem] break-all text-muted-foreground">
                 <span className="mr-1 uppercase opacity-70">unit id</span>
@@ -207,7 +219,7 @@ export function UsageCreditsField({
               variant="ghost"
               size="icon"
               title="Set this balance to zero"
-              aria-label={`Zero the ${symbol} balance`}
+              aria-label={`Zero the ${heading} balance`}
               disabled={disabled}
               onClick={() => onChange(rows.filter((_, position) => position !== index))}
             >
@@ -231,13 +243,13 @@ export function UsageCreditsField({
             disabled={disabled}
             onValueChange={(value) => {
               if (value.startsWith(CUSTOM_OPTION_PREFIX)) {
-                const group = value.slice(CUSTOM_OPTION_PREFIX.length);
+                const groupId = value.slice(CUSTOM_OPTION_PREFIX.length);
                 setCustomEntry({
-                  group,
-                  chain: chainForGroup(options, group),
+                  groupId,
+                  groupName: nameForGroup(options, groupId),
+                  chain: chainForGroup(options, groupId),
                   value: '',
                   symbol: '',
-                  decimals: String(DEFAULT_CREDIT_DECIMALS),
                 });
                 return;
               }
@@ -250,23 +262,23 @@ export function UsageCreditsField({
               <SelectValue placeholder="Add a credit unit" />
             </SelectTrigger>
             <SelectContent>
-              {groupedAvailable.map(([group, entries]) => {
-                const chain = chainForGroup(options, group);
+              {groupedAvailable.map(([groupId, entries]) => {
+                const chain = chainForGroup(options, groupId);
                 // 'Already on this key' collects units whose chain cannot be recovered
                 // from the stored string, so it can list what is there but cannot
                 // validate anything new typed into it.
                 const acceptsCustom = chain.kind !== 'unknown';
                 if (entries.length === 0 && !acceptsCustom) return null;
                 return (
-                  <SelectGroup key={group}>
-                    <SelectLabel>{group}</SelectLabel>
+                  <SelectGroup key={groupId}>
+                    <SelectLabel>{nameForGroup(options, groupId)}</SelectLabel>
                     {entries.map(({ option, index }) => (
                       <SelectItem key={option.unit || 'ada'} value={String(index)}>
                         {option.label}
                       </SelectItem>
                     ))}
                     {acceptsCustom && (
-                      <SelectItem value={`${CUSTOM_OPTION_PREFIX}${group}`}>
+                      <SelectItem value={`${CUSTOM_OPTION_PREFIX}${groupId}`}>
                         Custom asset&hellip;
                       </SelectItem>
                     )}
@@ -280,7 +292,7 @@ export function UsageCreditsField({
 
       {customEntry && (
         <div className="space-y-2 rounded-lg border p-3">
-          <p className="text-sm font-medium">Custom asset on {customEntry.group}</p>
+          <p className="text-sm font-medium">Custom asset on {customEntry.groupName}</p>
           <div className="space-y-1.5">
             <Label htmlFor="custom-credit-unit" className="text-xs text-muted-foreground">
               {customEntry.chain.kind === 'evm'
@@ -316,26 +328,10 @@ export function UsageCreditsField({
               Shown next to the amount, so the balance reads as an asset and not as a raw id.
             </p>
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="custom-credit-decimals" className="text-xs text-muted-foreground">
-              Decimals
-            </Label>
-            <Input
-              id="custom-credit-decimals"
-              type="text"
-              inputMode="numeric"
-              value={customEntry.decimals}
-              onChange={(event) =>
-                setCustomEntry({ ...customEntry, decimals: event.target.value, error: undefined })
-              }
-            />
-            {/* Decimals only scale what this form shows and sends; getting them wrong
-                funds the key by a factor of ten, so they are asked for rather than
-                assumed for an asset the presets do not describe. */}
-            <p className="text-xs text-muted-foreground">
-              How many decimal places the asset uses. Most stablecoins use 6.
-            </p>
-          </div>
+          <p className="text-xs text-muted-foreground">
+            Its balance is entered in base units, because nothing here records how many decimals the
+            asset uses and the node stores only the unit and the amount.
+          </p>
           {customEntry.error && <p className="text-xs text-destructive">{customEntry.error}</p>}
           <div className="flex gap-2">
             <Button

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,6 +19,7 @@ import {
   buildCustomCreditUnit,
   shortenCreditUnit,
   type CreditChain,
+  type CreditUnitGroup,
   type CreditUnitOption,
 } from '@/lib/api-key-credit-units';
 
@@ -33,10 +34,14 @@ export interface CreditRow {
 interface UsageCreditsFieldProps {
   /** Units this key can actually spend, derived from its own access list. */
   options: CreditUnitOption[];
+  /** Allowed chain groups, including chains with no preset token. */
+  groups: CreditUnitGroup[];
   rows: CreditRow[];
   /** The key's stored balances in base units, used for the "currently" hint. */
   current: Array<{ unit: string; amount: string }>;
   onChange: (rows: CreditRow[]) => void;
+  onBlur?: () => void;
+  inputRef?: (element: HTMLInputElement | null) => void;
   disabled?: boolean;
   /** Message per row index, keyed the same way the form validates. */
   rowErrors?: Record<number, string | undefined>;
@@ -72,16 +77,6 @@ function currentBalanceLabel(
   }
 }
 
-/** The chain a group's units settle on, read off any option already in that group. */
-function chainForGroup(options: CreditUnitOption[], groupId: string): CreditChain {
-  return options.find((option) => option.groupId === groupId)?.chain ?? { kind: 'unknown' };
-}
-
-/** The group's display name, which unlike its id is not guaranteed unique. */
-function nameForGroup(options: CreditUnitOption[], groupId: string): string {
-  return options.find((option) => option.groupId === groupId)?.group ?? groupId;
-}
-
 interface CustomEntry {
   groupId: string;
   groupName: string;
@@ -96,37 +91,43 @@ const CUSTOM_OPTION_PREFIX = 'custom:';
 
 export function UsageCreditsField({
   options,
+  groups,
   rows,
   current,
   onChange,
+  onBlur,
+  inputRef,
   disabled = false,
   rowErrors,
   customOptions,
   onCustomOptionsChange,
 }: UsageCreditsFieldProps) {
   const [customEntry, setCustomEntry] = useState<CustomEntry | null>(null);
+  const rowInputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const firstErrorIndex = rows.findIndex((_, index) => rowErrors?.[index] !== undefined);
+  useEffect(() => {
+    if (firstErrorIndex >= 0) rowInputRefs.current[firstErrorIndex]?.focus();
+  }, [firstErrorIndex]);
   // Custom names first. Without them a just-added row falls back to 'unknown unit' and
   // puts its own elided id where the symbol belongs; and a unit already on the ledger
   // appears in `options` under that same elided id, so with lookups taking the first
   // match the operator's own name has to come first to win.
   const knownOptions = useMemo(() => [...customOptions, ...options], [customOptions, options]);
+  const groupById = useMemo(() => new Map(groups.map((group) => [group.groupId, group])), [groups]);
 
   const groupedAvailable = useMemo(() => {
     const taken = new Set(rows.map((row) => row.unit));
-    const groups = new Map<string, Array<{ option: CreditUnitOption; index: number }>>();
+    const available = new Map<string, Array<{ option: CreditUnitOption; index: number }>>(
+      groups.map((group) => [group.groupId, []]),
+    );
     options.forEach((option, index) => {
       if (taken.has(option.unit)) return;
-      const bucket = groups.get(option.groupId) ?? [];
+      const bucket = available.get(option.groupId) ?? [];
       bucket.push({ option, index });
-      groups.set(option.groupId, bucket);
+      available.set(option.groupId, bucket);
     });
-    // A group whose presets are all taken still needs a row, because the custom
-    // entry below lives inside it.
-    for (const option of options) {
-      if (!groups.has(option.groupId)) groups.set(option.groupId, []);
-    }
-    return Array.from(groups.entries());
-  }, [options, rows]);
+    return Array.from(available.entries());
+  }, [groups, options, rows]);
 
   const takenUnits = useMemo(() => new Set(rows.map((row) => row.unit)), [rows]);
 
@@ -134,8 +135,7 @@ export function UsageCreditsField({
   // ledger, and those cannot take a custom asset. Once they are all placed as rows the
   // picker has nothing left to offer, so it is hidden rather than opened onto nothing.
   const hasSomethingToAdd = groupedAvailable.some(
-    ([groupId, entries]) =>
-      entries.length > 0 || chainForGroup(options, groupId).kind !== 'unknown',
+    ([groupId, entries]) => entries.length > 0 || groupById.get(groupId)?.customChain !== undefined,
   );
 
   function addCustomUnit(entry: CustomEntry) {
@@ -210,11 +210,18 @@ export function UsageCreditsField({
               <div className="flex items-center gap-2">
                 <Input
                   id={`credit-${index}`}
+                  ref={(element) => {
+                    rowInputRefs.current[index] = element;
+                    if (index === 0) inputRef?.(element);
+                  }}
                   type="text"
                   inputMode="decimal"
                   disabled={disabled}
+                  aria-invalid={rowErrors?.[index] !== undefined}
+                  aria-describedby={rowErrors?.[index] ? `credit-${index}-error` : undefined}
                   value={row.amount}
                   placeholder="0.00"
+                  onBlur={onBlur}
                   onChange={(event) => {
                     const next = [...rows];
                     next[index] = { ...row, amount: event.target.value };
@@ -229,7 +236,11 @@ export function UsageCreditsField({
                 <span className="mr-1 uppercase opacity-70">unit id</span>
                 <span className="font-mono">{option?.identifier ?? row.unit}</span>
               </p>
-              {rowErrors?.[index] && <p className="text-xs text-destructive">{rowErrors[index]}</p>}
+              {rowErrors?.[index] && (
+                <p id={`credit-${index}-error`} role="alert" className="text-xs text-destructive">
+                  {rowErrors[index]}
+                </p>
+              )}
             </div>
             <Button
               type="button"
@@ -246,7 +257,7 @@ export function UsageCreditsField({
         );
       })}
 
-      {options.length === 0 ? (
+      {groups.length === 0 ? (
         <p className="text-xs text-muted-foreground">
           This key has no Cardano network and no EVM chain in its access list, so there is nothing
           to fund yet.
@@ -261,10 +272,12 @@ export function UsageCreditsField({
             onValueChange={(value) => {
               if (value.startsWith(CUSTOM_OPTION_PREFIX)) {
                 const groupId = value.slice(CUSTOM_OPTION_PREFIX.length);
+                const group = groupById.get(groupId);
+                if (!group?.customChain) return;
                 setCustomEntry({
                   groupId,
-                  groupName: nameForGroup(options, groupId),
-                  chain: chainForGroup(options, groupId),
+                  groupName: group.group,
+                  chain: group.customChain,
                   value: '',
                   symbol: '',
                 });
@@ -280,15 +293,16 @@ export function UsageCreditsField({
             </SelectTrigger>
             <SelectContent>
               {groupedAvailable.map(([groupId, entries]) => {
-                const chain = chainForGroup(options, groupId);
+                const group = groupById.get(groupId);
+                if (!group) return null;
                 // 'Already on this key' collects units whose chain cannot be recovered
                 // from the stored string, so it can list what is there but cannot
                 // validate anything new typed into it.
-                const acceptsCustom = chain.kind !== 'unknown';
+                const acceptsCustom = group.customChain !== undefined;
                 if (entries.length === 0 && !acceptsCustom) return null;
                 return (
                   <SelectGroup key={groupId}>
-                    <SelectLabel>{nameForGroup(options, groupId)}</SelectLabel>
+                    <SelectLabel>{group.group}</SelectLabel>
                     {entries.map(({ option, index }) => (
                       <SelectItem key={option.unit || 'ada'} value={String(index)}>
                         {option.label}
@@ -321,6 +335,8 @@ export function UsageCreditsField({
               value={customEntry.value}
               autoComplete="off"
               spellCheck={false}
+              aria-invalid={customEntry.error !== undefined}
+              aria-describedby={customEntry.error ? 'custom-credit-unit-error' : undefined}
               className="font-mono"
               placeholder={
                 customEntry.chain.kind === 'evm' ? '0x…' : '56 hex characters, then the asset name'
@@ -349,7 +365,11 @@ export function UsageCreditsField({
             Its balance is entered in base units, because nothing here records how many decimals the
             asset uses and the node stores only the unit and the amount.
           </p>
-          {customEntry.error && <p className="text-xs text-destructive">{customEntry.error}</p>}
+          {customEntry.error && (
+            <p id="custom-credit-unit-error" role="alert" className="text-xs text-destructive">
+              {customEntry.error}
+            </p>
+          )}
           <div className="flex gap-2">
             <Button
               type="button"

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -108,7 +108,9 @@ export function UsageCreditsField({
   // Custom units are not in `options` (which is derived from the key's presets), so
   // without their names a just-added row falls back to 'unknown unit' and puts its own
   // elided id where the symbol belongs.
-  const knownOptions = useMemo(() => [...options, ...customOptions], [options, customOptions]);
+  // Custom names first: a unit already on the ledger also appears in `options` under its
+  // own elided id, and lookups take the first match, so the operator's name has to win.
+  const knownOptions = useMemo(() => [...customOptions, ...options], [customOptions, options]);
 
   const groupedAvailable = useMemo(() => {
     const taken = new Set(rows.map((row) => row.unit));

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { convertBaseUnitsToDecimal } from '@/lib/convertDecimalToBaseUnits';
+import { shortenCreditUnit, type CreditUnitOption } from '@/lib/api-key-credit-units';
+
+/** One editable balance. `amount` is a human decimal string, not base units. */
+export interface CreditRow {
+  unit: string;
+  amount: string;
+  /** Carried on the row so the form can validate precision without the option list. */
+  decimals: number;
+}
+
+interface UsageCreditsFieldProps {
+  /** Units this key can actually spend, derived from its own access list. */
+  options: CreditUnitOption[];
+  rows: CreditRow[];
+  /** The key's stored balances in base units, used for the "currently" hint. */
+  current: Array<{ unit: string; amount: string }>;
+  onChange: (rows: CreditRow[]) => void;
+  disabled?: boolean;
+  /** Message per row index, keyed the same way the form validates. */
+  rowErrors?: Record<number, string | undefined>;
+}
+
+function optionFor(options: CreditUnitOption[], unit: string): CreditUnitOption | undefined {
+  return options.find((option) => option.unit === unit);
+}
+
+function currentBalanceLabel(
+  current: Array<{ unit: string; amount: string }>,
+  unit: string,
+  decimals: number,
+): string {
+  const stored = current.find((row) => row.unit === unit);
+  if (!stored) return 'not funded yet';
+  try {
+    return `currently ${convertBaseUnitsToDecimal(stored.amount, decimals)}`;
+  } catch {
+    // A row the ledger holds in a shape this form cannot parse still has to be
+    // visible; showing the raw value beats hiding the balance entirely.
+    return `currently ${stored.amount} base units`;
+  }
+}
+
+export function UsageCreditsField({
+  options,
+  rows,
+  current,
+  onChange,
+  disabled = false,
+  rowErrors,
+}: UsageCreditsFieldProps) {
+  const groupedAvailable = useMemo(() => {
+    const taken = new Set(rows.map((row) => row.unit));
+    const groups = new Map<string, Array<{ option: CreditUnitOption; index: number }>>();
+    options.forEach((option, index) => {
+      if (taken.has(option.unit)) return;
+      const bucket = groups.get(option.group) ?? [];
+      bucket.push({ option, index });
+      groups.set(option.group, bucket);
+    });
+    return Array.from(groups.entries());
+  }, [options, rows]);
+
+  const hasAvailable = groupedAvailable.some(([, entries]) => entries.length > 0);
+
+  return (
+    <div className="space-y-3">
+      {rows.length === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No credit units on this key. A usage-limited key with no credits cannot pay for anything:
+          every purchase is rejected with &quot;Insufficient funds&quot;.
+        </p>
+      )}
+
+      {rows.map((row, index) => {
+        const option = optionFor(options, row.unit);
+        return (
+          <div key={row.unit} className="flex items-end gap-2">
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Label htmlFor={`credit-${index}`} className="text-xs text-muted-foreground">
+                {option?.label ?? shortenCreditUnit(row.unit)}
+                <span className="ml-1 opacity-70">
+                  {option ? option.group : 'unknown unit'} ·{' '}
+                  {currentBalanceLabel(current, row.unit, row.decimals)}
+                </span>
+              </Label>
+              <Input
+                id={`credit-${index}`}
+                type="text"
+                inputMode="decimal"
+                disabled={disabled}
+                value={row.amount}
+                placeholder="0.00"
+                onChange={(event) => {
+                  const next = [...rows];
+                  next[index] = { ...row, amount: event.target.value };
+                  onChange(next);
+                }}
+              />
+              <p className="font-mono text-[0.6875rem] break-all text-muted-foreground">
+                {option?.identifier ?? row.unit}
+              </p>
+              {rowErrors?.[index] && <p className="text-xs text-destructive">{rowErrors[index]}</p>}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              title="Set this balance to zero"
+              aria-label={`Zero the ${option?.label ?? shortenCreditUnit(row.unit)} balance`}
+              disabled={disabled}
+              onClick={() => onChange(rows.filter((_, position) => position !== index))}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+        );
+      })}
+
+      {options.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          This key has no Cardano network and no EVM chain in its access list, so there is nothing
+          to fund yet.
+        </p>
+      ) : (
+        hasAvailable && (
+          <Select
+            // Radix rejects an empty option value and ADA's unit IS the empty string, so
+            // the picker addresses options by index and maps back here.
+            value=""
+            disabled={disabled}
+            onValueChange={(value) => {
+              const option = options[Number(value)];
+              if (!option) return;
+              onChange([...rows, { unit: option.unit, amount: '', decimals: option.decimals }]);
+            }}
+          >
+            <SelectTrigger aria-label="Add a credit unit">
+              <SelectValue placeholder="Add a credit unit" />
+            </SelectTrigger>
+            <SelectContent>
+              {groupedAvailable.map(([group, entries]) => (
+                <SelectGroup key={group}>
+                  <SelectLabel>{group}</SelectLabel>
+                  {entries.map(({ option, index }) => (
+                    <SelectItem key={option.unit || 'ada'} value={String(index)}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -105,11 +105,10 @@ export function UsageCreditsField({
   onCustomOptionsChange,
 }: UsageCreditsFieldProps) {
   const [customEntry, setCustomEntry] = useState<CustomEntry | null>(null);
-  // Custom units are not in `options` (which is derived from the key's presets), so
-  // without their names a just-added row falls back to 'unknown unit' and puts its own
-  // elided id where the symbol belongs.
-  // Custom names first: a unit already on the ledger also appears in `options` under its
-  // own elided id, and lookups take the first match, so the operator's name has to win.
+  // Custom names first. Without them a just-added row falls back to 'unknown unit' and
+  // puts its own elided id where the symbol belongs; and a unit already on the ledger
+  // appears in `options` under that same elided id, so with lookups taking the first
+  // match the operator's own name has to come first to win.
   const knownOptions = useMemo(() => [...customOptions, ...options], [customOptions, options]);
 
   const groupedAvailable = useMemo(() => {
@@ -149,37 +148,38 @@ export function UsageCreditsField({
       setCustomEntry({ ...entry, error: 'That asset is already in the list' });
       return;
     }
-    onCustomOptionsChange([
-      // Replace rather than append: the same unit can be removed and added again under
-      // a different symbol, and optionFor takes the first match, so appending left the
-      // row wearing the name the operator just changed.
-      ...customOptions.filter((option) => option.unit !== built.unit),
-      {
-        unit: built.unit,
-        label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,
-        groupId: entry.groupId,
-        group: entry.groupName,
-        identifier: built.unit,
-        // Base units, like every other unit nothing describes. PATCH carries only unit
-        // and amount, so decimals typed here would be gone on the next open and the
-        // same balance would read back rescaled.
-        decimals: 0,
-        chain: entry.chain,
-      },
-    ]);
-    onChange([...rows, { unit: built.unit, amount: '', decimals: 0 }]);
+    // Typing an address the picker already lists is not an error, but the preset knows
+    // the asset better than the entry form does: it carries the real symbol and, more
+    // importantly, the real decimals. Taking those keeps the row out of base units and
+    // stops a stale custom name shadowing the preset after the row is removed and
+    // re-added from the picker.
+    const preset = options.find((option) => option.unit === built.unit);
+    const named = customOptions.filter((option) => option.unit !== built.unit);
+    onCustomOptionsChange(
+      preset !== undefined
+        ? named
+        : [
+            ...named,
+            {
+              unit: built.unit,
+              label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,
+              groupId: entry.groupId,
+              group: entry.groupName,
+              identifier: built.unit,
+              // Base units, like every other unit nothing describes. PATCH carries only
+              // unit and amount, so decimals typed here would be gone on the next open
+              // and the same balance would read back rescaled.
+              decimals: 0,
+              chain: entry.chain,
+            },
+          ],
+    );
+    onChange([...rows, { unit: built.unit, amount: '', decimals: preset?.decimals ?? 0 }]);
     setCustomEntry(null);
   }
 
   return (
     <div className="space-y-3">
-      {rows.length === 0 && (
-        <p className="text-xs text-muted-foreground">
-          No credit units on this key. A usage-limited key with no credits cannot pay for anything:
-          every purchase is rejected with &quot;Insufficient funds&quot;.
-        </p>
-      )}
-
       {rows.map((row, index) => {
         const option = optionFor(knownOptions, row.unit);
         const heading = option?.label ?? shortenCreditUnit(row.unit);

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -153,7 +153,12 @@ export function UsageCreditsField({
     // importantly, the real decimals. Taking those keeps the row out of base units and
     // stops a stale custom name shadowing the preset after the row is removed and
     // re-added from the picker.
-    const preset = options.find((option) => option.unit === built.unit);
+    // Chain 'unknown' means the option was recovered from the ledger, not configured on
+    // the node: its label is the elided unit id and its decimals are a fallback, so it
+    // knows nothing the entry form does not and must not override the typed symbol.
+    const preset = options.find(
+      (option) => option.unit === built.unit && option.chain.kind !== 'unknown',
+    );
     const named = customOptions.filter((option) => option.unit !== built.unit);
     onCustomOptionsChange(
       preset !== undefined

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -40,6 +40,12 @@ interface UsageCreditsFieldProps {
   disabled?: boolean;
   /** Message per row index, keyed the same way the form validates. */
   rowErrors?: Record<number, string | undefined>;
+  /**
+   * Names for units added in this session, held by the parent because this field is
+   * unmounted whenever the cap is switched off and would otherwise forget them.
+   */
+  customOptions: CreditUnitOption[];
+  onCustomOptionsChange: (options: CreditUnitOption[]) => void;
 }
 
 function optionFor(options: CreditUnitOption[], unit: string): CreditUnitOption | undefined {
@@ -95,12 +101,13 @@ export function UsageCreditsField({
   onChange,
   disabled = false,
   rowErrors,
+  customOptions,
+  onCustomOptionsChange,
 }: UsageCreditsFieldProps) {
   const [customEntry, setCustomEntry] = useState<CustomEntry | null>(null);
-  // Options for units added in this session. They are not in `options` (which is
-  // derived from the key's presets), so without them a just-added custom row falls
-  // back to 'unknown unit' and puts its own elided id where the symbol belongs.
-  const [customOptions, setCustomOptions] = useState<CreditUnitOption[]>([]);
+  // Custom units are not in `options` (which is derived from the key's presets), so
+  // without their names a just-added row falls back to 'unknown unit' and puts its own
+  // elided id where the symbol belongs.
   const knownOptions = useMemo(() => [...options, ...customOptions], [options, customOptions]);
 
   const groupedAvailable = useMemo(() => {
@@ -140,8 +147,8 @@ export function UsageCreditsField({
       setCustomEntry({ ...entry, error: 'That asset is already in the list' });
       return;
     }
-    setCustomOptions((previous) => [
-      ...previous,
+    onCustomOptionsChange([
+      ...customOptions,
       {
         unit: built.unit,
         label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -118,6 +118,13 @@ export function UsageCreditsField({
 
   const takenUnits = useMemo(() => new Set(rows.map((row) => row.unit)), [rows]);
 
+  // A key whose access list is empty still gets options for the units already on its
+  // ledger, and those cannot take a custom asset. Once they are all placed as rows the
+  // picker has nothing left to offer, so it is hidden rather than opened onto nothing.
+  const hasSomethingToAdd = groupedAvailable.some(
+    ([group, entries]) => entries.length > 0 || chainForGroup(options, group).kind !== 'unknown',
+  );
+
   function addCustomUnit(entry: CustomEntry) {
     const built = buildCustomCreditUnit(entry.chain, entry.value);
     if ('error' in built) {
@@ -216,57 +223,59 @@ export function UsageCreditsField({
           to fund yet.
         </p>
       ) : (
-        <Select
-          // Radix rejects an empty option value and ADA's unit IS the empty string, so
-          // the picker addresses options by index and maps back here.
-          value=""
-          disabled={disabled}
-          onValueChange={(value) => {
-            if (value.startsWith(CUSTOM_OPTION_PREFIX)) {
-              const group = value.slice(CUSTOM_OPTION_PREFIX.length);
-              setCustomEntry({
-                group,
-                chain: chainForGroup(options, group),
-                value: '',
-                symbol: '',
-                decimals: String(DEFAULT_CREDIT_DECIMALS),
-              });
-              return;
-            }
-            const option = options[Number(value)];
-            if (!option) return;
-            onChange([...rows, { unit: option.unit, amount: '', decimals: option.decimals }]);
-          }}
-        >
-          <SelectTrigger aria-label="Add a credit unit">
-            <SelectValue placeholder="Add a credit unit" />
-          </SelectTrigger>
-          <SelectContent>
-            {groupedAvailable.map(([group, entries]) => {
-              const chain = chainForGroup(options, group);
-              // 'Already on this key' collects units whose chain cannot be recovered
-              // from the stored string, so it can list what is there but cannot
-              // validate anything new typed into it.
-              const acceptsCustom = chain.kind !== 'unknown';
-              if (entries.length === 0 && !acceptsCustom) return null;
-              return (
-                <SelectGroup key={group}>
-                  <SelectLabel>{group}</SelectLabel>
-                  {entries.map(({ option, index }) => (
-                    <SelectItem key={option.unit || 'ada'} value={String(index)}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                  {acceptsCustom && (
-                    <SelectItem value={`${CUSTOM_OPTION_PREFIX}${group}`}>
-                      Custom asset&hellip;
-                    </SelectItem>
-                  )}
-                </SelectGroup>
-              );
-            })}
-          </SelectContent>
-        </Select>
+        hasSomethingToAdd && (
+          <Select
+            // Radix rejects an empty option value and ADA's unit IS the empty string, so
+            // the picker addresses options by index and maps back here.
+            value=""
+            disabled={disabled}
+            onValueChange={(value) => {
+              if (value.startsWith(CUSTOM_OPTION_PREFIX)) {
+                const group = value.slice(CUSTOM_OPTION_PREFIX.length);
+                setCustomEntry({
+                  group,
+                  chain: chainForGroup(options, group),
+                  value: '',
+                  symbol: '',
+                  decimals: String(DEFAULT_CREDIT_DECIMALS),
+                });
+                return;
+              }
+              const option = options[Number(value)];
+              if (!option) return;
+              onChange([...rows, { unit: option.unit, amount: '', decimals: option.decimals }]);
+            }}
+          >
+            <SelectTrigger aria-label="Add a credit unit">
+              <SelectValue placeholder="Add a credit unit" />
+            </SelectTrigger>
+            <SelectContent>
+              {groupedAvailable.map(([group, entries]) => {
+                const chain = chainForGroup(options, group);
+                // 'Already on this key' collects units whose chain cannot be recovered
+                // from the stored string, so it can list what is there but cannot
+                // validate anything new typed into it.
+                const acceptsCustom = chain.kind !== 'unknown';
+                if (entries.length === 0 && !acceptsCustom) return null;
+                return (
+                  <SelectGroup key={group}>
+                    <SelectLabel>{group}</SelectLabel>
+                    {entries.map(({ option, index }) => (
+                      <SelectItem key={option.unit || 'ada'} value={String(index)}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                    {acceptsCustom && (
+                      <SelectItem value={`${CUSTOM_OPTION_PREFIX}${group}`}>
+                        Custom asset&hellip;
+                      </SelectItem>
+                    )}
+                  </SelectGroup>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        )
       )}
 
       {customEntry && (

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -148,7 +148,10 @@ export function UsageCreditsField({
       return;
     }
     onCustomOptionsChange([
-      ...customOptions,
+      // Replace rather than append: the same unit can be removed and added again under
+      // a different symbol, and optionFor takes the first match, so appending left the
+      // row wearing the name the operator just changed.
+      ...customOptions.filter((option) => option.unit !== built.unit),
       {
         unit: built.unit,
         label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,

--- a/frontend/src/components/api-keys/UsageCreditsField.tsx
+++ b/frontend/src/components/api-keys/UsageCreditsField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,7 +15,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { convertBaseUnitsToDecimal } from '@/lib/convertDecimalToBaseUnits';
-import { shortenCreditUnit, type CreditUnitOption } from '@/lib/api-key-credit-units';
+import {
+  buildCustomCreditUnit,
+  DEFAULT_CREDIT_DECIMALS,
+  shortenCreditUnit,
+  type CreditChain,
+  type CreditUnitOption,
+} from '@/lib/api-key-credit-units';
 
 /** One editable balance. `amount` is a human decimal string, not base units. */
 export interface CreditRow {
@@ -41,21 +47,42 @@ function optionFor(options: CreditUnitOption[], unit: string): CreditUnitOption 
   return options.find((option) => option.unit === unit);
 }
 
+/** Fallback name for a custom asset whose symbol the operator left blank. */
+const UNNAMED_CUSTOM_SYMBOL = 'Custom';
+
 function currentBalanceLabel(
   current: Array<{ unit: string; amount: string }>,
   unit: string,
   decimals: number,
+  symbol: string,
 ): string {
   const stored = current.find((row) => row.unit === unit);
   if (!stored) return 'not funded yet';
   try {
-    return `currently ${convertBaseUnitsToDecimal(stored.amount, decimals)}`;
+    return `currently ${convertBaseUnitsToDecimal(stored.amount, decimals)} ${symbol}`;
   } catch {
     // A row the ledger holds in a shape this form cannot parse still has to be
     // visible; showing the raw value beats hiding the balance entirely.
     return `currently ${stored.amount} base units`;
   }
 }
+
+/** The chain a group's units settle on, read off any option already in that group. */
+function chainForGroup(options: CreditUnitOption[], group: string): CreditChain {
+  return options.find((option) => option.group === group)?.chain ?? { kind: 'unknown' };
+}
+
+interface CustomEntry {
+  group: string;
+  chain: CreditChain;
+  value: string;
+  symbol: string;
+  decimals: string;
+  error?: string;
+}
+
+/** Distinguishes the "add a custom asset" rows from the numeric option indices. */
+const CUSTOM_OPTION_PREFIX = 'custom:';
 
 export function UsageCreditsField({
   options,
@@ -65,6 +92,13 @@ export function UsageCreditsField({
   disabled = false,
   rowErrors,
 }: UsageCreditsFieldProps) {
+  const [customEntry, setCustomEntry] = useState<CustomEntry | null>(null);
+  // Options for units added in this session. They are not in `options` (which is
+  // derived from the key's presets), so without them a just-added custom row falls
+  // back to 'unknown unit' and puts its own elided id where the symbol belongs.
+  const [customOptions, setCustomOptions] = useState<CreditUnitOption[]>([]);
+  const knownOptions = useMemo(() => [...options, ...customOptions], [options, customOptions]);
+
   const groupedAvailable = useMemo(() => {
     const taken = new Set(rows.map((row) => row.unit));
     const groups = new Map<string, Array<{ option: CreditUnitOption; index: number }>>();
@@ -74,10 +108,45 @@ export function UsageCreditsField({
       bucket.push({ option, index });
       groups.set(option.group, bucket);
     });
+    // A group whose presets are all taken still needs a row, because the custom
+    // entry below lives inside it.
+    for (const option of options) {
+      if (!groups.has(option.group)) groups.set(option.group, []);
+    }
     return Array.from(groups.entries());
   }, [options, rows]);
 
-  const hasAvailable = groupedAvailable.some(([, entries]) => entries.length > 0);
+  const takenUnits = useMemo(() => new Set(rows.map((row) => row.unit)), [rows]);
+
+  function addCustomUnit(entry: CustomEntry) {
+    const built = buildCustomCreditUnit(entry.chain, entry.value);
+    if ('error' in built) {
+      setCustomEntry({ ...entry, error: built.error });
+      return;
+    }
+    if (takenUnits.has(built.unit)) {
+      setCustomEntry({ ...entry, error: 'That asset is already in the list' });
+      return;
+    }
+    const decimals = Number(entry.decimals);
+    if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+      setCustomEntry({ ...entry, error: 'Decimals must be a whole number from 0 to 30' });
+      return;
+    }
+    setCustomOptions((previous) => [
+      ...previous,
+      {
+        unit: built.unit,
+        label: entry.symbol.trim() || UNNAMED_CUSTOM_SYMBOL,
+        group: entry.group,
+        identifier: built.unit,
+        decimals,
+        chain: entry.chain,
+      },
+    ]);
+    onChange([...rows, { unit: built.unit, amount: '', decimals }]);
+    setCustomEntry(null);
+  }
 
   return (
     <div className="space-y-3">
@@ -89,32 +158,40 @@ export function UsageCreditsField({
       )}
 
       {rows.map((row, index) => {
-        const option = optionFor(options, row.unit);
+        const option = optionFor(knownOptions, row.unit);
+        const symbol = option?.label ?? shortenCreditUnit(row.unit);
         return (
           <div key={row.unit} className="flex items-end gap-2">
             <div className="min-w-0 flex-1 space-y-1.5">
               <Label htmlFor={`credit-${index}`} className="text-xs text-muted-foreground">
-                {option?.label ?? shortenCreditUnit(row.unit)}
+                <span className="font-medium text-foreground">{symbol}</span>
                 <span className="ml-1 opacity-70">
                   {option ? option.group : 'unknown unit'} ·{' '}
-                  {currentBalanceLabel(current, row.unit, row.decimals)}
+                  {currentBalanceLabel(current, row.unit, row.decimals, symbol)}
                 </span>
               </Label>
-              <Input
-                id={`credit-${index}`}
-                type="text"
-                inputMode="decimal"
-                disabled={disabled}
-                value={row.amount}
-                placeholder="0.00"
-                onChange={(event) => {
-                  const next = [...rows];
-                  next[index] = { ...row, amount: event.target.value };
-                  onChange(next);
-                }}
-              />
-              <p className="font-mono text-[0.6875rem] break-all text-muted-foreground">
-                {option?.identifier ?? row.unit}
+              {/* The symbol sits against the amount because the identifier line below
+                  used to be the only unit next to the number: an ADA row read as
+                  "250" over "lovelace", which is 250 ADA and 250_000_000 lovelace. */}
+              <div className="flex items-center gap-2">
+                <Input
+                  id={`credit-${index}`}
+                  type="text"
+                  inputMode="decimal"
+                  disabled={disabled}
+                  value={row.amount}
+                  placeholder="0.00"
+                  onChange={(event) => {
+                    const next = [...rows];
+                    next[index] = { ...row, amount: event.target.value };
+                    onChange(next);
+                  }}
+                />
+                <span className="shrink-0 text-sm font-medium">{symbol}</span>
+              </div>
+              <p className="text-[0.6875rem] break-all text-muted-foreground">
+                <span className="mr-1 uppercase opacity-70">unit id</span>
+                <span className="font-mono">{option?.identifier ?? row.unit}</span>
               </p>
               {rowErrors?.[index] && <p className="text-xs text-destructive">{rowErrors[index]}</p>}
             </div>
@@ -123,7 +200,7 @@ export function UsageCreditsField({
               variant="ghost"
               size="icon"
               title="Set this balance to zero"
-              aria-label={`Zero the ${option?.label ?? shortenCreditUnit(row.unit)} balance`}
+              aria-label={`Zero the ${symbol} balance`}
               disabled={disabled}
               onClick={() => onChange(rows.filter((_, position) => position !== index))}
             >
@@ -139,23 +216,40 @@ export function UsageCreditsField({
           to fund yet.
         </p>
       ) : (
-        hasAvailable && (
-          <Select
-            // Radix rejects an empty option value and ADA's unit IS the empty string, so
-            // the picker addresses options by index and maps back here.
-            value=""
-            disabled={disabled}
-            onValueChange={(value) => {
-              const option = options[Number(value)];
-              if (!option) return;
-              onChange([...rows, { unit: option.unit, amount: '', decimals: option.decimals }]);
-            }}
-          >
-            <SelectTrigger aria-label="Add a credit unit">
-              <SelectValue placeholder="Add a credit unit" />
-            </SelectTrigger>
-            <SelectContent>
-              {groupedAvailable.map(([group, entries]) => (
+        <Select
+          // Radix rejects an empty option value and ADA's unit IS the empty string, so
+          // the picker addresses options by index and maps back here.
+          value=""
+          disabled={disabled}
+          onValueChange={(value) => {
+            if (value.startsWith(CUSTOM_OPTION_PREFIX)) {
+              const group = value.slice(CUSTOM_OPTION_PREFIX.length);
+              setCustomEntry({
+                group,
+                chain: chainForGroup(options, group),
+                value: '',
+                symbol: '',
+                decimals: String(DEFAULT_CREDIT_DECIMALS),
+              });
+              return;
+            }
+            const option = options[Number(value)];
+            if (!option) return;
+            onChange([...rows, { unit: option.unit, amount: '', decimals: option.decimals }]);
+          }}
+        >
+          <SelectTrigger aria-label="Add a credit unit">
+            <SelectValue placeholder="Add a credit unit" />
+          </SelectTrigger>
+          <SelectContent>
+            {groupedAvailable.map(([group, entries]) => {
+              const chain = chainForGroup(options, group);
+              // 'Already on this key' collects units whose chain cannot be recovered
+              // from the stored string, so it can list what is there but cannot
+              // validate anything new typed into it.
+              const acceptsCustom = chain.kind !== 'unknown';
+              if (entries.length === 0 && !acceptsCustom) return null;
+              return (
                 <SelectGroup key={group}>
                   <SelectLabel>{group}</SelectLabel>
                   {entries.map(({ option, index }) => (
@@ -163,11 +257,91 @@ export function UsageCreditsField({
                       {option.label}
                     </SelectItem>
                   ))}
+                  {acceptsCustom && (
+                    <SelectItem value={`${CUSTOM_OPTION_PREFIX}${group}`}>
+                      Custom asset&hellip;
+                    </SelectItem>
+                  )}
                 </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
-        )
+              );
+            })}
+          </SelectContent>
+        </Select>
+      )}
+
+      {customEntry && (
+        <div className="space-y-2 rounded-lg border p-3">
+          <p className="text-sm font-medium">Custom asset on {customEntry.group}</p>
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-credit-unit" className="text-xs text-muted-foreground">
+              {customEntry.chain.kind === 'evm'
+                ? 'Token contract address'
+                : 'Policy id + asset name, as hex'}
+            </Label>
+            <Input
+              id="custom-credit-unit"
+              value={customEntry.value}
+              autoComplete="off"
+              spellCheck={false}
+              className="font-mono"
+              placeholder={
+                customEntry.chain.kind === 'evm' ? '0x…' : '56 hex characters, then the asset name'
+              }
+              onChange={(event) =>
+                setCustomEntry({ ...customEntry, value: event.target.value, error: undefined })
+              }
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-credit-symbol" className="text-xs text-muted-foreground">
+              Symbol
+            </Label>
+            <Input
+              id="custom-credit-symbol"
+              value={customEntry.symbol}
+              autoComplete="off"
+              placeholder={UNNAMED_CUSTOM_SYMBOL}
+              onChange={(event) => setCustomEntry({ ...customEntry, symbol: event.target.value })}
+            />
+            <p className="text-xs text-muted-foreground">
+              Shown next to the amount, so the balance reads as an asset and not as a raw id.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-credit-decimals" className="text-xs text-muted-foreground">
+              Decimals
+            </Label>
+            <Input
+              id="custom-credit-decimals"
+              type="text"
+              inputMode="numeric"
+              value={customEntry.decimals}
+              onChange={(event) =>
+                setCustomEntry({ ...customEntry, decimals: event.target.value, error: undefined })
+              }
+            />
+            {/* Decimals only scale what this form shows and sends; getting them wrong
+                funds the key by a factor of ten, so they are asked for rather than
+                assumed for an asset the presets do not describe. */}
+            <p className="text-xs text-muted-foreground">
+              How many decimal places the asset uses. Most stablecoins use 6.
+            </p>
+          </div>
+          {customEntry.error && <p className="text-xs text-destructive">{customEntry.error}</p>}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={disabled}
+              onClick={() => addCustomUnit(customEntry)}
+            >
+              Add asset
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={() => setCustomEntry(null)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/api-keys/X402WalletScopeField.tsx
+++ b/frontend/src/components/api-keys/X402WalletScopeField.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useX402Wallets } from '@/lib/hooks/useX402';
 import { shortenAddress } from '@/lib/utils';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 interface X402WalletScopeFieldProps {
   /** Whether this key is restricted to the selected managed EVM wallets. */
@@ -41,13 +42,11 @@ export function X402WalletScopeField({
           <Checkbox
             aria-label="Restrict to specific EVM wallets"
             checked={enabled}
-            onCheckedChange={(checked) => {
-              const next = checked === true;
-              onEnabledChange(next);
-              if (!next) {
-                onSelectedIdsChange([]);
-              }
-            }}
+            // The selection survives an untick. Clearing it here made
+            // untick-then-retick, a net-zero action on screen, save the scope
+            // with an empty list, which reaches no wallet at all. Both dialogs
+            // already send [] while the box is off.
+            onCheckedChange={(checked) => onEnabledChange(checked === true)}
           />
           <label className="text-sm font-medium">Restrict to specific EVM wallets</label>
         </div>
@@ -102,10 +101,15 @@ export function X402WalletScopeField({
               ))
             )}
           </div>
-          {selectedIds.length > 0 && (
+          {selectedIds.length > 0 ? (
             <p className="text-xs text-muted-foreground">
               {selectedIds.length} wallet{selectedIds.length !== 1 ? 's' : ''} selected
             </p>
+          ) : (
+            // In the field, not the dialogs: both of them render this picker, and
+            // the state it names is one neither could see, because the count line
+            // hid itself at zero.
+            <p className="text-xs text-destructive">{walletScopeProblem(true, selectedIds)}</p>
           )}
         </div>
       )}

--- a/frontend/src/components/api-keys/update-api-key-form.test.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.test.ts
@@ -78,3 +78,50 @@ test('an unlimited key skips credit validation and sends no deltas', () => {
   assert.equal(result.success, true);
   assert.deepEqual(usageCreditDeltas(false, current, invalidRows), []);
 });
+
+test('an enabled wallet restriction with nothing selected fails validation', () => {
+  // The deny-all state. The middleware reads an enabled flag with no rows as `[]`,
+  // and only `null` means unrestricted, so the key reaches no wallet at all.
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error?.issues[0]?.message ?? '', /at least one wallet/);
+  assert.deepEqual(result.error?.issues[0]?.path, ['walletScopeIds']);
+});
+
+test('an enabled x402 wallet restriction with nothing selected fails validation', () => {
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    x402WalletScopeEnabled: true,
+    x402WalletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error?.issues[0]?.path, ['x402WalletScopeIds']);
+});
+
+test('the wallet restriction is checked on an unlimited key too', () => {
+  // The rule sits above the `!usageLimited` early return on purpose. Below it, an
+  // uncapped key could still be saved reaching no wallet, which is the whole bug.
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+});
+
+test('a wallet restriction that names a wallet passes', () => {
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: ['wallet-1'],
+  });
+
+  assert.equal(result.success, true);
+});

--- a/frontend/src/components/api-keys/update-api-key-form.test.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildUpdateApiKeySchema,
+  MAX_USAGE_CREDIT_DELTAS,
+  usageCreditDeltas,
+  type UpdateApiKeyFormValues,
+} from './update-api-key-form';
+
+const BASE_VALUES: Omit<UpdateApiKeyFormValues, 'usageLimited' | 'credits'> = {
+  newToken: '',
+  status: 'Active',
+  walletScopeEnabled: false,
+  walletScopeIds: [],
+  x402WalletScopeEnabled: false,
+  x402WalletScopeIds: [],
+  evmChains: [],
+};
+
+function values(
+  usageLimited: boolean,
+  credits: UpdateApiKeyFormValues['credits'],
+): UpdateApiKeyFormValues {
+  return { ...BASE_VALUES, usageLimited, credits };
+}
+
+function rows(count: number, amount: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    unit: `unit-${index}`,
+    amount,
+    decimals: 0,
+  }));
+}
+
+test('a usage-limited key may remove its final credit balance', () => {
+  const current = [{ unit: '', amount: '1000000' }];
+  const result = buildUpdateApiKeySchema(current).safeParse(values(true, []));
+
+  assert.equal(result.success, true);
+  assert.deepEqual(usageCreditDeltas(true, current, []), [{ unit: '', amount: '-1000000' }]);
+});
+
+test('exactly 25 changed balances pass local validation', () => {
+  const current = rows(MAX_USAGE_CREDIT_DELTAS, '1');
+  const result = buildUpdateApiKeySchema(current).safeParse(
+    values(true, rows(MAX_USAGE_CREDIT_DELTAS, '2')),
+  );
+
+  assert.equal(result.success, true);
+});
+
+test('more than 25 changed balances fail local validation', () => {
+  const current = rows(MAX_USAGE_CREDIT_DELTAS + 1, '1');
+  const result = buildUpdateApiKeySchema(current).safeParse(
+    values(true, rows(MAX_USAGE_CREDIT_DELTAS + 1, '2')),
+  );
+
+  assert.equal(result.success, false);
+  if (result.success) return;
+  assert.deepEqual(result.error.issues[0]?.path, ['credits', 'root']);
+  assert.match(result.error.issues[0]?.message ?? '', /at most 25 balances/);
+});
+
+test('unchanged ledgers with more than 25 rows remain editable', () => {
+  const current = rows(MAX_USAGE_CREDIT_DELTAS + 1, '1');
+  const result = buildUpdateApiKeySchema(current).safeParse(
+    values(true, rows(MAX_USAGE_CREDIT_DELTAS + 1, '1')),
+  );
+
+  assert.equal(result.success, true);
+});
+
+test('an unlimited key skips credit validation and sends no deltas', () => {
+  const current = rows(MAX_USAGE_CREDIT_DELTAS + 1, '1');
+  const invalidRows = rows(MAX_USAGE_CREDIT_DELTAS + 1, '');
+  const result = buildUpdateApiKeySchema(current).safeParse(values(false, invalidRows));
+
+  assert.equal(result.success, true);
+  assert.deepEqual(usageCreditDeltas(false, current, invalidRows), []);
+});

--- a/frontend/src/components/api-keys/update-api-key-form.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { convertDecimalToBaseUnits } from '@/lib/convertDecimalToBaseUnits';
+import { creditDeltas, creditRowProblem } from '@/lib/api-key-credit-units';
+
+/** Mirrors updateAPIKeySchemaInput.UsageCreditsToAddOrRemove.max(25). */
+export const MAX_USAGE_CREDIT_DELTAS = 25;
+
+type StoredCredit = { unit: string; amount: string };
+type EditableCredit = { unit: string; amount: string; decimals: number };
+
+export function usageCreditDeltas(
+  usageLimited: boolean,
+  current: StoredCredit[],
+  next: EditableCredit[],
+): Array<{ unit: string; amount: string }> {
+  if (!usageLimited) return [];
+  return creditDeltas(
+    current,
+    next.map((credit) => ({
+      unit: credit.unit,
+      amount: convertDecimalToBaseUnits(credit.amount, credit.decimals),
+    })),
+  );
+}
+
+/** Build validation from the balances this key currently stores. */
+export function buildUpdateApiKeySchema(currentCredits: StoredCredit[]) {
+  const fundedUnits = new Set(currentCredits.map((credit) => credit.unit));
+
+  return z
+    .object({
+      newToken: z
+        .string()
+        .min(15, 'Token must be at least 15 characters')
+        .optional()
+        .or(z.literal('')),
+      status: z.enum(['Active', 'Revoked']),
+      usageLimited: z.boolean(),
+      credits: z.array(z.object({ unit: z.string(), amount: z.string(), decimals: z.number() })),
+      walletScopeEnabled: z.boolean(),
+      walletScopeIds: z.array(z.string()),
+      x402WalletScopeEnabled: z.boolean(),
+      x402WalletScopeIds: z.array(z.string()),
+      evmChains: z.array(z.string()),
+    })
+    .superRefine((value, context) => {
+      // An unlimited key ignores stored credits and sends no credit deltas.
+      if (!value.usageLimited) return;
+
+      let hasInvalidCredit = false;
+      value.credits.forEach((credit, index) => {
+        const problem = creditRowProblem(credit, fundedUnits);
+        if (problem === undefined) return;
+        hasInvalidCredit = true;
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: problem,
+          path: ['credits', index, 'amount'],
+        });
+      });
+      if (hasInvalidCredit) return;
+
+      const deltas = usageCreditDeltas(true, currentCredits, value.credits);
+      if (deltas.length > MAX_USAGE_CREDIT_DELTAS) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Change at most ${MAX_USAGE_CREDIT_DELTAS} balances in one update.`,
+          path: ['credits', 'root'],
+        });
+      }
+    });
+}
+
+export type UpdateApiKeyFormValues = z.infer<ReturnType<typeof buildUpdateApiKeySchema>>;

--- a/frontend/src/components/api-keys/update-api-key-form.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { convertDecimalToBaseUnits } from '@/lib/convertDecimalToBaseUnits';
 import { creditDeltas, creditRowProblem } from '@/lib/api-key-credit-units';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 /** Mirrors updateAPIKeySchemaInput.UsageCreditsToAddOrRemove.max(25). */
 export const MAX_USAGE_CREDIT_DELTAS = 25;
@@ -44,6 +45,24 @@ export function buildUpdateApiKeySchema(currentCredits: StoredCredit[]) {
       evmChains: z.array(z.string()),
     })
     .superRefine((value, context) => {
+      // Wallet scope first: it is checked for every key, capped or not, so it has to
+      // sit above the uncapped early return below.
+      const walletScope = walletScopeProblem(value.walletScopeEnabled, value.walletScopeIds);
+      if (walletScope !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: walletScope,
+          path: ['walletScopeIds'],
+        });
+      }
+      const x402Scope = walletScopeProblem(value.x402WalletScopeEnabled, value.x402WalletScopeIds);
+      if (x402Scope !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: x402Scope,
+          path: ['x402WalletScopeIds'],
+        });
+      }
       // An unlimited key ignores stored credits and sends no credit deltas.
       if (!value.usageLimited) return;
 

--- a/frontend/src/components/api-keys/wallet-scope.helpers.test.ts
+++ b/frontend/src/components/api-keys/wallet-scope.helpers.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { walletScopeProblem } from './wallet-scope.helpers';
+
+test('walletScopeProblem refuses an enabled restriction with nothing selected', () => {
+  // The deny-all state. The middleware reads an enabled flag with no rows as
+  // `[]`, not `null`, and only `null` means unrestricted, so the key reaches no
+  // wallet at all. Reachable by unticking the box and ticking it again, which
+  // clears the list and leaves the checkbox exactly where it started.
+  assert.match(walletScopeProblem(true, []) ?? '', /at least one wallet/);
+});
+
+test('walletScopeProblem allows an enabled restriction that names a wallet', () => {
+  assert.equal(walletScopeProblem(true, ['wallet-1']), undefined);
+});
+
+test('walletScopeProblem allows a disabled restriction with an empty list', () => {
+  // Unrestricted is the ordinary state for a key that never scoped anything,
+  // and submit sends an empty list for it on purpose.
+  assert.equal(walletScopeProblem(false, []), undefined);
+});
+
+test('walletScopeProblem ignores a stale list while the restriction is off', () => {
+  // The dialogs keep the previous selection in form state while the box is
+  // unticked, so re-ticking restores it instead of silently saving a deny-all.
+  // That list must not make a disabled scope look like a problem.
+  assert.equal(walletScopeProblem(false, ['wallet-1']), undefined);
+});

--- a/frontend/src/components/api-keys/wallet-scope.helpers.ts
+++ b/frontend/src/components/api-keys/wallet-scope.helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * Why a wallet scope cannot be saved, or undefined when it can.
+ *
+ * "Restrict to specific wallets" with nothing selected is not a narrow scope,
+ * it is a deny-all. The middleware maps an enabled flag with no rows to `[]`
+ * rather than `null`, and `null` is the value that means unrestricted, so
+ * `buildHotWalletScopeFilter` turns it into `{ id: { in: [] } }`: a filter no
+ * wallet matches. The key then reaches none of them, which is a state no
+ * operator picks on purpose and nothing on screen names.
+ *
+ * Shared by the create and update dialogs, and by both scopes, so the rule and
+ * its wording cannot drift between the four places that need it.
+ */
+export function walletScopeProblem(
+  enabled: boolean,
+  selectedIds: readonly string[],
+): string | undefined {
+  if (enabled && selectedIds.length === 0) {
+    return 'Select at least one wallet, or turn the restriction off. An empty restriction blocks every wallet.';
+  }
+  return undefined;
+}

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -388,3 +388,22 @@ test('creditRowProblem rejects negatives and exponent notation', () => {
     );
   }
 });
+
+test('creditRowProblem refuses a balance past what int8 can hold', () => {
+  // UnitValue.amount is a Prisma BigInt. Unbounded, the request is valid, Postgres
+  // raises 22003 on write, and the operator gets a generic failure with every other
+  // field of the same PATCH rolled back.
+  assert.match(
+    creditRowProblem({ unit: '', amount: '10000000000000', decimals: 6 }, NO_FUNDED_UNITS) ?? '',
+    /at most 9223372036854775807 base units/,
+  );
+});
+
+test('creditRowProblem allows the largest balance int8 can hold', () => {
+  // The bound is inclusive: 9223372036854775807 base units is storable, and rejecting
+  // it would refuse a value the ledger accepts.
+  assert.equal(
+    creditRowProblem({ unit: '', amount: '9223372036854775807', decimals: 0 }, NO_FUNDED_UNITS),
+    undefined,
+  );
+});

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -265,3 +265,62 @@ test('buildCustomCreditUnit rejects an empty entry and an unknown chain', () => 
   assert.ok('error' in buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, '   '));
   assert.ok('error' in buildCustomCreditUnit({ kind: 'unknown' }, 'a'.repeat(56)));
 });
+
+test('buildCustomCreditUnit refuses uppercase Cardano hex and says why', () => {
+  // The credit gate keys a Map by the stored string and looks up the requested unit
+  // byte for byte (credit-init-transaction.ts). Cardano tooling emits lowercase hex,
+  // so an uppercase row matches nothing and every purchase in that asset fails with
+  // `Credit unit not found` while the dialog shows the balance as funded.
+  const result = buildCustomCreditUnit(
+    { kind: 'cardano', network: 'Mainnet' },
+    USDM_MAINNET.toUpperCase(),
+  );
+  assert.ok('error' in result);
+  assert.match(result.error, /lowercase/);
+});
+
+test('a unit read back off the ledger is edited in base units', () => {
+  // Nothing records the decimals of an asset no preset describes, and PATCH carries
+  // only unit and amount, so an assumed 6dp cannot survive a reopen: the same stored
+  // balance would read back rescaled by a million.
+  const options = creditUnitOptionsForKey({
+    networkLimit: [],
+    chainIdLimit: [],
+    evmNetworks: [],
+    existingUnits: ['aabbcc'],
+  });
+  const recovered = options.find((option) => option.unit === 'aabbcc');
+  assert.ok(recovered);
+  assert.equal(recovered.decimals, 0);
+  assert.equal(recovered.chain.kind, 'unknown');
+});
+
+test('two chains sharing a display name stay separate groups', () => {
+  // X402Network.caip2Id is unique; displayName is free text and is not. Grouping by
+  // the name merged both chains into one picker group with a single custom-asset
+  // entry, which then qualified the asset for whichever chain came first.
+  const options = creditUnitOptionsForKey({
+    networkLimit: [],
+    chainIdLimit: ['eip155:8453', 'eip155:84532'],
+    evmNetworks: [
+      { ...BASE_MAINNET, displayName: 'Base' },
+      { ...BASE_MAINNET, caip2Id: 'eip155:84532', displayName: 'Base' },
+    ],
+  });
+  const groupIds = new Set(options.map((option) => option.groupId));
+  assert.deepEqual([...groupIds].sort(), ['eip155:8453', 'eip155:84532']);
+  assert.deepEqual(new Set(options.map((option) => option.group)), new Set(['Base']));
+});
+
+test('Cardano and EVM group ids never collide', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet', 'Preprod'],
+    chainIdLimit: ['eip155:8453'],
+    evmNetworks: [BASE_MAINNET],
+  });
+  assert.deepEqual([...new Set(options.map((option) => option.groupId))].sort(), [
+    'cardano:mainnet',
+    'cardano:preprod',
+    'eip155:8453',
+  ]);
+});

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -5,6 +5,7 @@ import {
   buildCustomCreditUnit,
   consolidateCreditRows,
   creditDeltas,
+  creditRowProblem,
   creditUnitOptionsForKey,
   shortenCreditUnit,
   type CreditUnitOption,
@@ -325,4 +326,65 @@ test('Cardano and EVM group ids never collide', () => {
     'cardano:preprod',
     'eip155:8453',
   ]);
+});
+
+const NO_FUNDED_UNITS = new Set<string>();
+
+test('creditRowProblem refuses a new unit at zero, whatever shape the zero takes', () => {
+  // creditDeltas drops a zero delta and the request omits the field entirely, so the
+  // save reports success and creates nothing. For x402 that leaves a key its operator
+  // believes is capped spending against the wallet's whole balance.
+  for (const amount of ['0', '0.0', '0.00', '.0', '0.']) {
+    assert.match(
+      creditRowProblem({ unit: '', amount, decimals: 6 }, NO_FUNDED_UNITS) ?? '',
+      /above zero/,
+      amount,
+    );
+  }
+});
+
+test('creditRowProblem allows zeroing a unit the ledger already holds', () => {
+  // Zeroing an existing row is a real delta and the server keeps the row, which is the
+  // record that the key is capped on that unit.
+  assert.equal(creditRowProblem({ unit: '', amount: '0', decimals: 6 }, new Set([''])), undefined);
+});
+
+test('creditRowProblem rejects a blank amount rather than treating it as zero', () => {
+  assert.match(
+    creditRowProblem({ unit: '', amount: '   ', decimals: 6 }, NO_FUNDED_UNITS) ?? '',
+    /Enter a balance/,
+  );
+});
+
+test('creditRowProblem names base units when the row has no decimals', () => {
+  assert.match(
+    creditRowProblem({ unit: 'zz', amount: '1.5', decimals: 0 }, NO_FUNDED_UNITS) ?? '',
+    /whole number of base units/,
+  );
+  assert.equal(
+    creditRowProblem({ unit: 'zz', amount: '150', decimals: 0 }, NO_FUNDED_UNITS),
+    undefined,
+  );
+});
+
+test('creditRowProblem refuses an over-precise amount instead of truncating it', () => {
+  assert.match(
+    creditRowProblem({ unit: '', amount: '1.1234567', decimals: 6 }, NO_FUNDED_UNITS) ?? '',
+    /at most 6 decimals/,
+  );
+  assert.equal(
+    creditRowProblem({ unit: '', amount: '1.123456', decimals: 6 }, NO_FUNDED_UNITS),
+    undefined,
+  );
+});
+
+test('creditRowProblem rejects negatives and exponent notation', () => {
+  // A balance, not a delta. convertDecimalToBaseUnits would also throw on '1e5'.
+  for (const amount of ['-1', '1e5', 'abc']) {
+    assert.notEqual(
+      creditRowProblem({ unit: '', amount, decimals: 6 }, NO_FUNDED_UNITS),
+      undefined,
+      amount,
+    );
+  }
 });

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -7,6 +7,7 @@ import {
   creditDeltas,
   creditRowProblem,
   creditUnitOptionsForKey,
+  normalizeCreditUnit,
   shortenCreditUnit,
   type CreditUnitOption,
 } from './api-key-credit-units';
@@ -405,5 +406,64 @@ test('creditRowProblem allows the largest balance int8 can hold', () => {
   assert.equal(
     creditRowProblem({ unit: '', amount: '9223372036854775807', decimals: 0 }, NO_FUNDED_UNITS),
     undefined,
+  );
+});
+
+test('normalizeCreditUnit folds lovelace onto the canonical ADA unit', () => {
+  // The server rewrites the unit it stores, so a 'lovelace' row is an ADA row that
+  // has not been touched since. Treating it as its own asset is what let the dialog
+  // offer an edit PATCH cannot express.
+  assert.equal(normalizeCreditUnit('lovelace'), ADA_CREDIT_UNIT);
+  assert.equal(normalizeCreditUnit('Lovelace'), ADA_CREDIT_UNIT);
+  assert.equal(normalizeCreditUnit(ADA_CREDIT_UNIT), ADA_CREDIT_UNIT);
+});
+
+test('normalizeCreditUnit lowercases a checksummed EVM unit', () => {
+  assert.equal(
+    normalizeCreditUnit('eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
+    'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  );
+});
+
+test('normalizeCreditUnit leaves a Cardano native asset verbatim', () => {
+  // Asset-name hex is case-significant and the credit gate matches it byte for byte,
+  // so lowercasing one here would group two genuinely different assets.
+  const unit = 'c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d';
+  assert.equal(normalizeCreditUnit(unit), unit);
+});
+
+test('consolidateCreditRows folds a legacy lovelace row into the ADA row', () => {
+  // The reported bug: two editable rows for one asset. Removing the 3 ADA row sent a
+  // delta the server normalized onto '' and took off the live balance instead.
+  assert.deepEqual(
+    consolidateCreditRows([
+      { unit: '', amount: '5000000' },
+      { unit: 'lovelace', amount: '3000000' },
+    ]),
+    [{ unit: '', amount: '8000000' }],
+  );
+});
+
+test('consolidateCreditRows folds EVM rows that differ only in address case', () => {
+  assert.deepEqual(
+    consolidateCreditRows([
+      { unit: 'eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', amount: '10' },
+      { unit: 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', amount: '5' },
+    ]),
+    [{ unit: 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', amount: '15' }],
+  );
+});
+
+test('consolidateCreditRows keeps distinct Cardano assets apart', () => {
+  const usdm = 'c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d';
+  assert.deepEqual(
+    consolidateCreditRows([
+      { unit: '', amount: '1' },
+      { unit: usdm, amount: '2' },
+    ]),
+    [
+      { unit: '', amount: '1' },
+      { unit: usdm, amount: '2' },
+    ],
   );
 });

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  ADA_CREDIT_UNIT,
+  consolidateCreditRows,
+  creditDeltas,
+  creditUnitOptionsForKey,
+  shortenCreditUnit,
+  type CreditUnitOption,
+} from './api-key-credit-units';
+
+const BASE_MAINNET = {
+  caip2Id: 'eip155:8453',
+  displayName: 'Base Mainnet',
+  defaultAsset: null,
+  defaultAssetDecimals: null,
+};
+
+const USDM_MAINNET = 'c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d';
+
+function units(options: CreditUnitOption[]): string[] {
+  return options.map((option) => option.unit);
+}
+
+test('ADA is offered as the empty unit, not lovelace', () => {
+  // The purchase path normalizes 'lovelace' to '' before the credit gate compares it,
+  // so a row stored as 'lovelace' can never match an ADA purchase.
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet'],
+    chainIdLimit: [],
+    evmNetworks: [],
+  });
+  const ada = options.find((option) => option.label === 'ADA');
+  assert.ok(ada);
+  assert.equal(ada.unit, ADA_CREDIT_UNIT);
+  assert.equal(ada.unit, '');
+});
+
+test('a Mainnet key can be funded in USDM, not only the active stablecoin', () => {
+  // getActiveStablecoinConfig('Mainnet') is USDCx, so the old two-field form could not
+  // fund a key for USDM at all, which is what the Cardano V1 agents actually charge.
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet'],
+    chainIdLimit: [],
+    evmNetworks: [],
+  });
+  assert.ok(units(options).includes(USDM_MAINNET));
+});
+
+test('EVM chains in the key limit contribute canonical lowercase units', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet'],
+    chainIdLimit: ['cardano:mainnet', 'eip155:8453'],
+    evmNetworks: [BASE_MAINNET],
+  });
+  const usdc = options.find((option) => option.unit.startsWith('eip155:8453:'));
+  assert.ok(usdc);
+  assert.equal(usdc.unit, 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
+  assert.equal(usdc.group, 'Base Mainnet');
+});
+
+test('an EVM chain the node does not know contributes nothing', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: [],
+    chainIdLimit: ['eip155:999999'],
+    evmNetworks: [BASE_MAINNET],
+  });
+  assert.deepEqual(options, []);
+});
+
+test('a chain configured with its own default asset wins over the preset', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: [],
+    chainIdLimit: ['eip155:8453'],
+    evmNetworks: [
+      {
+        ...BASE_MAINNET,
+        defaultAsset: '0xAAAABBBBCCCCDDDDEEEEFFFF0000111122223333',
+        defaultAssetDecimals: 18,
+      },
+    ],
+  });
+  const configured = options.find((option) => option.decimals === 18);
+  assert.ok(configured);
+  assert.equal(configured.unit, 'eip155:8453:0xaaaabbbbccccddddeeeeffff0000111122223333');
+});
+
+test('a unit already on the key stays visible even when unrecognised', () => {
+  // Otherwise a balance the operator has to see is simply absent from the form.
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Preprod'],
+    chainIdLimit: [],
+    evmNetworks: [],
+    existingUnits: ['deadbeef'.repeat(8)],
+  });
+  const stale = options.find((option) => option.group === 'Already on this key');
+  assert.ok(stale);
+  assert.equal(stale.unit, 'deadbeef'.repeat(8));
+});
+
+test('a stale lovelace row is surfaced next to the canonical ADA entry', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet'],
+    chainIdLimit: [],
+    evmNetworks: [],
+    existingUnits: ['lovelace'],
+  });
+  assert.ok(units(options).includes(''));
+  assert.ok(units(options).includes('lovelace'));
+});
+
+test('existing units are not duplicated when already offered', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet'],
+    chainIdLimit: [],
+    evmNetworks: [],
+    existingUnits: [USDM_MAINNET, ''],
+  });
+  assert.equal(units(options).filter((unit) => unit === USDM_MAINNET).length, 1);
+  assert.equal(units(options).filter((unit) => unit === '').length, 1);
+});
+
+test('creditDeltas sends only what changed', () => {
+  const deltas = creditDeltas(
+    [
+      { unit: '', amount: '1000000' },
+      { unit: USDM_MAINNET, amount: '5000000' },
+    ],
+    [
+      { unit: '', amount: '1000000' },
+      { unit: USDM_MAINNET, amount: '9000000' },
+    ],
+  );
+  assert.deepEqual(deltas, [{ unit: USDM_MAINNET, amount: '4000000' }]);
+});
+
+test('creditDeltas emits a negative delta when a balance is lowered', () => {
+  const deltas = creditDeltas([{ unit: '', amount: '3000000' }], [{ unit: '', amount: '1000000' }]);
+  assert.deepEqual(deltas, [{ unit: '', amount: '-2000000' }]);
+});
+
+test('creditDeltas zeroes a unit the operator removed', () => {
+  // Removing a row used to send nothing at all, so the stored balance survived and the
+  // form claimed a change it never made.
+  const deltas = creditDeltas(
+    [
+      { unit: '', amount: '3000000' },
+      { unit: USDM_MAINNET, amount: '5000000' },
+    ],
+    [{ unit: '', amount: '3000000' }],
+  );
+  assert.deepEqual(deltas, [{ unit: USDM_MAINNET, amount: '-5000000' }]);
+});
+
+test('creditDeltas leaves an already-zero removed unit alone', () => {
+  // A zero delta for an existing row is pointless, and the server keeps zeroed rows as
+  // the record that the key is capped on that unit.
+  const deltas = creditDeltas([{ unit: USDM_MAINNET, amount: '0' }], []);
+  assert.deepEqual(deltas, []);
+});
+
+test('creditDeltas ignores a unit added and removed before saving', () => {
+  const deltas = creditDeltas([], []);
+  assert.deepEqual(deltas, []);
+});
+
+test('creditDeltas treats a brand new unit as its full amount', () => {
+  const deltas = creditDeltas([], [{ unit: USDM_MAINNET, amount: '2500000' }]);
+  assert.deepEqual(deltas, [{ unit: USDM_MAINNET, amount: '2500000' }]);
+});
+
+test('shortenCreditUnit leaves short units alone', () => {
+  assert.equal(shortenCreditUnit('lovelace'), 'lovelace');
+  assert.equal(shortenCreditUnit(USDM_MAINNET).length < USDM_MAINNET.length, true);
+});
+
+test('consolidateCreditRows sums duplicate rows for one unit', () => {
+  // The node holds more than one row per unit in practice: its own purchase path
+  // collapses duplicates when it debits. Diffing against only one of them made the
+  // dialog compute a delta that moved the balance to the wrong total.
+  assert.deepEqual(
+    consolidateCreditRows([
+      { unit: '', amount: '100' },
+      { unit: 'eip155:8453:0xabc', amount: '5' },
+      { unit: '', amount: '50' },
+    ]),
+    [
+      { unit: '', amount: '150' },
+      { unit: 'eip155:8453:0xabc', amount: '5' },
+    ],
+  );
+});
+
+test('consolidateCreditRows leaves a single row per unit untouched', () => {
+  assert.deepEqual(consolidateCreditRows([{ unit: '', amount: '100' }]), [
+    { unit: '', amount: '100' },
+  ]);
+  assert.deepEqual(consolidateCreditRows([]), []);
+});

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   ADA_CREDIT_UNIT,
+  buildCustomCreditUnit,
   consolidateCreditRows,
   creditDeltas,
   creditUnitOptionsForKey,
@@ -196,4 +197,71 @@ test('consolidateCreditRows leaves a single row per unit untouched', () => {
     { unit: '', amount: '100' },
   ]);
   assert.deepEqual(consolidateCreditRows([]), []);
+});
+
+test('buildCustomCreditUnit chain-qualifies and lowercases a bare EVM address', () => {
+  // The x402 debit lowercases the asset address before it looks the row up, so a
+  // checksummed address — the form a wallet or explorer puts on the clipboard —
+  // would be stored verbatim and never match.
+  assert.deepEqual(
+    buildCustomCreditUnit(
+      { kind: 'evm', caip2Id: 'eip155:8453' },
+      '0x833589FCD6EDB6E08F4C7C32D4F71B54BDA02913',
+    ),
+    { unit: 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' },
+  );
+});
+
+test('buildCustomCreditUnit accepts an already-qualified unit for the same chain', () => {
+  assert.deepEqual(
+    buildCustomCreditUnit(
+      { kind: 'evm', caip2Id: 'eip155:8453' },
+      'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    ),
+    { unit: 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' },
+  );
+});
+
+test('buildCustomCreditUnit refuses a unit qualified for another chain', () => {
+  // Silently re-homing it would fund the key on a chain the operator did not pick.
+  const result = buildCustomCreditUnit(
+    { kind: 'evm', caip2Id: 'eip155:8453' },
+    'eip155:84532:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  );
+  assert.ok('error' in result);
+  assert.match(result.error, /another chain/);
+});
+
+test('buildCustomCreditUnit refuses a malformed EVM address', () => {
+  // findNonCanonicalEvmCreditUnit fails these closed on the server; catching them
+  // here keeps the dialog from posting a save that can only 400.
+  for (const bad of ['0x1234', 'native', '833589fcd6edb6e08f4c7c32d4f71b54bda02913']) {
+    const result = buildCustomCreditUnit({ kind: 'evm', caip2Id: 'eip155:8453' }, bad);
+    assert.ok('error' in result, bad);
+  }
+});
+
+test('buildCustomCreditUnit keeps Cardano asset-name hex case-significant', () => {
+  const unit = `${'a'.repeat(56)}44654144`;
+  assert.deepEqual(buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, unit), { unit });
+});
+
+test('buildCustomCreditUnit refuses a Cardano id that is not policy id + asset name hex', () => {
+  for (const bad of ['a'.repeat(55), `${'a'.repeat(56)}4`, 'not-hex-at-all']) {
+    const result = buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, bad);
+    assert.ok('error' in result, bad);
+  }
+});
+
+test('buildCustomCreditUnit points lovelace at the ADA option instead of storing it', () => {
+  // A row stored as 'lovelace' can never match an ADA purchase: the purchase path
+  // maps 'lovelace' to '' before the credit gate compares units.
+  const result = buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, 'lovelace');
+  assert.ok('error' in result);
+  assert.match(result.error, /ADA is already in this list/);
+});
+
+test('buildCustomCreditUnit rejects an empty entry and an unknown chain', () => {
+  assert.ok('error' in buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, '   '));
+  assert.ok('error' in buildCustomCreditUnit({ kind: 'unknown' }, 'a'.repeat(56)));
 });

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -6,6 +6,7 @@ import {
   consolidateCreditRows,
   creditDeltas,
   creditRowProblem,
+  creditUnitGroupsForKey,
   creditUnitOptionsForKey,
   normalizeCreditUnit,
   shortenCreditUnit,
@@ -69,6 +70,51 @@ test('an EVM chain the node does not know contributes nothing', () => {
     evmNetworks: [BASE_MAINNET],
   });
   assert.deepEqual(options, []);
+});
+
+test('a configured EVM chain without presets keeps a custom-asset group', () => {
+  const groups = creditUnitGroupsForKey({
+    networkLimit: [],
+    chainIdLimit: ['eip155:137'],
+    evmNetworks: [
+      {
+        caip2Id: 'eip155:137',
+        displayName: 'Polygon',
+        defaultAsset: null,
+        defaultAssetDecimals: null,
+      },
+    ],
+  });
+
+  assert.deepEqual(groups, [
+    {
+      groupId: 'eip155:137',
+      group: 'Polygon',
+      customChain: { kind: 'evm', caip2Id: 'eip155:137' },
+    },
+  ]);
+});
+
+test('an unconfigured EVM chain does not create a custom-asset group', () => {
+  const groups = creditUnitGroupsForKey({
+    networkLimit: [],
+    chainIdLimit: ['eip155:999999'],
+    evmNetworks: [BASE_MAINNET],
+  });
+
+  assert.deepEqual(groups, []);
+});
+
+test('ADA is offered once when both Cardano networks are allowed', () => {
+  const options = creditUnitOptionsForKey({
+    networkLimit: ['Mainnet', 'Preprod'],
+    chainIdLimit: [],
+    evmNetworks: [],
+  });
+  const ada = options.filter((option) => option.unit === ADA_CREDIT_UNIT);
+
+  assert.equal(ada.length, 1);
+  assert.equal(ada[0]?.group, 'Cardano Mainnet and Preprod');
 });
 
 test('a chain configured with its own default asset wins over the preset', () => {
@@ -323,6 +369,7 @@ test('Cardano and EVM group ids never collide', () => {
     evmNetworks: [BASE_MAINNET],
   });
   assert.deepEqual([...new Set(options.map((option) => option.groupId))].sort(), [
+    'cardano:all',
     'cardano:mainnet',
     'cardano:preprod',
     'eip155:8453',
@@ -333,8 +380,8 @@ const NO_FUNDED_UNITS = new Set<string>();
 
 test('creditRowProblem refuses a new unit at zero, whatever shape the zero takes', () => {
   // creditDeltas drops a zero delta and the request omits the field entirely, so the
-  // save reports success and creates nothing. For x402 that leaves a key its operator
-  // believes is capped spending against the wallet's whole balance.
+  // save reports success and creates nothing. The operator would see a unit that the
+  // ledger never stored, while matching payments remain blocked.
   for (const amount of ['0', '0.0', '0.00', '.0', '0.']) {
     assert.match(
       creditRowProblem({ unit: '', amount, decimals: 6 }, NO_FUNDED_UNITS) ?? '',

--- a/frontend/src/lib/api-key-credit-units.test.ts
+++ b/frontend/src/lib/api-key-credit-units.test.ts
@@ -241,7 +241,9 @@ test('buildCustomCreditUnit refuses a malformed EVM address', () => {
   }
 });
 
-test('buildCustomCreditUnit keeps Cardano asset-name hex case-significant', () => {
+test('buildCustomCreditUnit stores a lowercase Cardano unit verbatim', () => {
+  // Stored exactly as written: the server normalizes only EVM-shaped units, so this
+  // string is what the credit gate will look up.
   const unit = `${'a'.repeat(56)}44654144`;
   assert.deepEqual(buildCustomCreditUnit({ kind: 'cardano', network: 'Mainnet' }, unit), { unit });
 });

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -162,6 +162,28 @@ export function creditUnitOptionsForKey({
   return options;
 }
 
+/** The chain-qualified EVM credit unit the debit path stores, always lowercase. */
+const EVM_CREDIT_UNIT = /^eip155:\d+:0x[0-9a-fA-F]{40}$/;
+
+/**
+ * The unit a stored row is really about, matching `normalizeCreditUnit` on the server
+ * (src/routes/api/api-key/credit-units.ts).
+ *
+ * The dialog has to group rows the way PATCH resolves them, or the two disagree about
+ * what a row IS. 'lovelace' and '' are one asset to the server, and it rewrites the
+ * unit it stores, so showing them as two rows offered an edit the API cannot express:
+ * a delta for either one is normalized to '' and applied to the ADA balance. Removing
+ * the legacy row then drained the live one. EVM units differ only in address case for
+ * the same reason.
+ *
+ * Cardano native assets are NOT touched: asset-name hex is case-significant there and
+ * the credit gate matches it byte for byte.
+ */
+export function normalizeCreditUnit(unit: string): string {
+  if (unit.toLowerCase() === 'lovelace') return ADA_CREDIT_UNIT;
+  return EVM_CREDIT_UNIT.test(unit) ? unit.toLowerCase() : unit;
+}
+
 /**
  * Sum the ledger's rows per unit.
  *
@@ -171,13 +193,18 @@ export function creditUnitOptionsForKey({
  * one unit would otherwise become two editable fields sharing a React key, two deltas
  * both diffed against a single row's balance, and a "currently" hint that reads only
  * one of them.
+ *
+ * Grouped on the NORMALIZED unit, because that is what PATCH folds a delta onto. A
+ * legacy 'lovelace' row grouped on its own read as a second asset the operator could
+ * edit or remove separately, and neither edit meant what it looked like.
  */
 export function consolidateCreditRows(
   rows: Array<{ unit: string; amount: string }>,
 ): Array<{ unit: string; amount: string }> {
   const totals = new Map<string, bigint>();
   for (const row of rows) {
-    totals.set(row.unit, (totals.get(row.unit) ?? BigInt(0)) + BigInt(row.amount));
+    const unit = normalizeCreditUnit(row.unit);
+    totals.set(unit, (totals.get(unit) ?? BigInt(0)) + BigInt(row.amount));
   }
   return Array.from(totals, ([unit, amount]) => ({ unit, amount: amount.toString() }));
 }

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -22,6 +22,9 @@ export const DEFAULT_CREDIT_DECIMALS = 6;
 
 export type CardanoNetwork = 'Mainnet' | 'Preprod';
 
+/** Group for units read back off a key's ledger that no preset describes. */
+export const UNKNOWN_GROUP_ID = 'unknown';
+
 /**
  * The chain a group of units settles on, carried so a custom asset typed into that
  * group can be validated and chain-qualified without the field guessing from the
@@ -38,6 +41,13 @@ export interface CreditUnitOption {
   unit: string;
   /** Short name for the amount field, e.g. 'ADA' or 'USDC'. */
   label: string;
+  /**
+   * Stable key for the unit's chain. NOT the display name: X402Network.displayName is
+   * free text and only caip2Id is unique, so two chains named "Base" would otherwise
+   * merge into one picker group and one custom-asset entry, which would then qualify
+   * the asset for whichever chain happened to be first.
+   */
+  groupId: string;
   /** Where the unit spends, e.g. 'Cardano Mainnet' or 'Base Mainnet'. */
   group: string;
   /** Full identifier, shown under the label so two same-symbol assets stay distinguishable. */
@@ -48,12 +58,14 @@ export interface CreditUnitOption {
 
 function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
   const group = `Cardano ${network}`;
+  const groupId = `cardano:${network.toLowerCase()}`;
   const chain: CreditChain = { kind: 'cardano', network };
   const usdm = getUsdmConfig(network);
   const options: CreditUnitOption[] = [
     {
       unit: ADA_CREDIT_UNIT,
       label: 'ADA',
+      groupId,
       group,
       identifier: 'lovelace',
       decimals: DEFAULT_CREDIT_DECIMALS,
@@ -62,6 +74,7 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
     {
       unit: usdm.fullAssetId,
       label: network === 'Mainnet' ? 'USDM' : 'tUSDM',
+      groupId,
       group,
       identifier: usdm.fullAssetId,
       decimals: DEFAULT_CREDIT_DECIMALS,
@@ -72,6 +85,7 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
     options.push({
       unit: USDCX_CONFIG.fullAssetId,
       label: getActiveStablecoinSymbol(network),
+      groupId,
       group,
       identifier: USDCX_CONFIG.fullAssetId,
       decimals: DEFAULT_CREDIT_DECIMALS,
@@ -89,6 +103,7 @@ function evmOptions(caip2Id: string, networks: AssetPresetNetwork[]): CreditUnit
     // shape outright (findNonCanonicalEvmCreditUnit), so build the canonical form here.
     unit: `${caip2Id}:${preset.address.toLowerCase()}`,
     label: preset.symbol,
+    groupId: caip2Id,
     group: network.displayName,
     identifier: `${caip2Id}:${preset.address.toLowerCase()}`,
     decimals: preset.decimals,
@@ -132,9 +147,13 @@ export function creditUnitOptionsForKey({
     options.push({
       unit,
       label: unit === ADA_CREDIT_UNIT ? 'ADA' : shortenCreditUnit(unit),
+      groupId: UNKNOWN_GROUP_ID,
       group: 'Already on this key',
       identifier: unit === ADA_CREDIT_UNIT ? 'lovelace' : unit,
-      decimals: DEFAULT_CREDIT_DECIMALS,
+      // Nothing here says how many decimals this asset uses, and PATCH carries only
+      // unit and amount, so a decimals guess cannot survive a reopen either. Base
+      // units round-trip exactly instead.
+      decimals: 0,
       chain: { kind: 'unknown' },
     });
   }
@@ -165,7 +184,7 @@ export function consolidateCreditRows(
  * A Cardano native asset unit: a 28-byte policy id followed by an asset name of up
  * to 32 bytes, both hex, concatenated exactly as the ledger stores them.
  */
-const CARDANO_ASSET_UNIT = /^[0-9a-fA-F]{56}(?:[0-9a-fA-F]{2}){0,32}$/;
+const CARDANO_ASSET_UNIT = /^[0-9a-f]{56}(?:[0-9a-f]{2}){0,32}$/;
 
 /** A bare ERC-20 contract address, before it is chain-qualified. */
 const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
@@ -215,11 +234,16 @@ export function buildCustomCreditUnit(
       return { error: `An asset id is at most ${MAX_CREDIT_UNIT_LENGTH} characters` };
     }
     if (!CARDANO_ASSET_UNIT.test(value)) {
+      if (CARDANO_ASSET_UNIT.test(value.toLowerCase())) {
+        return { error: 'Use lowercase hex. The node matches this id exactly, byte for byte.' };
+      }
       return {
-        error: 'Enter policy id + asset name as hex: 56 characters, then the name in pairs',
+        error:
+          'Enter policy id + asset name as lowercase hex: 56 characters, then the name in pairs',
       };
     }
-    // Asset-name hex is case-significant on Cardano, so this is stored verbatim.
+    // Stored verbatim: the server normalizes only EVM-shaped units, and the credit gate
+    // looks this string up exactly as written.
     return { unit: value };
   }
 

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -4,6 +4,7 @@ import {
   getActiveStablecoinSymbol,
 } from '@/lib/constants/defaultWallets';
 import { assetPresetsForNetwork, type AssetPresetNetwork } from '@/lib/x402-registration';
+import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
 
 /**
  * The unit an ADA credit row must carry.
@@ -285,4 +286,38 @@ export function creditDeltas(
     deltas.push({ unit, amount: (-amount).toString() });
   }
   return deltas;
+}
+
+/**
+ * Why an edited balance cannot be saved, or undefined when it can.
+ *
+ * Pulled out of the dialog's resolver so the rules are testable on their own: each one
+ * exists because breaking it produces a key that looks funded and pays nothing, and
+ * that is not a state a form should be able to reach quietly.
+ *
+ * `fundedUnits` is the set of units the ledger already holds a row for.
+ */
+export function creditRowProblem(
+  row: { unit: string; amount: string; decimals: number },
+  fundedUnits: ReadonlySet<string>,
+): string | undefined {
+  if (row.amount.trim() === '') {
+    return 'Enter a balance, or remove this unit';
+  }
+  // Balances, not deltas: a negative balance is meaningless and the server rejects it
+  // anyway. Precision is checked against the unit's own decimals so an over-precise
+  // entry is refused instead of silently truncated on convert.
+  if (!isValidDecimalAmount(row.amount, { decimals: row.decimals })) {
+    return row.decimals === 0
+      ? 'Enter a whole number of base units'
+      : `Enter a positive amount with at most ${row.decimals} decimals`;
+  }
+  // A zero balance for a unit the ledger has no row for sends no delta at all
+  // (creditDeltas skips it) and the server refuses to create one (400 'Invalid
+  // amount'). The save would report success and leave the unit uncapped, which for
+  // x402 means the key keeps spending with no ceiling.
+  if (!fundedUnits.has(row.unit) && convertDecimalToBaseUnits(row.amount, row.decimals) === '0') {
+    return 'Enter an amount above zero. The node cannot store a new unit at zero.';
+  }
+  return undefined;
 }

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -22,6 +22,17 @@ export const DEFAULT_CREDIT_DECIMALS = 6;
 
 export type CardanoNetwork = 'Mainnet' | 'Preprod';
 
+/**
+ * The chain a group of units settles on, carried so a custom asset typed into that
+ * group can be validated and chain-qualified without the field guessing from the
+ * group's display name. 'unknown' marks units recovered from the key's own ledger:
+ * a stored string alone does not say which chain issued it.
+ */
+export type CreditChain =
+  | { kind: 'cardano'; network: CardanoNetwork }
+  | { kind: 'evm'; caip2Id: string }
+  | { kind: 'unknown' };
+
 export interface CreditUnitOption {
   /** Exact string written to `UsageCreditsToAddOrRemove[].unit`. */
   unit: string;
@@ -32,10 +43,12 @@ export interface CreditUnitOption {
   /** Full identifier, shown under the label so two same-symbol assets stay distinguishable. */
   identifier: string;
   decimals: number;
+  chain: CreditChain;
 }
 
 function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
   const group = `Cardano ${network}`;
+  const chain: CreditChain = { kind: 'cardano', network };
   const usdm = getUsdmConfig(network);
   const options: CreditUnitOption[] = [
     {
@@ -44,6 +57,7 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
       group,
       identifier: 'lovelace',
       decimals: DEFAULT_CREDIT_DECIMALS,
+      chain,
     },
     {
       unit: usdm.fullAssetId,
@@ -51,6 +65,7 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
       group,
       identifier: usdm.fullAssetId,
       decimals: DEFAULT_CREDIT_DECIMALS,
+      chain,
     },
   ];
   if (network === 'Mainnet') {
@@ -60,6 +75,7 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
       group,
       identifier: USDCX_CONFIG.fullAssetId,
       decimals: DEFAULT_CREDIT_DECIMALS,
+      chain,
     });
   }
   return options;
@@ -76,6 +92,7 @@ function evmOptions(caip2Id: string, networks: AssetPresetNetwork[]): CreditUnit
     group: network.displayName,
     identifier: `${caip2Id}:${preset.address.toLowerCase()}`,
     decimals: preset.decimals,
+    chain: { kind: 'evm', caip2Id },
   }));
 }
 
@@ -118,6 +135,7 @@ export function creditUnitOptionsForKey({
       group: 'Already on this key',
       identifier: unit === ADA_CREDIT_UNIT ? 'lovelace' : unit,
       decimals: DEFAULT_CREDIT_DECIMALS,
+      chain: { kind: 'unknown' },
     });
   }
   return options;
@@ -141,6 +159,71 @@ export function consolidateCreditRows(
     totals.set(row.unit, (totals.get(row.unit) ?? BigInt(0)) + BigInt(row.amount));
   }
   return Array.from(totals, ([unit, amount]) => ({ unit, amount: amount.toString() }));
+}
+
+/**
+ * A Cardano native asset unit: a 28-byte policy id followed by an asset name of up
+ * to 32 bytes, both hex, concatenated exactly as the ledger stores them.
+ */
+const CARDANO_ASSET_UNIT = /^[0-9a-fA-F]{56}(?:[0-9a-fA-F]{2}){0,32}$/;
+
+/** A bare ERC-20 contract address, before it is chain-qualified. */
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+/** `UsageCreditsToAddOrRemove[].unit` is `z.string().max(150)` on both routes. */
+const MAX_CREDIT_UNIT_LENGTH = 150;
+
+/**
+ * Turn an operator-typed asset id into the exact unit string the debit path looks up,
+ * or explain why it cannot be one.
+ *
+ * The preset lists only cover the assets this repo ships constants for, so a key that
+ * pays in any other token could not be funded at all from the dialog. Accepting free
+ * text needs the same canonical shape the server enforces, because a near miss is not
+ * a cosmetic problem: `findNonCanonicalEvmCreditUnit` rejects EVM-ish units outright,
+ * and a Cardano unit that does not match what the purchase path requests is stored
+ * happily and then fails every payment with `Credit unit not found`.
+ *
+ * EVM input may be a bare address or an already-qualified `eip155:<id>:0x…` unit; a
+ * qualified one must name the chain it was typed under, so an address pasted into the
+ * wrong group is refused instead of silently re-homed.
+ */
+export function buildCustomCreditUnit(
+  chain: CreditChain,
+  raw: string,
+): { unit: string } | { error: string } {
+  const value = raw.trim();
+  if (value === '') return { error: 'Enter an asset id' };
+
+  if (chain.kind === 'evm') {
+    const qualified = value.toLowerCase().startsWith('eip155:');
+    const address = qualified ? value.slice(value.lastIndexOf(':') + 1) : value;
+    if (qualified && !value.toLowerCase().startsWith(`${chain.caip2Id.toLowerCase()}:`)) {
+      return { error: `That id is for another chain. This group is ${chain.caip2Id}.` };
+    }
+    if (!EVM_ADDRESS.test(address)) {
+      return { error: 'Enter a contract address: 0x followed by 40 hex characters' };
+    }
+    return { unit: `${chain.caip2Id}:${address}`.toLowerCase() };
+  }
+
+  if (chain.kind === 'cardano') {
+    if (value.toLowerCase() === 'lovelace' || value.toLowerCase() === 'ada') {
+      return { error: 'ADA is already in this list; pick it there' };
+    }
+    if (value.length > MAX_CREDIT_UNIT_LENGTH) {
+      return { error: `An asset id is at most ${MAX_CREDIT_UNIT_LENGTH} characters` };
+    }
+    if (!CARDANO_ASSET_UNIT.test(value)) {
+      return {
+        error: 'Enter policy id + asset name as hex: 56 characters, then the name in pairs',
+      };
+    }
+    // Asset-name hex is case-significant on Cardano, so this is stored verbatim.
+    return { unit: value };
+  }
+
+  return { error: 'This group does not accept a custom asset' };
 }
 
 /** Middle-elide a policy id or chain-qualified address so it fits a label. */

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -1,0 +1,181 @@
+import {
+  getUsdmConfig,
+  USDCX_CONFIG,
+  getActiveStablecoinSymbol,
+} from '@/lib/constants/defaultWallets';
+import { assetPresetsForNetwork, type AssetPresetNetwork } from '@/lib/x402-registration';
+
+/**
+ * The unit an ADA credit row must carry.
+ *
+ * NOT 'lovelace'. The purchase path runs every requested unit through
+ * `normalizePurchaseUnit` (src/utils/shared/transformers.ts), which maps
+ * 'lovelace' to '' before the cost reaches the credit gate. The gate compares
+ * those units against `RemainingUsageCredits` verbatim, so a row stored as
+ * 'lovelace' can never match an ADA purchase and the key fails with
+ * `Credit unit not found:` for a balance the dashboard shows as funded.
+ */
+export const ADA_CREDIT_UNIT = '';
+
+/** Cardano native assets and the EVM stablecoins in EVM_ASSET_PRESETS are all 6dp. */
+export const DEFAULT_CREDIT_DECIMALS = 6;
+
+export type CardanoNetwork = 'Mainnet' | 'Preprod';
+
+export interface CreditUnitOption {
+  /** Exact string written to `UsageCreditsToAddOrRemove[].unit`. */
+  unit: string;
+  /** Short name for the amount field, e.g. 'ADA' or 'USDC'. */
+  label: string;
+  /** Where the unit spends, e.g. 'Cardano Mainnet' or 'Base Mainnet'. */
+  group: string;
+  /** Full identifier, shown under the label so two same-symbol assets stay distinguishable. */
+  identifier: string;
+  decimals: number;
+}
+
+function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
+  const group = `Cardano ${network}`;
+  const usdm = getUsdmConfig(network);
+  const options: CreditUnitOption[] = [
+    {
+      unit: ADA_CREDIT_UNIT,
+      label: 'ADA',
+      group,
+      identifier: 'lovelace',
+      decimals: DEFAULT_CREDIT_DECIMALS,
+    },
+    {
+      unit: usdm.fullAssetId,
+      label: network === 'Mainnet' ? 'USDM' : 'tUSDM',
+      group,
+      identifier: usdm.fullAssetId,
+      decimals: DEFAULT_CREDIT_DECIMALS,
+    },
+  ];
+  if (network === 'Mainnet') {
+    options.push({
+      unit: USDCX_CONFIG.fullAssetId,
+      label: getActiveStablecoinSymbol(network),
+      group,
+      identifier: USDCX_CONFIG.fullAssetId,
+      decimals: DEFAULT_CREDIT_DECIMALS,
+    });
+  }
+  return options;
+}
+
+function evmOptions(caip2Id: string, networks: AssetPresetNetwork[]): CreditUnitOption[] {
+  const network = networks.find((candidate) => candidate.caip2Id === caip2Id);
+  if (!network) return [];
+  return assetPresetsForNetwork(network).map((preset) => ({
+    // The x402 debit lowercases the asset address, and the API rejects any other
+    // shape outright (findNonCanonicalEvmCreditUnit), so build the canonical form here.
+    unit: `${caip2Id}:${preset.address.toLowerCase()}`,
+    label: preset.symbol,
+    group: network.displayName,
+    identifier: `${caip2Id}:${preset.address.toLowerCase()}`,
+    decimals: preset.decimals,
+  }));
+}
+
+/**
+ * The credit units a given API key can actually spend, derived from that key's own
+ * access list rather than from a fixed pair of fields.
+ *
+ * The dialog used to offer exactly ADA and the active stablecoin, so a key that pays
+ * in USDM on Mainnet (where the active stablecoin is USDCx) could not be funded for
+ * the asset it spends, and an EVM key could not be funded at all. Every unit the key
+ * already holds a row for is included too, even an unrecognised or stale one, so a
+ * balance is never invisible in the UI that is supposed to manage it.
+ */
+export function creditUnitOptionsForKey({
+  networkLimit,
+  chainIdLimit,
+  evmNetworks,
+  existingUnits = [],
+}: {
+  networkLimit: CardanoNetwork[];
+  chainIdLimit: string[];
+  evmNetworks: AssetPresetNetwork[];
+  existingUnits?: string[];
+}): CreditUnitOption[] {
+  const options: CreditUnitOption[] = [];
+  for (const network of ['Mainnet', 'Preprod'] as const) {
+    if (networkLimit.includes(network)) options.push(...cardanoOptions(network));
+  }
+  for (const caip2Id of chainIdLimit.filter((chainId) => chainId.startsWith('eip155:'))) {
+    options.push(...evmOptions(caip2Id, evmNetworks));
+  }
+
+  const known = new Set(options.map((option) => option.unit));
+  for (const unit of existingUnits) {
+    if (known.has(unit)) continue;
+    known.add(unit);
+    options.push({
+      unit,
+      label: unit === ADA_CREDIT_UNIT ? 'ADA' : shortenCreditUnit(unit),
+      group: 'Already on this key',
+      identifier: unit === ADA_CREDIT_UNIT ? 'lovelace' : unit,
+      decimals: DEFAULT_CREDIT_DECIMALS,
+    });
+  }
+  return options;
+}
+
+/**
+ * Sum the ledger's rows per unit.
+ *
+ * `GET /api-key` returns `RemainingUsageCredits` verbatim, and the node can hold more
+ * than one row for the same unit: `runPurchaseCreditInitTransaction` collapses
+ * duplicates when it debits, which is only necessary because they occur. Two rows for
+ * one unit would otherwise become two editable fields sharing a React key, two deltas
+ * both diffed against a single row's balance, and a "currently" hint that reads only
+ * one of them.
+ */
+export function consolidateCreditRows(
+  rows: Array<{ unit: string; amount: string }>,
+): Array<{ unit: string; amount: string }> {
+  const totals = new Map<string, bigint>();
+  for (const row of rows) {
+    totals.set(row.unit, (totals.get(row.unit) ?? BigInt(0)) + BigInt(row.amount));
+  }
+  return Array.from(totals, ([unit, amount]) => ({ unit, amount: amount.toString() }));
+}
+
+/** Middle-elide a policy id or chain-qualified address so it fits a label. */
+export function shortenCreditUnit(unit: string): string {
+  if (unit.length <= 20) return unit;
+  return `${unit.slice(0, 10)}…${unit.slice(-6)}`;
+}
+
+/**
+ * Turn edited balances into the deltas PATCH expects.
+ *
+ * `UsageCreditsToAddOrRemove` is a delta list, not a set of absolute balances, so an
+ * operator typing a new balance means "move it by this much". Units whose balance is
+ * unchanged are omitted entirely; sending a zero delta for an absent unit is a 400
+ * ('Invalid amount') on the server.
+ *
+ * A unit dropped from `next` is zeroed rather than ignored, because otherwise removing a
+ * row in the UI left the stored balance untouched and the form lied about what it saved.
+ * The server keeps a zeroed row on purpose: it is the record that the key is capped on
+ * that unit, and deleting it would read as "never capped" to the x402 enforcement probe.
+ */
+export function creditDeltas(
+  current: Array<{ unit: string; amount: string }>,
+  next: Array<{ unit: string; amount: string }>,
+): Array<{ unit: string; amount: string }> {
+  const currentByUnit = new Map(current.map((row) => [row.unit, BigInt(row.amount)]));
+  const nextUnits = new Set(next.map((row) => row.unit));
+  const deltas: Array<{ unit: string; amount: string }> = [];
+  for (const row of next) {
+    const delta = BigInt(row.amount) - (currentByUnit.get(row.unit) ?? BigInt(0));
+    if (delta !== BigInt(0)) deltas.push({ unit: row.unit, amount: delta.toString() });
+  }
+  for (const [unit, amount] of currentByUnit) {
+    if (nextUnits.has(unit) || amount === BigInt(0)) continue;
+    deltas.push({ unit, amount: (-amount).toString() });
+  }
+  return deltas;
+}

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -36,7 +36,15 @@ export const UNKNOWN_GROUP_ID = 'unknown';
 export type CreditChain =
   | { kind: 'cardano'; network: CardanoNetwork }
   | { kind: 'evm'; caip2Id: string }
+  | { kind: 'shared-cardano' }
   | { kind: 'unknown' };
+
+export interface CreditUnitGroup {
+  groupId: string;
+  group: string;
+  /** Present only when the group can validate and qualify a custom asset. */
+  customChain?: CreditChain;
+}
 
 export interface CreditUnitOption {
   /** Exact string written to `UsageCreditsToAddOrRemove[].unit`. */
@@ -58,13 +66,14 @@ export interface CreditUnitOption {
   chain: CreditChain;
 }
 
-function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
+function cardanoOptions(network: CardanoNetwork, includeAda: boolean): CreditUnitOption[] {
   const group = `Cardano ${network}`;
   const groupId = `cardano:${network.toLowerCase()}`;
   const chain: CreditChain = { kind: 'cardano', network };
   const usdm = getUsdmConfig(network);
-  const options: CreditUnitOption[] = [
-    {
+  const options: CreditUnitOption[] = [];
+  if (includeAda) {
+    options.push({
       unit: ADA_CREDIT_UNIT,
       label: 'ADA',
       groupId,
@@ -72,17 +81,17 @@ function cardanoOptions(network: CardanoNetwork): CreditUnitOption[] {
       identifier: 'lovelace',
       decimals: DEFAULT_CREDIT_DECIMALS,
       chain,
-    },
-    {
-      unit: usdm.fullAssetId,
-      label: network === 'Mainnet' ? 'USDM' : 'tUSDM',
-      groupId,
-      group,
-      identifier: usdm.fullAssetId,
-      decimals: DEFAULT_CREDIT_DECIMALS,
-      chain,
-    },
-  ];
+    });
+  }
+  options.push({
+    unit: usdm.fullAssetId,
+    label: network === 'Mainnet' ? 'USDM' : 'tUSDM',
+    groupId,
+    group,
+    identifier: usdm.fullAssetId,
+    decimals: DEFAULT_CREDIT_DECIMALS,
+    chain,
+  });
   if (network === 'Mainnet') {
     options.push({
       unit: USDCX_CONFIG.fullAssetId,
@@ -123,29 +132,68 @@ function evmOptions(caip2Id: string, networks: AssetPresetNetwork[]): CreditUnit
  * already holds a row for is included too, even an unrecognised or stale one, so a
  * balance is never invisible in the UI that is supposed to manage it.
  */
-export function creditUnitOptionsForKey({
-  networkLimit,
-  chainIdLimit,
-  evmNetworks,
-  existingUnits = [],
-}: {
+type CreditUnitCatalogParameters = {
   networkLimit: CardanoNetwork[];
   chainIdLimit: string[];
   evmNetworks: AssetPresetNetwork[];
   existingUnits?: string[];
-}): CreditUnitOption[] {
+};
+
+function buildCreditUnitCatalog({
+  networkLimit,
+  chainIdLimit,
+  evmNetworks,
+  existingUnits = [],
+}: CreditUnitCatalogParameters): {
+  options: CreditUnitOption[];
+  groups: CreditUnitGroup[];
+} {
   const options: CreditUnitOption[] = [];
-  for (const network of ['Mainnet', 'Preprod'] as const) {
-    if (networkLimit.includes(network)) options.push(...cardanoOptions(network));
+  const groups: CreditUnitGroup[] = [];
+  const cardanoNetworks = (['Mainnet', 'Preprod'] as const).filter((network) =>
+    networkLimit.includes(network),
+  );
+
+  if (cardanoNetworks.length > 1) {
+    const groupId = 'cardano:all';
+    const group = 'Cardano Mainnet and Preprod';
+    groups.push({ groupId, group });
+    options.push({
+      unit: ADA_CREDIT_UNIT,
+      label: 'ADA',
+      groupId,
+      group,
+      identifier: 'lovelace',
+      decimals: DEFAULT_CREDIT_DECIMALS,
+      chain: { kind: 'shared-cardano' },
+    });
   }
+
+  for (const network of cardanoNetworks) {
+    const groupId = `cardano:${network.toLowerCase()}`;
+    const group = `Cardano ${network}`;
+    const customChain: CreditChain = { kind: 'cardano', network };
+    groups.push({ groupId, group, customChain });
+    options.push(...cardanoOptions(network, cardanoNetworks.length === 1));
+  }
+
   for (const caip2Id of chainIdLimit.filter((chainId) => chainId.startsWith('eip155:'))) {
+    const network = evmNetworks.find((candidate) => candidate.caip2Id === caip2Id);
+    if (!network) continue;
+    groups.push({
+      groupId: caip2Id,
+      group: network.displayName,
+      customChain: { kind: 'evm', caip2Id },
+    });
     options.push(...evmOptions(caip2Id, evmNetworks));
   }
 
   const known = new Set(options.map((option) => option.unit));
+  let hasUnknownGroup = false;
   for (const unit of existingUnits) {
     if (known.has(unit)) continue;
     known.add(unit);
+    hasUnknownGroup = true;
     options.push({
       unit,
       label: unit === ADA_CREDIT_UNIT ? 'ADA' : shortenCreditUnit(unit),
@@ -159,7 +207,22 @@ export function creditUnitOptionsForKey({
       chain: { kind: 'unknown' },
     });
   }
-  return options;
+  if (hasUnknownGroup) {
+    groups.push({ groupId: UNKNOWN_GROUP_ID, group: 'Already on this key' });
+  }
+
+  return { options, groups };
+}
+
+export function creditUnitOptionsForKey(
+  parameters: CreditUnitCatalogParameters,
+): CreditUnitOption[] {
+  return buildCreditUnitCatalog(parameters).options;
+}
+
+/** Picker groups, including configured EVM chains that have no preset token yet. */
+export function creditUnitGroupsForKey(parameters: CreditUnitCatalogParameters): CreditUnitGroup[] {
+  return buildCreditUnitCatalog(parameters).groups;
 }
 
 /** The chain-qualified EVM credit unit the debit path stores, always lowercase. */
@@ -295,8 +358,8 @@ export function shortenCreditUnit(unit: string): string {
  *
  * A unit dropped from `next` is zeroed rather than ignored, because otherwise removing a
  * row in the UI left the stored balance untouched and the form lied about what it saved.
- * The server keeps a zeroed row on purpose: it is the record that the key is capped on
- * that unit, and deleting it would read as "never capped" to the x402 enforcement probe.
+ * The server keeps a zeroed row so the allowance stays visible and can be funded again
+ * without retyping the unit. Missing and zero balances both block a usage-limited key.
  */
 export function creditDeltas(
   current: Array<{ unit: string; amount: string }>,
@@ -342,8 +405,8 @@ export function creditRowProblem(
   }
   // A zero balance for a unit the ledger has no row for sends no delta at all
   // (creditDeltas skips it) and the server refuses to create one (400 'Invalid
-  // amount'). The save would report success and leave the unit uncapped, which for
-  // x402 means the key keeps spending with no ceiling.
+  // amount'). The save would report success but store no allowance. A usage-limited
+  // key would still reject payments for that unit.
   if (!fundedUnits.has(row.unit) && convertDecimalToBaseUnits(row.amount, row.decimals) === '0') {
     return 'Enter an amount above zero. The node cannot store a new unit at zero.';
   }

--- a/frontend/src/lib/api-key-credit-units.ts
+++ b/frontend/src/lib/api-key-credit-units.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/constants/defaultWallets';
 import { assetPresetsForNetwork, type AssetPresetNetwork } from '@/lib/x402-registration';
 import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
+import { POSTGRES_BIGINT_MAX } from '@/lib/registry-validation';
 
 /**
  * The unit an ADA credit row must carry.
@@ -318,6 +319,14 @@ export function creditRowProblem(
   // x402 means the key keeps spending with no ceiling.
   if (!fundedUnits.has(row.unit) && convertDecimalToBaseUnits(row.amount, row.decimals) === '0') {
     return 'Enter an amount above zero. The node cannot store a new unit at zero.';
+  }
+  // UnitValue.amount is a Prisma BigInt, so Postgres refuses anything past int8 with
+  // `22003 value out of range`. Unchecked it leaves as a valid request and comes back
+  // as a generic 'Failed to update API key', with every other field in the same PATCH
+  // rolled back. Now that this field takes ADA rather than lovelace, an extra six
+  // digits is an easy slip.
+  if (BigInt(convertDecimalToBaseUnits(row.amount, row.decimals)) > POSTGRES_BIGINT_MAX) {
+    return `Enter at most ${POSTGRES_BIGINT_MAX.toString()} base units`;
   }
   return undefined;
 }

--- a/frontend/src/lib/x402-registration.ts
+++ b/frontend/src/lib/x402-registration.ts
@@ -83,9 +83,17 @@ export function addressesMatch(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
 }
 
-export function assetPresetsForNetwork(
-  network: X402RegistrationNetwork | undefined,
-): EvmAssetPreset[] {
+/**
+ * The fields the preset lookup actually reads. Narrower than a whole network object so
+ * a caller holding the admin `X402Network` shape (which has no `canSettle`) can pass it
+ * without a cast.
+ */
+export type AssetPresetNetwork = Pick<
+  X402RegistrationNetwork,
+  'caip2Id' | 'displayName' | 'defaultAsset' | 'defaultAssetDecimals'
+>;
+
+export function assetPresetsForNetwork(network: AssetPresetNetwork | undefined): EvmAssetPreset[] {
   if (!network) return [];
 
   const presets = EVM_ASSET_PRESETS.filter((preset) => preset.network === network.caip2Id);

--- a/frontend/src/pages/api-keys.tsx
+++ b/frontend/src/pages/api-keys.tsx
@@ -60,6 +60,23 @@ function isRedactedApiKeyToken(token: string): boolean {
   return token.startsWith('*****');
 }
 
+/**
+ * Whether a listed key is the one this session is signed in with.
+ *
+ * GET /api-key never returns a plaintext token: it masks it as
+ * `'*****' + token.slice(-4)` (src/routes/api/api-key/index.ts). Comparing that
+ * mask to the session's plaintext key is therefore always false, which silently
+ * disabled the "cannot delete the key you are signed in with" guard and let an
+ * operator lock themselves out of the dashboard in one click. Mask the session key
+ * the same way instead. Two keys sharing a last-four collide and both get guarded,
+ * which is the safe direction to be wrong in.
+ */
+function isSessionApiKey(listedToken: string, sessionApiKey: string | null): boolean {
+  if (!sessionApiKey) return false;
+  if (listedToken === sessionApiKey) return true;
+  return listedToken === `*****${sessionApiKey.slice(-4)}`;
+}
+
 export default function ApiKeys() {
   const router = useRouter();
   const { apiClient, network, apiKey } = useAppContext();
@@ -135,15 +152,16 @@ export default function ApiKeys() {
     loadMore();
   };
 
-  const handleSelectKey = (token: string) => {
-    setSelectedKeys((prev) =>
-      prev.includes(token) ? prev.filter((k) => k !== token) : [...prev, token],
-    );
+  // Select by id, not by token. The listed token is a mask, so every key ending in the
+  // same four characters shared one selection entry: ticking one ticked them all, and a
+  // bulk action would have hit every collider.
+  const handleSelectKey = (id: string) => {
+    setSelectedKeys((prev) => (prev.includes(id) ? prev.filter((k) => k !== id) : [...prev, id]));
   };
 
   const handleSelectAll = () => {
     setSelectedKeys(
-      selectedKeys.length === filteredApiKeys.length ? [] : filteredApiKeys.map((key) => key.token),
+      selectedKeys.length === filteredApiKeys.length ? [] : filteredApiKeys.map((key) => key.id),
     );
   };
 
@@ -259,18 +277,24 @@ export default function ApiKeys() {
                     </td>
                   </tr>
                 ) : (
-                  filteredApiKeys.map((key, index) => (
-                    <tr key={index} className="border-b" onClick={() => {}}>
+                  filteredApiKeys.map((key) => (
+                    <tr key={key.id} className="border-b" onClick={() => {}}>
                       <td className="p-4">
                         <Checkbox
-                          checked={selectedKeys.includes(key.token)}
-                          onCheckedChange={() => handleSelectKey(key.token)}
+                          aria-label={`Select key ${key.token}`}
+                          checked={selectedKeys.includes(key.id)}
+                          onCheckedChange={() => handleSelectKey(key.id)}
                         />
                       </td>
                       <td className="p-4 truncate">
                         <div className="flex items-center gap-2">
                           <span className="font-mono text-sm text-muted-foreground">
-                            {shortenAddress(key.token)}
+                            {/* A masked token is already short; running it through
+                                shortenAddress elided the only four characters that
+                                identify it. */}
+                            {isRedactedApiKeyToken(key.token)
+                              ? key.token
+                              : shortenAddress(key.token)}
                           </span>
                           {!isRedactedApiKeyToken(key.token) && <CopyButton value={key.token} />}
                         </div>
@@ -329,11 +353,13 @@ export default function ApiKeys() {
                           <SelectContent>
                             <SelectItem value="update">Update</SelectItem>
                             <SelectItem
-                              disabled={key.token === apiKey}
+                              disabled={isSessionApiKey(key.token, apiKey)}
                               value="delete"
                               className="text-red-600"
                             >
-                              {key.token === apiKey ? 'Cannot delete current API key' : 'Delete'}
+                              {isSessionApiKey(key.token, apiKey)
+                                ? 'Cannot delete current API key'
+                                : 'Delete'}
                             </SelectItem>
                           </SelectContent>
                         </Select>

--- a/prisma/migrations/20260712010000_harden_v1_batch_reconciliation/migration.sql
+++ b/prisma/migrations/20260712010000_harden_v1_batch_reconciliation/migration.sql
@@ -1,0 +1,49 @@
+-- Persist the signed batch transaction's ledger expiry so a missing hash is
+-- never requeued solely because a wall-clock timeout elapsed.
+ALTER TABLE "Transaction"
+ADD COLUMN IF NOT EXISTS "invalidHereafterSlot" BIGINT;
+
+-- One Cardano batch has one signed body and therefore one Transaction row.
+-- Allow every participating PurchaseRequest to reference that shared row.
+DROP INDEX IF EXISTS "PurchaseRequest_currentTransactionId_key";
+
+CREATE INDEX IF NOT EXISTS "PurchaseRequest_currentTransactionId_idx"
+ON "PurchaseRequest" ("currentTransactionId");
+
+-- A shared batch transaction must remain in every participating request's
+-- history after reconciliation. Keep the legacy scalar relation for rolling
+-- deploy compatibility, while new code writes the many-to-many relation.
+CREATE TABLE IF NOT EXISTS "_PurchaseTransactionHistory" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+DO $$ BEGIN
+    ALTER TABLE "_PurchaseTransactionHistory"
+        ADD CONSTRAINT "_PurchaseTransactionHistory_A_fkey"
+        FOREIGN KEY ("A") REFERENCES "PurchaseRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE "_PurchaseTransactionHistory"
+        ADD CONSTRAINT "_PurchaseTransactionHistory_B_fkey"
+        FOREIGN KEY ("B") REFERENCES "Transaction"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "_PurchaseTransactionHistory_AB_unique"
+ON "_PurchaseTransactionHistory" ("A", "B");
+
+CREATE INDEX IF NOT EXISTS "_PurchaseTransactionHistory_B_index"
+ON "_PurchaseTransactionHistory" ("B");
+
+DO $$ BEGIN
+    INSERT INTO "_PurchaseTransactionHistory" ("A", "B")
+    SELECT "purchaseRequestHistoryId", "id"
+    FROM "Transaction"
+    WHERE "purchaseRequestHistoryId" IS NOT NULL
+    ON CONFLICT DO NOTHING;
+EXCEPTION
+    -- The refactored branch already moved history fully to this join table and
+    -- dropped the legacy scalar. Keep this migration merge-safe across branches.
+    WHEN undefined_column THEN NULL;
+END $$;

--- a/src/routes/api/api-key/credit-units.spec.ts
+++ b/src/routes/api/api-key/credit-units.spec.ts
@@ -77,10 +77,8 @@ describe('findNonCanonicalEvmCreditUnit', () => {
 		['short address', 'eip155:8453:0x' + 'a'.repeat(39)],
 		['missing 0x', 'eip155:8453:' + 'a'.repeat(40)],
 	])('rejects a near-miss EVM unit (%s)', (_label, unit) => {
-		// These must FAIL CLOSED. Stored verbatim, none of them would ever match the
-		// x402 debit lookup, and the key would then hold no rows the enforcement
-		// probe recognizes — spending with no ceiling while the dashboard shows it
-		// as funded and usage limited.
+		// Stored verbatim, none of these units would match the exact x402 debit lookup.
+		// The dashboard would show credit while every matching payment returns 402.
 		expect(findNonCanonicalEvmCreditUnit([unit])).toBe(unit);
 	});
 
@@ -238,5 +236,60 @@ describe('planCreditDelta', () => {
 			1n,
 		);
 		expect(plan).toEqual({ updateId: 'ada', deleteIds: [], amount: 6n });
+	});
+
+	it('folds a legacy lovelace row into the ADA row it duplicates', () => {
+		// The dashboard shows one ADA balance, so an edit that lowers it to 1 sends -7
+		// against the pair. Applying that to the ADA row alone took 5 to -2 and 400'd.
+		expect(
+			planCreditDelta(
+				[
+					{ id: 'row-a', unit: '', amount: 5n },
+					{ id: 'row-b', unit: 'lovelace', amount: 3n },
+				],
+				'',
+				-7n,
+			),
+		).toEqual({ updateId: 'row-a', deleteIds: ['row-b'], amount: 1n });
+	});
+
+	it('keeps the exact canonical EVM row when an alias also exists', () => {
+		// x402 debits and refunds pin a row id, and the row they pin is the canonical
+		// one. Folding onto the alias instead would retire the id they hold.
+		const canonicalUnit = 'eip155:8453:0x' + 'ab'.repeat(20);
+		const alias = 'eip155:8453:0x' + 'AB'.repeat(20);
+		expect(
+			planCreditDelta(
+				[
+					{ id: 'row-a', unit: alias, amount: 2n },
+					{ id: 'row-b', unit: canonicalUnit, amount: 3n },
+				],
+				canonicalUnit,
+				1n,
+			),
+		).toEqual({ updateId: 'row-b', deleteIds: ['row-a'], amount: 6n });
+	});
+
+	it('keeps one zero row when the aggregate is fully removed', () => {
+		expect(
+			planCreditDelta(
+				[
+					{ id: 'row-a', unit: '', amount: 5n },
+					{ id: 'row-b', unit: 'lovelace', amount: 3n },
+				],
+				'',
+				-8n,
+			),
+		).toEqual({ updateId: 'row-a', deleteIds: ['row-b'], amount: 0n });
+	});
+
+	it('canonicalizes a legacy alias with the zero delta used when enabling the cap', () => {
+		// Turning the cap on seeds a zero delta per stored unit, so the row is rewritten
+		// under the unit the exact-match debit lookup uses.
+		expect(planCreditDelta([{ id: 'row-a', unit: 'lovelace', amount: 1_000_000n }], '', 0n)).toEqual({
+			updateId: 'row-a',
+			deleteIds: [],
+			amount: 1_000_000n,
+		});
 	});
 });

--- a/src/routes/api/api-key/credit-units.ts
+++ b/src/routes/api/api-key/credit-units.ts
@@ -42,12 +42,10 @@ export function normalizeCreditUnit(unit: string): string {
  * Reject EVM-ish credit units that are not exactly `eip155:<chainId>:0x<40 hex>`.
  *
  * This has to FAIL CLOSED, because the x402 cap is only enforced for units the
- * debit path can find: a near miss (`EIP155:…`, `eip155:8453:native`, a truncated
- * address) would be stored verbatim, never match the lookup, and — since the key
- * then has no rows the enforcement probe recognizes — leave the key spending with
- * no ceiling at all while the dashboard shows it as funded and limited. Storing
- * such a unit is always an operator mistake, so it is better to refuse it at the
- * boundary than to silently disable a spending control.
+ * debit path can find. A near miss (`EIP155:…`, `eip155:8453:native`, or a
+ * truncated address) would be stored verbatim and never match the lookup. The
+ * dashboard would show credit that every matching payment rejects. Refuse it at
+ * the boundary instead.
  *
  * Returns the offending unit, or null when the unit is fine.
  */
@@ -90,11 +88,11 @@ export interface CreditDeltaPlan {
  * Plan the ledger writes for one unit's delta, across EVERY row that carries it.
  *
  * The ledger has no unique index on (apiKeyId, unit), so a key can hold several rows
- * for one asset: two rows created before the write paths consolidated, or a stale
- * checksummed row beside the canonical lowercase one. Every reader sums them, because
- * the dashboard shows one balance per unit and the x402 debit folds duplicates before
- * it charges. Resolving a single row here left the update path the only one that did
- * not.
+ * for one asset: two rows created before the write paths consolidated, a legacy
+ * 'lovelace' row beside an ADA one, or a stale checksummed row beside the canonical
+ * lowercase one. Every reader sums them, because the dashboard shows one balance per
+ * unit and the x402 debit folds duplicates before it charges. Resolving a single row
+ * here left the update path the only one that did not.
  *
  * The visible failure was an edit that could not be saved. 5 ADA + 3 ADA reads as 8,
  * so lowering it to 1 sends -7, and applying that to the first row alone takes 5 to
@@ -103,10 +101,12 @@ export interface CreditDeltaPlan {
  * row matched first, so clearing a stale row could take its balance off the live row
  * instead and leave the stale one standing.
  *
- * Folding onto the first row also repairs the duplicates, the same way
- * `runPurchaseCreditInitTransaction` and the x402 debit already do, so a key stops
- * carrying them after the first edit. No guard is needed on the read: the caller runs
- * inside the Serializable transaction that read these rows.
+ * The kept row is the one already stored under the exact canonical unit, because
+ * x402 debits and refunds pin that row id; ties break on the lowest id so the choice
+ * does not depend on query order. Folding onto it also repairs the duplicates, the
+ * same way `runPurchaseCreditInitTransaction` and the x402 debit already do, so a key
+ * stops carrying them after the first edit. No guard is needed on the read: the
+ * caller runs inside the Serializable transaction that read these rows.
  *
  * Returns null when the delta is not applicable — it would take the unit below zero,
  * or it is a non-positive delta for a unit the key holds no row for.
@@ -116,7 +116,12 @@ export function planCreditDelta(
 	unit: string,
 	delta: bigint,
 ): CreditDeltaPlan | null {
-	const matching = rows.filter((row) => normalizeCreditUnit(row.unit) === unit);
+	const matching = rows
+		.filter((row) => normalizeCreditUnit(row.unit) === unit)
+		.sort((left, right) => {
+			const canonicalFirst = Number(right.unit === unit) - Number(left.unit === unit);
+			return canonicalFirst || left.id.localeCompare(right.id);
+		});
 	if (matching.length === 0) {
 		return delta > 0n ? { updateId: null, deleteIds: [], amount: delta } : null;
 	}

--- a/src/routes/api/api-key/index.ts
+++ b/src/routes/api/api-key/index.ts
@@ -274,7 +274,7 @@ export const addAPIKeyEndpointPost = adminAuthenticatedEndpointFactory.build({
 		const chainIdLimit = isAdmin ? [] : (input.ChainIdLimit ?? (await allConfiguredEvmChainIds(input.NetworkLimit)));
 		// Fail closed on a unit that was meant to be an EVM credit but is not exactly
 		// eip155:<chainId>:0x<40 hex>: stored verbatim it would never match the debit
-		// lookup and would leave the key's x402 spending uncapped while looking funded.
+		// lookup, so payments would fail despite the displayed balance.
 		const badUnit = findNonCanonicalEvmCreditUnit(input.UsageCredits.map((credit) => credit.unit));
 		if (badUnit != null) {
 			throw createHttpError(
@@ -390,11 +390,12 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 					if (!apiKey) {
 						throw createHttpError(404, 'API key not found');
 					}
-					if (input.UsageCreditsToAddOrRemove) {
+					if (input.UsageCreditsToAddOrRemove || input.usageLimited === true) {
+						const requestedUsageCredits = input.UsageCreditsToAddOrRemove ?? [];
 						// Same fail-closed check as the create path: an EVM-ish unit that is
 						// not exactly eip155:<chainId>:0x<40 hex> would never match the debit
-						// lookup and would leave the key's x402 spending uncapped.
-						const badUnit = findNonCanonicalEvmCreditUnit(input.UsageCreditsToAddOrRemove.map((credit) => credit.unit));
+						// lookup, so payments would fail despite the displayed balance.
+						const badUnit = findNonCanonicalEvmCreditUnit(requestedUsageCredits.map((credit) => credit.unit));
 						if (badUnit != null) {
 							throw createHttpError(
 								400,
@@ -407,7 +408,7 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 						// row and then updated the deleted id (raw P2025 500, whole PATCH lost),
 						// and two positive deltas for a new unit created two rows for it.
 						const deltasByUnit = new Map<string, bigint>();
-						for (const usageCredit of input.UsageCreditsToAddOrRemove) {
+						for (const usageCredit of requestedUsageCredits) {
 							// Match and store the normalized unit: the x402 debit looks credits up
 							// by the lowercased form, so a checksummed top-up would otherwise
 							// create (or leave) a row the payment path can never match. Comparing
@@ -415,6 +416,17 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 							// of stranding it next to a new lowercase one.
 							const unit = normalizeCreditUnit(usageCredit.unit);
 							deltasByUnit.set(unit, (deltasByUnit.get(unit) ?? 0n) + BigInt(usageCredit.amount));
+						}
+						// Enabling the cap must also repair stored aliases. The update dialog
+						// displays `lovelace` as `''` and checksummed EVM units in lowercase, so
+						// an unchanged balance sends no delta. Seed a zero delta for each stored
+						// unit so the plan below consolidates and writes its canonical form before
+						// the limited key starts using exact-unit lookups.
+						if (input.usageLimited === true) {
+							for (const credit of apiKey.RemainingUsageCredits) {
+								const unit = normalizeCreditUnit(credit.unit);
+								if (!deltasByUnit.has(unit)) deltasByUnit.set(unit, 0n);
+							}
 						}
 						for (const [unit, delta] of deltasByUnit) {
 							// Applied across EVERY row carrying the unit, not just the first one


### PR DESCRIPTION
Stacked on #800.

## What was wrong

The update dialog offered exactly two credit fields, ADA and "the active stablecoin", and no control for `usageLimited` at all.

**Wrong asset.** `getActiveStablecoinConfig('Mainnet')` is USDCx, so a key that pays in USDM could not be funded for the asset it actually spends, and a key limited to EVM chains could not be funded at all.

**Wrong ADA unit.** The ADA field wrote `unit: 'lovelace'`. The purchase path runs every requested unit through `normalizePurchaseUnit`, which maps `'lovelace'` to `''` before the cost reaches the credit gate. A credit row written by this dialog could therefore never match an ADA purchase, and the key failed with `Credit unit not found:` for a balance the dashboard showed as funded.

**No balances.** Both fields were blank delta inputs whose `0.00` was only a placeholder, so the form never showed whether a key was funded.

## The change

The credit list is derived from the key's own access list: every allowed Cardano network contributes ADA and that network's stablecoins, every `eip155:` entry in `ChainIdLimit` contributes the chain's configured assets in the canonical lowercase form the debit path looks up, and any unit already on the key stays listed even when it is unrecognised. ADA writes the empty unit.

Rows load the stored balances, the operator edits balances directly, and only what moved is sent as a delta. Zeroing a row emits the negative delta instead of silently keeping the stored amount. Adds the `usageLimited` toggle, and blocks saving a usage-limited key with no funded unit.

## Key list

The list treated the masked token as an identity. It never carries a plaintext token (`'*****' + slice(-4)`), so:

- `key.token === apiKey` was always false and the "cannot delete the current API key" guard never fired
- selection was keyed by the same mask, so two keys ending in the same four characters shared one checkbox
- `shortenAddress` elided the only four characters that identify a masked token

Rows now key by id, selection by id, and the guard compares against the masked session key.

## Verification

- `npm test` in `frontend` — 186 tests, all passing (15 new, covering unit derivation and delta maths)
- `pnpm run typecheck:frontend` — clean
- `pnpm -C frontend run lint` — clean
- Mutation check: reverting ADA to `'lovelace'` and dropping the removal-zeroing fails 3 of 15
