### PR TITLE
fix(api-keys): refuse a wallet restriction that selects no wallet

### DIFF
--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/lib/constants/defaultWallets';
 import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
 import type { ApiKey, PostApiKeyData } from '@/lib/api/generated';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 interface AddApiKeyDialogProps {
   open: boolean;
@@ -69,6 +70,20 @@ const apiKeySchema = z
     x402WalletScopeIds: z.array(z.string()),
   })
   .superRefine((val, ctx) => {
+    // Create can reach the same deny-all as update: tick the restriction, pick
+    // nothing, save. The key is then born reaching no wallet.
+    const walletScope = walletScopeProblem(val.walletScopeEnabled, val.walletScopeIds);
+    if (walletScope !== undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: walletScope, path: ['walletScopeIds'] });
+    }
+    const x402Scope = walletScopeProblem(val.x402WalletScopeEnabled, val.x402WalletScopeIds);
+    if (x402Scope !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: x402Scope,
+        path: ['x402WalletScopeIds'],
+      });
+    }
     if (
       val.canPay &&
       !val.canAdmin &&
@@ -600,12 +615,10 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                           <Checkbox
                             aria-label="Restrict to specific wallets"
                             checked={field.value}
-                            onCheckedChange={(checked) => {
-                              field.onChange(checked);
-                              if (!checked) {
-                                setValue('walletScopeIds', []);
-                              }
-                            }}
+                            // The selection survives an untick, as in the update
+                            // dialog: clearing it here let a net-zero tick save the
+                            // scope with an empty list, which reaches no wallet.
+                            onCheckedChange={(checked) => field.onChange(checked)}
                           />
                         )}
                       />
@@ -664,10 +677,14 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                           ))
                         )}
                       </div>
-                      {walletScopeIds.length > 0 && (
+                      {walletScopeIds.length > 0 ? (
                         <p className="text-xs text-muted-foreground">
                           {walletScopeIds.length} wallet{walletScopeIds.length !== 1 ? 's' : ''}{' '}
                           selected
+                        </p>
+                      ) : (
+                        <p className="text-xs text-destructive">
+                          {walletScopeProblem(true, walletScopeIds)}
                         </p>
                       )}
                     </div>

--- a/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/UpdateApiKeyDialog.tsx
@@ -39,6 +39,7 @@ import {
   usageCreditDeltas,
   type UpdateApiKeyFormValues,
 } from '@/components/api-keys/update-api-key-form';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 import { Switch } from '@/components/ui/switch';
 
 interface UpdateApiKeyDialogProps {
@@ -594,12 +595,11 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       <Checkbox
                         aria-label="Restrict to specific wallets"
                         checked={field.value}
-                        onCheckedChange={(checked) => {
-                          field.onChange(checked);
-                          if (!checked) {
-                            setValue('walletScopeIds', []);
-                          }
-                        }}
+                        // The selection survives an untick. Clearing it here made
+                        // untick-then-retick, a net-zero action on screen, save
+                        // walletScopeEnabled with an empty list: a deny-all key.
+                        // Submit already sends [] while the box is off.
+                        onCheckedChange={(checked) => field.onChange(checked)}
                       />
                     )}
                   />
@@ -655,10 +655,17 @@ export function UpdateApiKeyDialog({ open, onClose, onSuccess, apiKey }: UpdateA
                       ))
                     )}
                   </div>
