### PR TITLE
fix(api-keys): apply a credit delta across every row for the unit

### DIFF
--- a/src/routes/api/api-key/credit-units.spec.ts
+++ b/src/routes/api/api-key/credit-units.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { consolidateUsageCredits, findNonCanonicalEvmCreditUnit, normalizeCreditUnit } from './credit-units';
+import {
+	consolidateUsageCredits,
+	findNonCanonicalEvmCreditUnit,
+	normalizeCreditUnit,
+	planCreditDelta,
+} from './credit-units';
 
 describe('normalizeCreditUnit', () => {
 	it('lowercases a checksummed EVM chain-qualified unit', () => {
@@ -103,5 +108,112 @@ describe('consolidateUsageCredits', () => {
 
 	it('throws on a negative amount', () => {
 		expect(() => consolidateUsageCredits([{ unit: 'lovelace', amount: -1n }])).toThrow('Invalid amount');
+	});
+});
+
+describe('planCreditDelta', () => {
+	it('spends a balance split across duplicate rows', () => {
+		// The reported bug. 5 ADA + 3 ADA shows as 8, so lowering it to 1 sends -7.
+		// Resolving the first row alone took 5 to -2 and 400'd the whole PATCH for an
+		// edit the balance covers twice over.
+		const plan = planCreditDelta(
+			[
+				{ id: 'a', unit: '', amount: 5_000_000n },
+				{ id: 'b', unit: '', amount: 3_000_000n },
+			],
+			'',
+			-7_000_000n,
+		);
+		expect(plan).toEqual({ updateId: 'a', deleteIds: ['b'], amount: 1_000_000n });
+	});
+
+	it('folds a checksummed row into the canonical one it duplicates', () => {
+		// Both rows are the same ERC-20 to the debit path, which looks the unit up
+		// lowercased. Removing the 3 the stale row holds used to land on whichever row
+		// matched first, taking it off the live balance and leaving the stale row.
+		const canonical = 'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+		const plan = planCreditDelta(
+			[
+				{ id: 'live', unit: canonical, amount: 5_000_000n },
+				{ id: 'stale', unit: 'eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', amount: 3_000_000n },
+			],
+			canonical,
+			-3_000_000n,
+		);
+		expect(plan).toEqual({ updateId: 'live', deleteIds: ['stale'], amount: 5_000_000n });
+	});
+
+	it('matches a checksummed EVM row from the canonical unit', () => {
+		const plan = planCreditDelta(
+			[{ id: 'a', unit: 'eip155:8453:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', amount: 10n }],
+			'eip155:8453:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+			5n,
+		);
+		expect(plan).toEqual({ updateId: 'a', deleteIds: [], amount: 15n });
+	});
+
+	it('keeps a row that the delta zeroes', () => {
+		// A zeroed row is the record that the key is capped on that unit. Deleting it
+		// would read as "never capped" and lose the unit the operator would retype.
+		expect(planCreditDelta([{ id: 'a', unit: '', amount: 7n }], '', -7n)).toEqual({
+			updateId: 'a',
+			deleteIds: [],
+			amount: 0n,
+		});
+	});
+
+	it('consolidates duplicates even when the delta does not move the balance', () => {
+		// Reached by topping one unit up and back down in the same submit. The rows
+		// still need folding, otherwise the next edit hits the same split balance.
+		expect(
+			planCreditDelta(
+				[
+					{ id: 'a', unit: '', amount: 4n },
+					{ id: 'b', unit: '', amount: 6n },
+				],
+				'',
+				0n,
+			),
+		).toEqual({ updateId: 'a', deleteIds: ['b'], amount: 10n });
+	});
+
+	it('refuses an overdraw against the summed balance', () => {
+		expect(
+			planCreditDelta(
+				[
+					{ id: 'a', unit: '', amount: 5n },
+					{ id: 'b', unit: '', amount: 3n },
+				],
+				'',
+				-9n,
+			),
+		).toBeNull();
+	});
+
+	it('creates a row for a positive delta on an unfunded unit', () => {
+		expect(planCreditDelta([{ id: 'a', unit: '', amount: 5n }], 'other', 12n)).toEqual({
+			updateId: null,
+			deleteIds: [],
+			amount: 12n,
+		});
+	});
+
+	it('refuses a non-positive delta on an unfunded unit', () => {
+		// Nothing to remove from, and a zero grant is made through UsageCredits on
+		// create, not through a no-op delta here.
+		expect(planCreditDelta([], 'other', 0n)).toBeNull();
+		expect(planCreditDelta([], 'other', -1n)).toBeNull();
+	});
+
+	it('leaves rows for other units alone', () => {
+		const plan = planCreditDelta(
+			[
+				{ id: 'ada', unit: '', amount: 5n },
+				{ id: 'usdm', unit: 'c48cbb', amount: 9n },
+			],
+			'',
+			1n,
+		);
+		expect(plan).toEqual({ updateId: 'ada', deleteIds: [], amount: 6n });
 	});
 });

--- a/src/routes/api/api-key/credit-units.ts
+++ b/src/routes/api/api-key/credit-units.ts
@@ -64,3 +64,53 @@ export function consolidateUsageCredits(
 	}
 	return Array.from(byUnit.entries()).map(([unit, amount]) => ({ unit, amount }));
 }
+
+/** The ledger writes one unit's delta needs. `updateId` null means create a new row. */
+export interface CreditDeltaPlan {
+	updateId: string | null;
+	/** Duplicate rows for the same unit, folded into `updateId`. Delete them. */
+	deleteIds: string[];
+	/** The unit's balance after the delta. */
+	amount: bigint;
+}
+
+/**
+ * Plan the ledger writes for one unit's delta, across EVERY row that carries it.
+ *
+ * The ledger has no unique index on (apiKeyId, unit), so a key can hold several rows
+ * for one asset: two rows created before the write paths consolidated, or a stale
+ * checksummed row beside the canonical lowercase one. Every reader sums them, because
+ * the dashboard shows one balance per unit and the x402 debit folds duplicates before
+ * it charges. Resolving a single row here left the update path the only one that did
+ * not.
+ *
+ * The visible failure was an edit that could not be saved. 5 ADA + 3 ADA reads as 8,
+ * so lowering it to 1 sends -7, and applying that to the first row alone takes 5 to
+ * -2: a 400 that rolls back the whole PATCH, for an edit the balance covers twice
+ * over. Removing a duplicate was worse than useless: the delta landed on whichever
+ * row matched first, so clearing a stale row could take its balance off the live row
+ * instead and leave the stale one standing.
+ *
+ * Folding onto the first row also repairs the duplicates, the same way
+ * `runPurchaseCreditInitTransaction` and the x402 debit already do, so a key stops
+ * carrying them after the first edit. No guard is needed on the read: the caller runs
+ * inside the Serializable transaction that read these rows.
+ *
+ * Returns null when the delta is not applicable — it would take the unit below zero,
+ * or it is a non-positive delta for a unit the key holds no row for.
+ */
+export function planCreditDelta(
+	rows: ReadonlyArray<{ id: string; unit: string; amount: bigint }>,
+	unit: string,
+	delta: bigint,
+): CreditDeltaPlan | null {
+	const matching = rows.filter((row) => normalizeCreditUnit(row.unit) === unit);
+	if (matching.length === 0) {
+		return delta > 0n ? { updateId: null, deleteIds: [], amount: delta } : null;
+	}
+	const amount = matching.reduce((total, row) => total + row.amount, 0n) + delta;
+	if (amount < 0n) {
+		return null;
+	}
+	return { updateId: matching[0].id, deleteIds: matching.slice(1).map((row) => row.id), amount };
+}

--- a/src/routes/api/api-key/index.ts
+++ b/src/routes/api/api-key/index.ts
@@ -28,7 +28,12 @@ import {
 	updateAPIKeySchemaInput,
 	updateAPIKeySchemaOutput,
 } from './schemas';
-import { consolidateUsageCredits, findNonCanonicalEvmCreditUnit, normalizeCreditUnit } from './credit-units';
+import {
+	consolidateUsageCredits,
+	findNonCanonicalEvmCreditUnit,
+	normalizeCreditUnit,
+	planCreditDelta,
+} from './credit-units';
 import {
 	computePermissionFromFlags,
 	flagsFromLegacyPermission,
@@ -413,13 +418,18 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 							deltasByUnit.set(unit, (deltasByUnit.get(unit) ?? 0n) + BigInt(usageCredit.amount));
 						}
 						for (const [unit, delta] of deltasByUnit) {
-							const existingCredit = apiKey.RemainingUsageCredits.find(
-								(credit) => normalizeCreditUnit(credit.unit) == unit,
-							);
-							if (existingCredit) {
-								const nextAmount = existingCredit.amount + delta;
-								if (nextAmount < 0n) {
-									throw createHttpError(400, 'Invalid amount');
+							// Applied across EVERY row carrying the unit, not just the first one
+							// found. Duplicate rows read as a single balance everywhere else, so
+							// resolving one row here refused edits the real balance covered and let
+							// a removal land on the wrong row.
+							const plan = planCreditDelta(apiKey.RemainingUsageCredits, unit, delta);
+							if (plan === null) {
+								throw createHttpError(400, 'Invalid amount');
+							}
+							if (plan.updateId !== null) {
+								// Fold the duplicates away first, so the unit is left on one row.
+								if (plan.deleteIds.length > 0) {
+									await prisma.unitValue.deleteMany({ where: { id: { in: plan.deleteIds } } });
 								}
 								// A zeroed row is KEPT, not deleted: it is the record that this key
 								// is capped on that chain and asset, and the operator can top it up
@@ -429,17 +439,14 @@ export const updateAPIKeyEndpointPatch = adminAuthenticatedEndpointFactory.build
 								// zeroed allowances is easier to reason about than one that hides
 								// them.
 								await prisma.unitValue.update({
-									where: { id: existingCredit.id },
-									data: { amount: nextAmount, unit },
+									where: { id: plan.updateId },
+									data: { amount: plan.amount, unit },
 								});
 							} else {
-								if (delta <= 0n) {
-									throw createHttpError(400, 'Invalid amount');
-								}
 								await prisma.unitValue.create({
 									data: {
 										unit,
-										amount: delta,
+										amount: plan.amount,
 										apiKeyId: apiKey.id,
 										agentFixedPricingId: null,
 										paymentRequestId: null,


### PR DESCRIPTION
## What

`PATCH /api-key` resolved a single ledger row per unit with `.find` and applied the whole delta to it. The ledger has no unique index on `(apiKeyId, unit)`, so a key can hold several rows for one asset.

Every other reader already sums them. The dashboard shows one balance per unit, and the x402 debit folds duplicates before it charges. The update path was the only place that did not.

## User-facing impact

A balance held as 5 ADA + 3 ADA reads as 8 in the dialog. Lowering it to 1 sends a delta of -7, which landed on the first row alone and took 5 to -2: a `400 Invalid amount` that rolls back the entire PATCH, for an edit the balance covers twice over.

Clearing a duplicate was worse. The delta landed on whichever row matched first, so it could take the stale row's balance off the live row and leave the stale row standing.

## How

`planCreditDelta` sums every row whose normalized unit matches, checks the result against zero, and folds the duplicates onto the row it keeps. A key stops carrying duplicates after the first edit, which is the same repair `runPurchaseCreditInitTransaction` and the x402 debit already perform.

No optimistic guard is needed. The caller runs inside the Serializable transaction that read these rows.

## Verification

- `npx jest src/routes/api/api-key/` — 26 passed, 26 total (8 new).
- Mutation check: restoring the single-row behaviour (`.slice(0, 1)` on the match) fails 3 of the 26. The tests cover the fix rather than the shape of the code.
- `npx tsc --noEmit` — exit 0.
- `pnpm run lint:backend` — exit 0.
- `prettier --check` on the touched files — clean.

## Not in this PR

The dialog groups its rows on the raw unit, so a legacy `lovelace` row still displays beside the canonical ADA row. That file does not exist on `dev` yet; the fix belongs in the branch that introduces it.