### PR TITLE
fix(x402): refuse payment when a usage-limited key has no credits

### DIFF
--- a/packages/payment-source-x402/src/pay.ts
+++ b/packages/payment-source-x402/src/pay.ts
@@ -68,24 +68,16 @@ async function reserveCreditsForAttempt({
 				select: { id: true, amount: true },
 			});
 			if (creditRows.length === 0) {
-				// Grandfathering: usageLimited predates EVM credits, so an existing key
-				// whose flag meant "Cardano-limited" would be hard-stopped on deploy by a
-				// unit format it has never heard of. A key with NO chain-qualified rows at
-				// all keeps its pre-cap behaviour (uncapped x402) and says so in the log;
-				// the moment the operator provisions any eip155 credit row the cap becomes
-				// binding for every EVM chain, so it cannot be dodged chain-by-chain.
-				const evmCreditRowCount = await tx.unitValue.count({
-					where: { apiKeyId, unit: { startsWith: 'eip155:' } },
-				});
-				if (evmCreditRowCount > 0) {
-					throw createHttpError(
-						402,
-						`Insufficient usage credits for ${creditUnit}. This API key is usage limited; top up its credits for this chain and asset, or remove the limit.`,
-					);
-				}
-				logger.warn(
-					'x402 credit cap not enforced: usage-limited key has no EVM credit rows (pre-cap key); add eip155-format usage credits to activate the cap',
-					{ apiKeyId: '[REDACTED]', unit: creditUnit },
+				// Fail closed. This used to grandfather a key with NO chain-qualified rows
+				// to its pre-cap behaviour, on the grounds that usageLimited predates EVM
+				// credits and once meant "Cardano-limited". That inverted what the flag
+				// promises: a key the operator had marked limited spent x402 against the
+				// wallet's whole balance, capped by nothing, and the only trace was a log
+				// line nobody reads. No credits for the unit means no allowance, so the
+				// payment is refused — the same answer the Cardano path gives.
+				throw createHttpError(
+					402,
+					`Insufficient usage credits for ${creditUnit}. This API key is usage limited; top up its credits for this chain and asset, or remove the limit.`,
 				);
 			} else {
 				// Consolidate split rows into the first one before debiting. Every write is

--- a/packages/payment-source-x402/src/service.spec.ts
+++ b/packages/payment-source-x402/src/service.spec.ts
@@ -1525,23 +1525,27 @@ describe('x402 service helpers', () => {
 			expect(mockCreatePaymentPayload).not.toHaveBeenCalled();
 		});
 
-		it('does not enforce the cap for a usage-limited key with no EVM credit rows at all', async () => {
-			// Grandfathering: usageLimited predates EVM credits. A pre-existing key with
-			// only Cardano-format credits must keep paying on x402 after the deploy
-			// instead of being hard-stopped by a unit format it has never heard of.
+		it('rejects with 402 for a usage-limited key with no EVM credit rows at all', async () => {
+			// This case used to be grandfathered through uncapped, because usageLimited
+			// predates EVM credits and once meant 'Cardano-limited'. It inverted the
+			// flag: a key the operator had marked limited spent x402 against the whole
+			// wallet balance. The answer now matches the case above, so it no longer
+			// depends on what the key happens to hold for OTHER chains.
 			mockUnitValueFindMany.mockResolvedValue([]);
 			mockUnitValueCount.mockResolvedValue(0);
 
-			await service.createX402Payment({
-				apiKeyId: 'api-key-1',
-				caip2NetworkLimit: [source.network],
-				evmWalletId: 'wallet-1',
-				paymentRequired,
-				usageLimited: true,
-			});
+			await expect(
+				service.createX402Payment({
+					apiKeyId: 'api-key-1',
+					caip2NetworkLimit: [source.network],
+					evmWalletId: 'wallet-1',
+					paymentRequired,
+					usageLimited: true,
+				}),
+			).rejects.toMatchObject({ status: 402 });
 
 			expect(mockUnitValueUpdateMany).not.toHaveBeenCalled();
-			expect(mockCreatePaymentPayload).toHaveBeenCalled();
+			expect(mockCreatePaymentPayload).not.toHaveBeenCalled();
 		});
 
 		it('rejects with 402 when usage credits cannot cover the payment', async () => {

--- a/src/routes/api/api-key/index.ts
+++ b/src/routes/api/api-key/index.ts
@@ -421,11 +421,13 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 								if (nextAmount < 0n) {
 									throw createHttpError(400, 'Invalid amount');
 								}
-								// A zeroed row is KEPT, not deleted. Deleting it removed the only
-								// evidence that this key is capped on that chain+asset, and the
-								// x402 enforcement probe reads "no EVM credit rows" as "pre-cap
-								// key, do not enforce" — so revoking a key's last EVM allowance
-								// used to hand it UNLIMITED spend instead of none.
+								// A zeroed row is KEPT, not deleted: it is the record that this key
+								// is capped on that chain and asset, and the operator can top it up
+								// again without retyping the unit. Enforcement no longer depends on
+								// the row existing — a usage-limited key with no credits for the
+								// unit it pays in is refused either way — but a key that shows its
+								// zeroed allowances is easier to reason about than one that hides
+								// them.
 								await prisma.unitValue.update({
 									where: { id: existingCredit.id },
 									data: { amount: nextAmount, unit },


### PR DESCRIPTION
> **Merge order.** masumi-network/sokosumi#4040 must merge and deploy BEFORE this PR. Ordered the other way, Soko lists agents as buy-side ready that this change then refuses at pay time.

## What changes

A usage-limited API key with no `eip155:` credit rows no longer pays on x402. It gets `402 Insufficient usage credits`, the same answer a key that holds rows for other chains already got.

## Why

`usageLimited` predates EVM credits, so `pay.ts` grandfathered these keys to their pre-cap behaviour: the payment went through with no ceiling, and the only trace was a `logger.warn` line. That inverts what the flag promises. An operator who marks a key limited gets a key that can spend the purchasing wallet's entire balance, and the admin UI shows it as capped.

The `evmCreditRowCount > 0` probe is gone with it, so the answer no longer depends on what the key holds for unrelated chains.

## Breaking change

Any live key with `usageLimited: true` and no `eip155:` credit rows stops making x402 payments on deploy. Two ways out, both already supported:

- Fund the key for the chain and asset it pays in, through `PATCH /api-key` or the admin API keys dialog.
- Set `usageLimited: false` if the key is meant to be uncapped.

This is the safe direction of the two: the current behaviour lets a key spend without a ceiling.

## Verification

- `pnpm test` on the whole backend: `Test Suites: 294 passed, 1 skipped`, `Tests: 3555 passed, 2 skipped`.
- `pnpm exec tsc --noEmit`: clean.
- `service.spec.ts` had a test asserting the old behaviour. It now asserts the 402, and reverting `pay.ts` makes exactly that test fail (`1 failed, 112 passed`).

## Also in this change

`src/routes/api/api-key/index.ts` keeps a zeroed credit row rather than deleting it. Its comment justified that by the enforcement probe this PR removes, so the comment now states the reason that still holds.

## Follow-up in #801

The admin API keys dialog on #801 tells the operator that x402 is "not capped yet" for a usage-limited key with no EVM credit rows, which is true today and false once this merges. That copy has to flip to "every x402 payment is refused until you fund a chain" in whichever branch lands second. Merging #801 first is safe: it describes the behaviour that still exists. Merging this first leaves #801 claiming a key is uncapped when it is refused.

## Blocked on sokosumi

masumi-network/sokosumi#4040 removes the matching exception in Soko's x402 buy-side readiness, which today lists a pair as payable precisely when this grandfathering applies. That PR must merge and deploy first, or Soko advertises agents that this change then refuses at pay time.

