### PR TITLE
fix(x402): let the sidebar switch off the EVM rail from an x402 page

### DIFF
--- a/frontend/src/lib/x402-navigation.test.ts
+++ b/frontend/src/lib/x402-navigation.test.ts
@@ -48,6 +48,23 @@ test('direct x402 routes restore the rail only after available chains load', () 
   assert.equal(shouldRestoreX402Rail('/wallets', false, 1), false);
 });
 
+test('an explicit switch off the EVM rail is not undone by the deep-link restore', () => {
+  // Picking a Cardano source while standing on /x402/wallets leaves the rail on
+  // 'cardano' with the pathname still pointing at the EVM page for one render. Without
+  // this guard the restore fired, put the rail back on x402, and the pending navigation
+  // to '/' was then bounced on to /x402/dashboard, so the switch looked like it did
+  // nothing. `isRouteChanging` cannot cover this: Next emits routeChangeStart only after
+  // an await inside router.push, so it is still false when the effects flush.
+  assert.equal(shouldRestoreX402Rail('/x402/wallets', false, 1, false, true), false);
+  assert.equal(shouldRestoreX402Rail('/x402/dashboard', false, 1, false, true), false);
+});
+
+test('a deep link to an EVM page still restores the rail', () => {
+  // The case the restore exists for: the session arrives already on the Cardano rail,
+  // with no switch behind it, so the sidebar has to follow the page.
+  assert.equal(shouldRestoreX402Rail('/x402/wallets', false, 1, false, false), true);
+});
+
 test('x402 permission fallback, home, and setup paths keep rail context', () => {
   assert.equal(isX402RailPath('/x402-setup'), true);
   assert.equal(deniedPathFallback('/x402/chains', '/developers'), '/x402/dashboard');

--- a/frontend/src/lib/x402-navigation.ts
+++ b/frontend/src/lib/x402-navigation.ts
@@ -62,14 +62,35 @@ export function isX402RailPath(pathname: string): boolean {
   return pathname === '/x402' || pathname.startsWith('/x402/') || pathname === X402_SETUP_PATH;
 }
 
+/**
+ * Whether a session sitting on an x402 route should have the EVM rail restored.
+ *
+ * This exists for deep links: someone opens /x402/wallets with a persisted Cardano rail
+ * and the sidebar has to follow the page. It must NOT fire for the opposite case, where
+ * someone standing on an x402 page picks a Cardano source in the sidebar, because the
+ * rail is then already 'cardano' while `pathname` still points at the old page for one
+ * render.
+ *
+ * `isRouteChanging` was meant to cover that window and cannot. Next emits
+ * `routeChangeStart` only after an `await matchesMiddleware(...)` inside `router.push`,
+ * so the flag is still false when React flushes the click's effects. The switch was
+ * therefore reverted to x402, and the pending navigation to '/' then landed on a
+ * Cardano-only page with the rail restored, which bounced it on to /x402/dashboard.
+ * `railJustSwitchedAway` closes the window with a value that is known synchronously.
+ */
 export function shouldRestoreX402Rail(
   pathname: string,
   areChainsLoading: boolean,
   availableChainCount: number,
   isRouteChanging = false,
+  railJustSwitchedAway = false,
 ): boolean {
   return (
-    isX402RailPath(pathname) && !isRouteChanging && !areChainsLoading && availableChainCount > 0
+    isX402RailPath(pathname) &&
+    !isRouteChanging &&
+    !railJustSwitchedAway &&
+    !areChainsLoading &&
+    availableChainCount > 0
   );
 }
 

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -70,6 +70,14 @@ function ToastWrapper() {
 
 function ThemedApp({ Component, pageProps, router }: AppProps) {
   const isRouteChanging = useRef(false);
+  // Previous rail, so an explicit switch away from x402 can be told apart from a deep
+  // link that arrives already on the Cardano rail. Updated by the recorder effect
+  // below, which is declared BEFORE the guard effect so the transition is recorded
+  // before the guard reads it on the same render.
+  const previousRailRef = useRef<'cardano' | 'x402'>('cardano');
+  // Pathname the user switched away from the EVM rail on. The restore stays suppressed
+  // for that pathname until the pending navigation actually lands somewhere else.
+  const suppressRailRestoreOnPathRef = useRef<string | null>(null);
   const [isHealthy, setIsHealthy] = useState<boolean | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [isMobileWarningDismissed, setIsMobileWarningDismissed] = useState(false);
@@ -131,6 +139,28 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
     silentErrors: true,
   });
 
+  // Record a switch off the EVM rail before the guard effect below can act on it.
+  //
+  // Declared first and free of early returns, so the transition is observed on every
+  // run: folding this into the guard effect meant a run that bailed early (still
+  // loading, admin-only redirect) consumed the transition, and the next run could no
+  // longer tell the user's switch from a deep link.
+  //
+  // Keyed by pathname rather than by a single render, because `router.push` has not
+  // landed yet at this point. Next emits `routeChangeStart` only after an
+  // `await matchesMiddleware(...)` inside push, so `isRouteChanging` is still false
+  // here; without this key, picking a Cardano source on /x402/wallets was reverted to
+  // x402 and the pending navigation to '/' was then bounced on to /x402/dashboard.
+  useEffect(() => {
+    const switchedAway = previousRailRef.current === 'x402' && activeRail === 'cardano';
+    previousRailRef.current = activeRail;
+    if (switchedAway) {
+      suppressRailRestoreOnPathRef.current = router.pathname;
+    } else if (suppressRailRestoreOnPathRef.current !== router.pathname) {
+      suppressRailRestoreOnPathRef.current = null;
+    }
+  }, [activeRail, router.pathname]);
+
   useEffect(() => {
     // Non-admins cannot open admin-only routes — do this before waiting on
     // payment sources to load, or deep-links would mount those pages and fire admin APIs first.
@@ -187,7 +217,13 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
       apiKey &&
       isHealthy &&
       activeRail !== 'x402' &&
-      shouldRestoreX402Rail(router.pathname, x402Loading, x402ChainCount, isRouteChanging.current)
+      shouldRestoreX402Rail(
+        router.pathname,
+        x402Loading,
+        x402ChainCount,
+        isRouteChanging.current,
+        suppressRailRestoreOnPathRef.current === router.pathname,
+      )
     ) {
       setActiveRail('x402');
       return;


### PR DESCRIPTION
## Reproduction

On `/x402/wallets`, open the sidebar source picker and choose a Cardano source (either the V2 default `addr1wxs…tgge2j6d` or the V1 legacy `addr1wx7…sq87ujx7`). Nothing switches: the rail stays on the EVM chain and the page lands on `/x402/dashboard`.

## Cause

`selectCardanoSource` sets the rail to `'cardano'` and pushes `'/'`. For one render the rail is Cardano while `router.pathname` still points at the x402 page. The deep-link restore in `_app.tsx` reads exactly that state as "this session deep-linked onto an x402 route, follow it" and puts the rail back. The pending navigation then lands on `'/'`, which is a Cardano-only page, and the restored rail bounces it on to `/x402/dashboard`.

`isRouteChanging` was meant to cover that window and cannot. In Next 16.2.12, `router.push` emits `routeChangeStart` only **after** an `await matchesMiddleware(...)`, so the flag is still `false` when React flushes the click's effects.

```
node_modules/next/dist/shared/lib/router/router.js
  const isMiddlewareMatch = !options.shallow && await matchesMiddleware({   // yields here
  ...
  Router.events.emit('routeChangeStart', as, routeProps);                   // line 1045
```

## The change

Record the switch instead, keyed by the pathname it happened on, and keep the restore suppressed until the navigation lands somewhere else. The recorder is its own effect declared ahead of the guard so it has no early returns above it: folding it into the guard meant a run that bailed early (still loading, admin-only redirect) consumed the transition, and the next run could no longer tell a switch from a deep link.

The guard effect keeps its original control flow, so a genuine deep link is unaffected. It arrives with no switch behind it.

## Verification

- `npm test` in `frontend` — 173 tests, all passing (2 new cases on `shouldRestoreX402Rail`)
- `pnpm run typecheck:frontend` — clean
- `pnpm -C frontend run lint` — clean
- Mutation check: dropping the new guard clause fails 1 of 8