-                  {walletScopeIds.length > 0 && (
+                  {walletScopeIds.length > 0 ? (
                     <p className="text-xs text-muted-foreground">
                       {walletScopeIds.length} wallet{walletScopeIds.length !== 1 ? 's' : ''}{' '}
                       selected
+                    </p>
+                  ) : (
+                    // Shown from the watched value, like the credits rule, so the reason
+                    // Update is blocked is on screen. Nothing named this state before: the
+                    // count line hid itself at zero, so a deny-all read as a tidy list.
+                    <p className="text-xs text-destructive">
+                      {walletScopeProblem(true, walletScopeIds)}
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/api-keys/X402WalletScopeField.tsx
+++ b/frontend/src/components/api-keys/X402WalletScopeField.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { useX402Wallets } from '@/lib/hooks/useX402';
 import { shortenAddress } from '@/lib/utils';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 interface X402WalletScopeFieldProps {
   /** Whether this key is restricted to the selected managed EVM wallets. */
@@ -41,13 +42,11 @@ export function X402WalletScopeField({
           <Checkbox
             aria-label="Restrict to specific EVM wallets"
             checked={enabled}
-            onCheckedChange={(checked) => {
-              const next = checked === true;
-              onEnabledChange(next);
-              if (!next) {
-                onSelectedIdsChange([]);
-              }
-            }}
+            // The selection survives an untick. Clearing it here made
+            // untick-then-retick, a net-zero action on screen, save the scope
+            // with an empty list, which reaches no wallet at all. Both dialogs
+            // already send [] while the box is off.
+            onCheckedChange={(checked) => onEnabledChange(checked === true)}
           />
           <label className="text-sm font-medium">Restrict to specific EVM wallets</label>
         </div>
@@ -102,10 +101,15 @@ export function X402WalletScopeField({
               ))
             )}
           </div>
-          {selectedIds.length > 0 && (
+          {selectedIds.length > 0 ? (
             <p className="text-xs text-muted-foreground">
               {selectedIds.length} wallet{selectedIds.length !== 1 ? 's' : ''} selected
             </p>
+          ) : (
+            // In the field, not the dialogs: both of them render this picker, and
+            // the state it names is one neither could see, because the count line
+            // hid itself at zero.
+            <p className="text-xs text-destructive">{walletScopeProblem(true, selectedIds)}</p>
           )}
         </div>
       )}

--- a/frontend/src/components/api-keys/update-api-key-form.test.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.test.ts
@@ -78,3 +78,50 @@ test('an unlimited key skips credit validation and sends no deltas', () => {
   assert.equal(result.success, true);
   assert.deepEqual(usageCreditDeltas(false, current, invalidRows), []);
 });
+
+test('an enabled wallet restriction with nothing selected fails validation', () => {
+  // The deny-all state. The middleware reads an enabled flag with no rows as `[]`,
+  // and only `null` means unrestricted, so the key reaches no wallet at all.
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error?.issues[0]?.message ?? '', /at least one wallet/);
+  assert.deepEqual(result.error?.issues[0]?.path, ['walletScopeIds']);
+});
+
+test('an enabled x402 wallet restriction with nothing selected fails validation', () => {
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    x402WalletScopeEnabled: true,
+    x402WalletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error?.issues[0]?.path, ['x402WalletScopeIds']);
+});
+
+test('the wallet restriction is checked on an unlimited key too', () => {
+  // The rule sits above the `!usageLimited` early return on purpose. Below it, an
+  // uncapped key could still be saved reaching no wallet, which is the whole bug.
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: [],
+  });
+
+  assert.equal(result.success, false);
+});
+
+test('a wallet restriction that names a wallet passes', () => {
+  const result = buildUpdateApiKeySchema([]).safeParse({
+    ...values(false, []),
+    walletScopeEnabled: true,
+    walletScopeIds: ['wallet-1'],
+  });
+
+  assert.equal(result.success, true);
+});

--- a/frontend/src/components/api-keys/update-api-key-form.ts
+++ b/frontend/src/components/api-keys/update-api-key-form.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { convertDecimalToBaseUnits } from '@/lib/convertDecimalToBaseUnits';
 import { creditDeltas, creditRowProblem } from '@/lib/api-key-credit-units';
+import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
 
 /** Mirrors updateAPIKeySchemaInput.UsageCreditsToAddOrRemove.max(25). */
 export const MAX_USAGE_CREDIT_DELTAS = 25;
@@ -44,6 +45,24 @@ export function buildUpdateApiKeySchema(currentCredits: StoredCredit[]) {
       evmChains: z.array(z.string()),
     })
     .superRefine((value, context) => {
+      // Wallet scope first: it is checked for every key, capped or not, so it has to
+      // sit above the uncapped early return below.
+      const walletScope = walletScopeProblem(value.walletScopeEnabled, value.walletScopeIds);
+      if (walletScope !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: walletScope,
+          path: ['walletScopeIds'],
+        });
+      }
+      const x402Scope = walletScopeProblem(value.x402WalletScopeEnabled, value.x402WalletScopeIds);
+      if (x402Scope !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: x402Scope,
+          path: ['x402WalletScopeIds'],
+        });
+      }
       // An unlimited key ignores stored credits and sends no credit deltas.
       if (!value.usageLimited) return;
 

--- a/frontend/src/components/api-keys/wallet-scope.helpers.test.ts
+++ b/frontend/src/components/api-keys/wallet-scope.helpers.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { walletScopeProblem } from './wallet-scope.helpers';
+
+test('walletScopeProblem refuses an enabled restriction with nothing selected', () => {
+  // The deny-all state. The middleware reads an enabled flag with no rows as
+  // `[]`, not `null`, and only `null` means unrestricted, so the key reaches no
+  // wallet at all. Reachable by unticking the box and ticking it again, which
+  // clears the list and leaves the checkbox exactly where it started.
+  assert.match(walletScopeProblem(true, []) ?? '', /at least one wallet/);
+});
+
+test('walletScopeProblem allows an enabled restriction that names a wallet', () => {
+  assert.equal(walletScopeProblem(true, ['wallet-1']), undefined);
+});
+
+test('walletScopeProblem allows a disabled restriction with an empty list', () => {
+  // Unrestricted is the ordinary state for a key that never scoped anything,
+  // and submit sends an empty list for it on purpose.
+  assert.equal(walletScopeProblem(false, []), undefined);
+});
+
+test('walletScopeProblem ignores a stale list while the restriction is off', () => {
+  // The dialogs keep the previous selection in form state while the box is
+  // unticked, so re-ticking restores it instead of silently saving a deny-all.
+  // That list must not make a disabled scope look like a problem.
+  assert.equal(walletScopeProblem(false, ['wallet-1']), undefined);
+});

--- a/frontend/src/components/api-keys/wallet-scope.helpers.ts
+++ b/frontend/src/components/api-keys/wallet-scope.helpers.ts
@@ -1,0 +1,22 @@
+/**
+ * Why a wallet scope cannot be saved, or undefined when it can.
+ *
+ * "Restrict to specific wallets" with nothing selected is not a narrow scope,
+ * it is a deny-all. The middleware maps an enabled flag with no rows to `[]`
+ * rather than `null`, and `null` is the value that means unrestricted, so
+ * `buildHotWalletScopeFilter` turns it into `{ id: { in: [] } }`: a filter no
+ * wallet matches. The key then reaches none of them, which is a state no
+ * operator picks on purpose and nothing on screen names.
+ *
+ * Shared by the create and update dialogs, and by both scopes, so the rule and
+ * its wording cannot drift between the four places that need it.
+ */
+export function walletScopeProblem(
+  enabled: boolean,
+  selectedIds: readonly string[],
+): string | undefined {
+  if (enabled && selectedIds.length === 0) {
+    return 'Select at least one wallet, or turn the restriction off. An empty restriction blocks every wallet.';
+  }
+  return undefined;
+}


### PR DESCRIPTION
Stacked on #801, which rewrites `UpdateApiKeyDialog.tsx`. Basing this on `dev` instead would conflict with that rewrite.

## The bug

Open a non-admin key that has "Restrict to specific wallets" ticked with one wallet chosen. Untick the box. Tick it again. The checkbox ends exactly where it started. Click Update.

The request carries `walletScopeEnabled: true` with `WalletScopeHotWalletIds: []`. The server deletes every scope row and creates none. The middleware then maps an enabled flag with no rows to `[]`, not `null`, and only `null` means unrestricted:

```ts
const walletScopeIds =
  apiKey.canAdmin || !apiKey.walletScopeEnabled ? null : apiKey.WalletScopes.map((ws) => ws.hotWalletId);
```

`buildHotWalletScopeFilter([])` returns `{ id: { in: [] } }`, a filter no wallet matches. That filter is ANDed into `fund-wallet`, `payment-source-extended`, and `wallet/low-balance`, so the key reaches no wallet at all.

Nothing on screen named the state: the "N wallets selected" line hid itself at zero, so a deny-all looked like a tidy empty list.

The same state was reachable at creation, by ticking the restriction and saving without picking anything. Both scopes had it, Cardano and EVM.

## The fix

- The selection survives an untick. Submit already sends `[]` while the box is off, so clearing form state bought nothing and cost this bug.
- A resolver rule refuses enabled-with-nothing-selected, in both dialogs and for both scopes. It sits above the uncapped early return, so it runs for every key rather than only usage-limited ones.
- The message renders from the watched value where the count line used to hide, so Update never looks dead.

One helper, `walletScopeProblem`, carries the rule and its wording for all four call sites.

## Verification

Browser, against the local node, on the built frontend:

- Ticking the restriction with nothing selected shows "Select at least one wallet, or turn the restriction off. An empty restriction blocks every wallet."
- Update with that state issues no PATCH. Only GETs appear in the network log and the dialog stays open.
- Select a wallet, untick, re-tick: still "1 wallet selected", with the wallet still checked. Before the fix this produced an empty list.

Automated:

- `pnpm --filter frontend test`: 106 pass, 0 fail, including 4 new cases for the helper.
- Both mutations caught: dropping the rule fails 1 test, dropping the `enabled` guard fails a different one.
- `tsc --noEmit` clean, eslint clean, `npm run build` exit 0.

## Not fixed here

The server accepts `walletScopeEnabled: true` with an empty list and writes the deny-all. This PR closes the UI route to it; the API route stays open. That belongs in a separate change, next to the decision about whether the endpoint should reject it or treat it as unrestricted.
