### PR TITLE
perf(e2e): run flow files in parallel and trim scheduler intervals

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,6 +178,15 @@ jobs:
           DATABASE_URL: '${{ steps.create-branch.outputs.connection_uri }}'
           PURCHASE_WALLET_PREPROD_MNEMONIC: '${{ secrets.PURCHASE_WALLET_PREPROD_MNEMONIC }}'
           SELLING_WALLET_PREPROD_MNEMONIC: '${{ secrets.SELLING_WALLET_PREPROD_MNEMONIC }}'
+          # Optional extra selling wallets. globalSetup registers one agent per
+          # selling wallet, so each of these gives one more V1 flow file its own
+          # wallet instead of queueing behind the first (V1 processes one request
+          # per hot wallet per scheduler tick). Unset secrets arrive as empty
+          # strings and the seed skips them, which is the single-wallet default.
+          # Each mnemonic must be a distinct, FUNDED preprod wallet: an unfunded
+          # one still gets picked and stalls its flow.
+          SELLING_WALLET_PREPROD_MNEMONIC_2: '${{ secrets.SELLING_WALLET_PREPROD_MNEMONIC_2 }}'
+          SELLING_WALLET_PREPROD_MNEMONIC_3: '${{ secrets.SELLING_WALLET_PREPROD_MNEMONIC_3 }}'
           # V2 mnemonics MUST be distinct from V1 mnemonics: HotWallet.walletVkey
           # is globally unique, so reusing V1 mnemonics would derive the same
           # vkeys and the V2 seed INSERT would fail with P2002
@@ -226,6 +235,28 @@ jobs:
           ENCRYPTION_KEY: '${{ secrets.ENCRYPTION_KEY }}'
           NODE_ENV: 'test'
           PORT: 3001
+          # Scheduler cadence. Without these the e2e server runs the production
+          # defaults (30s batching, 20s tx-sync, 15s for most actions), and every
+          # on-chain hop in a flow pays that latency twice: once for the action
+          # job that builds the tx and once for the tx-sync pass that observes
+          # it, plus a wallet-unlock tick before the next action on that wallet.
+          # 5 is the floor `parseNumberEnv` enforces in
+          # packages/payment-core/src/config.ts; CHECK_TX_INTERVAL's floor is 15.
+          # Preprod block time still dominates, so this trims minutes, not hops.
+          BATCH_PAYMENT_INTERVAL: 5
+          CHECK_TX_INTERVAL: 15
+          CHECK_COLLECTION_INTERVAL: 5
+          CHECK_COLLECT_REFUND_INTERVAL: 5
+          CHECK_SET_REFUND_INTERVAL: 5
+          CHECK_UNSET_REFUND_INTERVAL: 5
+          CHECK_WALLET_TRANSACTION_HASH_INTERVAL: 5
+          CHECK_AUTHORIZE_REFUND_INTERVAL: 5
+          CHECK_AUTHORIZE_WITHDRAWAL_INTERVAL: 5
+          CHECK_SUBMIT_RESULT_INTERVAL: 5
+          REGISTER_AGENT_INTERVAL: 5
+          DEREGISTER_AGENT_INTERVAL: 5
+          CHECK_REGISTRY_TRANSACTIONS_INTERVAL: 5
+          AUTO_DECISION_INTERVAL: 5
 
       - name: Wait for Server Ready
         run: |
@@ -317,6 +348,12 @@ jobs:
           TEST_API_URL: http://127.0.0.1:3001
           TEST_NETWORK: Preprod
           TEST_TIMEOUT_REGISTRATION: 1800000
+          # Agents (and therefore selling wallets) per payment source. Keep this
+          # in step with the SELLING_WALLET_PREPROD_MNEMONIC_* secrets set on the
+          # seed step above: asking for more agents than there are seeded wallets
+          # only logs a warning and shares wallets, but every wallet it does use
+          # must be funded. Default 1 = one agent per source, shared by all flows.
+          E2E_AGENTS_PER_SOURCE: 1
           DATABASE_URL: ${{ steps.create-branch.outputs.connection_uri }}
           BLOCKFROST_API_KEY_PREPROD: ${{ secrets.BLOCKFROST_API_KEY_PREPROD }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -235,28 +235,32 @@ jobs:
           ENCRYPTION_KEY: '${{ secrets.ENCRYPTION_KEY }}'
           NODE_ENV: 'test'
           PORT: 3001
-          # Scheduler cadence. Without these the e2e server runs the production
-          # defaults (30s batching, 20s tx-sync, 15s for most actions), and every
-          # on-chain hop in a flow pays that latency twice: once for the action
-          # job that builds the tx and once for the tx-sync pass that observes
-          # it, plus a wallet-unlock tick before the next action on that wallet.
-          # 5 is the floor `parseNumberEnv` enforces in
-          # packages/payment-core/src/config.ts; CHECK_TX_INTERVAL's floor is 15.
+          # Scheduler cadence. The production defaults (30s batching, 20s
+          # tx-sync, 15s for most actions) make every on-chain hop pay that
+          # latency twice: once for the action job that builds the tx and once
+          # for the tx-sync pass that observes it, plus a wallet-unlock tick
+          # before the next action on the same wallet.
+          #
+          # Only the jobs on the flow's critical path are shortened, and only to
+          # 10s. Running every job at its 5s floor (run 33393794038) put the API
+          # server at 17.5 scheduler job-seconds per wall second against 3.0 on
+          # the previous run, because a single job takes 1-6s and they all
+          # overlap on one event loop. Request latency followed: POST /purchase
+          # went from a 4.7s median to 21.5s, and one call passed the e2e
+          # client's timeout and failed a flow. The collection, withdrawal and
+          # auto-decision jobs are left at their defaults; no flow waits on them.
+          #
           # Preprod block time still dominates, so this trims minutes, not hops.
-          BATCH_PAYMENT_INTERVAL: 5
+          BATCH_PAYMENT_INTERVAL: 10
           CHECK_TX_INTERVAL: 15
-          CHECK_COLLECTION_INTERVAL: 5
-          CHECK_COLLECT_REFUND_INTERVAL: 5
-          CHECK_SET_REFUND_INTERVAL: 5
-          CHECK_UNSET_REFUND_INTERVAL: 5
-          CHECK_WALLET_TRANSACTION_HASH_INTERVAL: 5
-          CHECK_AUTHORIZE_REFUND_INTERVAL: 5
-          CHECK_AUTHORIZE_WITHDRAWAL_INTERVAL: 5
-          CHECK_SUBMIT_RESULT_INTERVAL: 5
-          REGISTER_AGENT_INTERVAL: 5
-          DEREGISTER_AGENT_INTERVAL: 5
-          CHECK_REGISTRY_TRANSACTIONS_INTERVAL: 5
-          AUTO_DECISION_INTERVAL: 5
+          CHECK_SET_REFUND_INTERVAL: 10
+          CHECK_UNSET_REFUND_INTERVAL: 10
+          CHECK_WALLET_TRANSACTION_HASH_INTERVAL: 10
+          CHECK_AUTHORIZE_REFUND_INTERVAL: 10
+          CHECK_SUBMIT_RESULT_INTERVAL: 10
+          REGISTER_AGENT_INTERVAL: 10
+          DEREGISTER_AGENT_INTERVAL: 10
+          CHECK_REGISTRY_TRANSACTIONS_INTERVAL: 10
 
       - name: Wait for Server Ready
         run: |
@@ -348,6 +352,12 @@ jobs:
           TEST_API_URL: http://127.0.0.1:3001
           TEST_NETWORK: Preprod
           TEST_TIMEOUT_REGISTRATION: 1800000
+          # Per-HTTP-request timeout, up from the 30s default. POST /payment and
+          # POST /purchase are CPU-heavy and share one event loop with the
+          # schedulers, so concurrent flows stretch them: run 33393794038
+          # measured a 21.5s median for POST /purchase and lost a flow to the
+          # 30s abort. These tests assert business flow, not latency.
+          TEST_TIMEOUT_API: 120000
           # Agents (and therefore selling wallets) per payment source. Keep this
           # in step with the SELLING_WALLET_PREPROD_MNEMONIC_* secrets set on the
           # seed step above: asking for more agents than there are seeded wallets

--- a/jest.e2e.config.ts
+++ b/jest.e2e.config.ts
@@ -31,6 +31,20 @@ const testMatch = process.env.TEST_PAYMENT_SOURCE_TYPE
 	? (sourceScopedTestMatches[process.env.TEST_PAYMENT_SOURCE_TYPE] ?? allE2ETestMatches)
 	: allE2ETestMatches;
 
+// One worker per V1 flow file, which is the largest set a single Jest
+// invocation discovers today. Overridable with E2E_MAX_WORKERS.
+const DEFAULT_E2E_MAX_WORKERS = 3;
+
+function parseMaxWorkers(): number {
+	const raw = process.env.E2E_MAX_WORKERS;
+	if (raw == null || raw.trim() === '') return DEFAULT_E2E_MAX_WORKERS;
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		throw new Error(`E2E_MAX_WORKERS must be a positive integer, got "${raw}"`);
+	}
+	return parsed;
+}
+
 const config: Config.InitialOptions = {
 	preset: 'ts-jest/presets/default-esm',
 	displayName: 'E2E',
@@ -51,11 +65,22 @@ const config: Config.InitialOptions = {
 	setupFilesAfterEnv: ['<rootDir>/jest.setup.libsodium.ts', '<rootDir>/tests/e2e/setup/testEnvironment.ts'],
 	// Per-test timeout (applies to each `test(...)` and async hooks in test files)
 	testTimeout: 1_200_000, // 20 minutes
-	// Sequential workers: the V2 source-isolation suite mutates
-	// `global.testConfig.paymentSourceType` and the describe.each blocks in the
-	// shared flow tests do the same. Running in parallel would cause cross-file
-	// races on that shared global.
-	maxWorkers: 1,
+	// Concurrent test files. Suites mutate `global.testConfig.paymentSourceType`
+	// and `global.testAgent`, but that cannot race across files: Jest gives every
+	// test file its own module registry and its own `global`, and worker
+	// processes inherit `process.env` at fork time, so globalSetup's agent state
+	// still reaches them.
+	//
+	// What still serializes is on chain. V1 takes one request per hot wallet per
+	// scheduler tick and keeps the wallet locked until its transaction confirms,
+	// so flows sharing a wallet pipeline instead of running fully in parallel.
+	// Seed one selling wallet per flow to remove that half (see
+	// tests/e2e/README.md > Parallel flows).
+	//
+	// Set E2E_MAX_WORKERS=1 to go back to serial, live-streamed logs: a worker
+	// buffers its console output until the test file finishes, which hides
+	// progress while a long on-chain wait is in flight.
+	maxWorkers: parseMaxWorkers(),
 	collectCoverageFrom: ['src/**/*.ts', '!src/**/*.spec.ts', '!src/**/*.test.ts'],
 };
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -45,6 +45,25 @@ function requireMnemonic(mnemonic: string | undefined, envName: string): string 
 	return mnemonic;
 }
 
+/**
+ * Read the optional numbered siblings of a wallet mnemonic env var, e.g.
+ * `SELLING_WALLET_PREPROD_MNEMONIC_2`, `..._3`, stopping at the first gap.
+ *
+ * Opt-in on purpose, and never brewed: an extra hot wallet that nobody funded
+ * still gets picked by the batch services, so seeding one without a mnemonic
+ * would stall real work. Absent env means the source keeps exactly the wallets
+ * it had before.
+ */
+function readExtraMnemonics(baseEnvName: string): string[] {
+	const mnemonics: string[] = [];
+	for (let index = 2; ; index++) {
+		const raw = process.env[`${baseEnvName}_${index}`];
+		if (raw == null || raw.trim() === '') break;
+		mnemonics.push(raw.trim());
+	}
+	return mnemonics;
+}
+
 async function queryLatestTxHash(blockfrostApiKey: string, smartContractAddress: string, networkLabel: string) {
 	const blockfrostApi = new BlockFrostAPI({
 		projectId: blockfrostApiKey,
@@ -260,6 +279,25 @@ export const seed = async (prisma: PrismaClient) => {
 				// secrets table and complicating manual recovery.
 				const purchasingUnusedAddress = (await purchasingWallet.getUnusedAddresses())[0];
 				const sellingUnusedAddress = (await sellingWallet.getUnusedAddresses())[0];
+				// Extra selling wallets, Preprod only. The e2e suite registers one
+				// agent per selling wallet so its concurrent flows stop queueing
+				// behind a single wallet (V1 processes one request per hot wallet
+				// per scheduler tick). Each extra mnemonic must be funded.
+				const extraSellingPreprod = await Promise.all(
+					readExtraMnemonics('SELLING_WALLET_PREPROD_MNEMONIC').map(async (mnemonic) => {
+						const wallet = new MeshWallet({
+							networkId: 0,
+							key: { type: 'mnemonic', words: mnemonic.split(' ') },
+						});
+						return {
+							address: (await wallet.getUnusedAddresses())[0],
+							encryptedMnemonic: encrypt(mnemonic),
+						};
+					}),
+				);
+				if (extraSellingPreprod.length > 0) {
+					console.log(`Seeding ${extraSellingPreprod.length} extra Preprod selling wallet(s) from env.`);
+				}
 				await prisma.$transaction(async (tx) => {
 					const purchasingWalletSecretId = await tx.walletSecret.create({
 						data: { encryptedMnemonic: purchasingWalletSecret },
@@ -267,6 +305,20 @@ export const seed = async (prisma: PrismaClient) => {
 					const sellingWalletSecretId = await tx.walletSecret.create({
 						data: { encryptedMnemonic: sellingWalletSecret },
 					});
+					const extraSellingWallets = [];
+					for (const extra of extraSellingPreprod) {
+						const secret = await tx.walletSecret.create({
+							data: { encryptedMnemonic: extra.encryptedMnemonic },
+						});
+						extraSellingWallets.push({
+							walletVkey: resolvePaymentKeyHash(extra.address),
+							walletAddress: extra.address,
+							note: 'Created by seeding (extra selling wallet)',
+							type: HotWalletType.Selling,
+							secretId: secret.id,
+							collectionAddress: collectionWalletPreprodAddress,
+						});
+					}
 					await tx.paymentSource.create({
 						data: {
 							smartContractAddress: smartContractAddress,
@@ -312,6 +364,7 @@ export const seed = async (prisma: PrismaClient) => {
 											secretId: sellingWalletSecretId.id,
 											collectionAddress: collectionWalletPreprodAddress,
 										},
+										...extraSellingWallets,
 									],
 								},
 							},

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -95,6 +95,11 @@ Set `E2E_MAX_WORKERS=1` to run the files one after another. Do that when you are
 debugging a stuck run: a worker buffers its console output until its test file
 finishes, so live progress is hidden while a long on-chain wait is in flight.
 
+Concurrent flows also make the API server slower to answer. `POST /payment` and
+`POST /purchase` are CPU-heavy and share one event loop with the schedulers, so
+three at once stretch a ~5s call past 20s. Raise `TEST_TIMEOUT_API` (CI uses
+`120000`) instead of accepting the 30s default, or requests abort mid-flow.
+
 ### One selling wallet per flow (optional)
 
 What still serializes is on chain. V1 takes one request per hot wallet per

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -83,6 +83,69 @@ pnpm run test:e2e:v1
 pnpm run test:e2e:v2
 ```
 
+## Parallel flows
+
+Flow files run concurrently. `maxWorkers` in `jest.e2e.config.ts` defaults to 3,
+one per V1 flow file. Nothing in the suite shares state across files: Jest gives
+each test file its own module registry and its own `global`, and worker
+processes inherit `process.env`, so the agents that `globalSetup` registered
+still reach them.
+
+Set `E2E_MAX_WORKERS=1` to run the files one after another. Do that when you are
+debugging a stuck run: a worker buffers its console output until its test file
+finishes, so live progress is hidden while a long on-chain wait is in flight.
+
+### One selling wallet per flow (optional)
+
+What still serializes is on chain. V1 takes one request per hot wallet per
+scheduler tick and keeps the wallet locked until the transaction confirms, so
+concurrent flows that share a wallet pipeline instead of overlapping.
+
+`globalSetup` registers `E2E_AGENTS_PER_SOURCE` agents per payment source, each
+bound to its own selling hot wallet, and each flow file claims an agent slot
+(`AGENT_SLOT` in the file, resolved by `pickAgentForSlot`). The default is 1:
+one agent shared by every flow, which is how the flows behaved when they ran one
+at a time.
+
+To give the three V1 flows a wallet each, seed two more selling wallets and
+raise the count:
+
+```bash
+# seed step
+SELLING_WALLET_PREPROD_MNEMONIC_2="24 words ..."
+SELLING_WALLET_PREPROD_MNEMONIC_3="24 words ..."
+
+# test step
+E2E_AGENTS_PER_SOURCE=3
+```
+
+The seed reads `SELLING_WALLET_PREPROD_MNEMONIC_2`, `_3` and so on, stopping at
+the first gap, and never brews a replacement. Every extra mnemonic must be a
+distinct and **funded** Preprod wallet: an unfunded wallet is still picked by the
+scheduler and stalls the flow that owns it. Asking for more agents than there
+are wallets logs a warning and falls back to sharing.
+
+The wallets are created while the payment source is seeded. A database that
+already holds the V1 source skips seeding under `SEED_ONLY_IF_EMPTY=true`, so a
+mnemonic added later needs a fresh database. CI creates one per run.
+
+Buyer-side actions (request-refund, cancel-refund) still queue. They run on the
+purchasing wallet, and the V1 batch builder fills the first eligible purchasing
+wallet before it uses a second one, so extra purchasing wallets do not spread
+them. Pinning a purchase to a wallet needs a wallet-scoped API key per flow.
+
+### Purchasing wallet funding
+
+Concurrent flows lock funds together, in one batched transaction from one
+purchasing wallet, so that wallet needs `maxWorkers` locks' worth at once rather
+than one lock at a time. `globalSetup` checks this before any on-chain work and
+fails with the required amount and the observed balances. The check exists
+because the batch builder parks requests it cannot fund in
+`WaitingForManualAction` with `InsufficientFunds`, and that state never retries.
+
+The floor scales with `maxWorkers`, so a single-file debugging run still asks for
+the full amount. Set `E2E_MAX_WORKERS=1` to lower it.
+
 ## 🏗️ Test Architecture
 
 ```

--- a/tests/e2e/flows/cancel-refund-request-flow.test.ts
+++ b/tests/e2e/flows/cancel-refund-request-flow.test.ts
@@ -29,8 +29,16 @@ import {
 	waitForRefundRequested,
 } from '../helperFunctions';
 import { describeEachOrSkip } from '../utils/describeForCases';
+import { pickAgentForSlot } from '../utils/agentSlots';
 
 const testNetwork = (process.env.TEST_NETWORK as Network) || Network.Preprod;
+
+// Flow files run concurrently (see `maxWorkers` in jest.e2e.config.ts). Each
+// one claims its own agent slot so that a payment source seeded with several
+// selling wallets gives every flow its own wallet, instead of all three
+// queueing behind one. With a single seeded wallet every slot resolves to the
+// same agent, which is the behaviour these flows had when they ran serially.
+const AGENT_SLOT = 1;
 
 // V2 is intentionally NOT covered by this single-item flow test. V2's
 // equivalent action surface is exercised by
@@ -68,10 +76,7 @@ describeEachOrSkip(
 			throw new Error('Test API client not initialized.');
 		}
 
-		const agent = global.testAgents?.[sourceType];
-		if (!agent) {
-			throw new Error(`No registered agent for ${sourceType}. globalSetup may have skipped this source type.`);
-		}
+		const agent = pickAgentForSlot(sourceType, AGENT_SLOT);
 
 		global.testConfig.paymentSourceType = sourceType;
 		global.testAgent = agent;

--- a/tests/e2e/flows/complete-flow-with-refund.test.ts
+++ b/tests/e2e/flows/complete-flow-with-refund.test.ts
@@ -26,8 +26,16 @@ import {
 	TimingConfig,
 } from '../helperFunctions';
 import { describeEachOrSkip } from '../utils/describeForCases';
+import { pickAgentForSlot } from '../utils/agentSlots';
 
 const testNetwork = (process.env.TEST_NETWORK as Network) || Network.Preprod;
+
+// Flow files run concurrently (see `maxWorkers` in jest.e2e.config.ts). Each
+// one claims its own agent slot so that a payment source seeded with several
+// selling wallets gives every flow its own wallet, instead of all three
+// queueing behind one. With a single seeded wallet every slot resolves to the
+// same agent, which is the behaviour these flows had when they ran serially.
+const AGENT_SLOT = 0;
 
 // V2 is intentionally NOT covered by this single-item flow test. V2's
 // equivalent action surface (submit-result, request-refund, authorize-refund)
@@ -72,10 +80,7 @@ describeEachOrSkip(
 			throw new Error('Test API client not initialized. Make sure test setup ran correctly.');
 		}
 
-		const agent = global.testAgents?.[sourceType];
-		if (!agent) {
-			throw new Error(`No registered agent for ${sourceType}. globalSetup may have skipped this source type.`);
-		}
+		const agent = pickAgentForSlot(sourceType, AGENT_SLOT);
 
 		global.testConfig.paymentSourceType = sourceType;
 		global.testAgent = agent;

--- a/tests/e2e/flows/early-refund-complete-flow.test.ts
+++ b/tests/e2e/flows/early-refund-complete-flow.test.ts
@@ -28,8 +28,16 @@ import {
 	authorizeRefund,
 } from '../helperFunctions';
 import { describeEachOrSkip } from '../utils/describeForCases';
+import { pickAgentForSlot } from '../utils/agentSlots';
 
 const testNetwork = (process.env.TEST_NETWORK as Network) || Network.Preprod;
+
+// Flow files run concurrently (see `maxWorkers` in jest.e2e.config.ts). Each
+// one claims its own agent slot so that a payment source seeded with several
+// selling wallets gives every flow its own wallet, instead of all three
+// queueing behind one. With a single seeded wallet every slot resolves to the
+// same agent, which is the behaviour these flows had when they ran serially.
+const AGENT_SLOT = 2;
 
 // V2 is intentionally NOT covered by this single-item flow test. V2's
 // equivalent action surface is exercised by
@@ -67,10 +75,7 @@ describeEachOrSkip(
 			throw new Error('Test API client not initialized.');
 		}
 
-		const agent = global.testAgents?.[sourceType];
-		if (!agent) {
-			throw new Error(`No registered agent for ${sourceType}. globalSetup may have skipped this source type.`);
-		}
+		const agent = pickAgentForSlot(sourceType, AGENT_SLOT);
 
 		global.testConfig.paymentSourceType = sourceType;
 		global.testAgent = agent;

--- a/tests/e2e/helperFunctions.ts
+++ b/tests/e2e/helperFunctions.ts
@@ -240,19 +240,30 @@ export interface TimingConfig {
  * Register an agent and wait for full confirmation with agent identifier
  * @param network - The blockchain network (Preprod, Mainnet, etc.)
  * @param paymentSourceType - Optional override for the payment source type (defaults to `global.testConfig.paymentSourceType`)
+ * @param signal - Aborts the confirmation polls when the caller gives up
+ * @param sellingWalletVkey - Bind the agent to this selling wallet instead of
+ *   the newest one. `globalSetup` passes it so each concurrent flow file can
+ *   own a wallet: V1 processes one request per hot wallet per scheduler tick.
  * @returns Confirmed agent data with identifier
  */
 export async function registerAndConfirmAgent(
 	network: Network,
 	paymentSourceType?: PaymentSourceType,
 	signal?: AbortSignal,
+	sellingWalletVkey?: string,
 ): Promise<ConfirmedAgent> {
 	const resolvedPaymentSourceType = paymentSourceType ?? global.testConfig.paymentSourceType;
 	console.log('📝 E2E: starting agent registration and confirmation...');
 
 	// Get test wallet dynamically from database
 	console.log('🔍 E2E: loading test wallet from database...');
-	const testWallet = await getTestWalletFromDatabase(network, 'seller', undefined, resolvedPaymentSourceType);
+	const testWallet =
+		sellingWalletVkey != null
+			? {
+					name: `Selected seller wallet (${resolvedPaymentSourceType}, ${network})`,
+					vkey: sellingWalletVkey,
+				}
+			: await getTestWalletFromDatabase(network, 'seller', undefined, resolvedPaymentSourceType);
 	const testScenario = getTestScenarios().basicAgent;
 	const smartContractAddress =
 		resolvedPaymentSourceType === PaymentSourceType.Web3CardanoV2

--- a/tests/e2e/setup/e2eGlobalState.ts
+++ b/tests/e2e/setup/e2eGlobalState.ts
@@ -3,7 +3,12 @@ import { Network, PaymentSourceType } from '@/generated/prisma/enums';
 
 export type E2EGlobalState = {
 	network: Network;
-	agents: Partial<Record<PaymentSourceType, ConfirmedAgent>>;
+	/**
+	 * Confirmed agents per payment source type, one per selling hot wallet.
+	 * A source seeded with a single selling wallet therefore holds exactly one
+	 * agent, which is what every flow file used before they ran concurrently.
+	 */
+	agents: Partial<Record<PaymentSourceType, ConfirmedAgent[]>>;
 	createdAt: string;
 };
 

--- a/tests/e2e/setup/globalSetup.ts
+++ b/tests/e2e/setup/globalSetup.ts
@@ -5,21 +5,40 @@ import { ApiClient } from '../utils/apiClient';
 import { getTestEnvironment } from '../fixtures/testData';
 import { waitForServer } from '../utils/waitFor';
 import { registerAndConfirmAgent, type ConfirmedAgent } from '../helperFunctions';
-import { validateE2EPaymentSourceWallets } from '../utils/paymentSourceHelper';
+import { getSellingWalletVkeys, validateE2EPaymentSourceWallets } from '../utils/paymentSourceHelper';
+import { assertPurchasingWalletFunded } from '../utils/walletFunding';
 import './globals';
 import { E2E_GLOBAL_STATE_ENV_KEY, encodeE2EGlobalState, type E2EGlobalState } from './e2eGlobalState';
 import { PaymentSourceType } from '@/generated/prisma/enums';
+import type { Config } from '@jest/types';
+
+/**
+ * How many agents (and therefore selling hot wallets) each payment source uses.
+ *
+ * Defaults to 1: one agent per source, shared by every flow file, which is what
+ * the suite did when its flows ran one at a time. Raise it only when the source
+ * has that many funded selling wallets seeded.
+ */
+function parseAgentsPerSource(): number {
+	const raw = process.env.E2E_AGENTS_PER_SOURCE;
+	if (raw == null || raw.trim() === '') return 1;
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 1) {
+		throw new Error(`E2E_AGENTS_PER_SOURCE must be a positive integer, got "${raw}"`);
+	}
+	return parsed;
+}
 
 /**
  * Jest global setup for E2E tests.
  * Runs ONCE per Jest invocation (not per test file).
  *
- * Discovers every PaymentSource the API exposes for the test network and registers
- * an agent against each one in parallel. The resulting agents are stored under
- * their PaymentSourceType so the per-test `describe.each` blocks can pick the
- * right one without re-registering.
+ * Discovers every PaymentSource the API exposes for the test network and
+ * registers one agent per selling hot wallet, all in parallel. The resulting
+ * agents are stored under their PaymentSourceType so the flow files can pick
+ * one (see `pickAgentForSlot`) without re-registering.
  */
-export default async function globalSetup() {
+export default async function globalSetup(globalConfig: Config.GlobalConfig) {
 	const GLOBAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 	// AbortController cancels in-flight registrations when the global timeout
 	// fires. Without this, the timeout rejection wins the Promise.race but
@@ -139,30 +158,79 @@ And accessible at: ${config.apiUrl}
 			}
 		}
 
-		console.log(`🧑‍💻 [globalSetup] Registering shared E2E agents in parallel for: ${uniqueSourceTypes.join(', ')}`);
-		// Promise.allSettled (not Promise.all) so a single source's failure
-		// doesn't strand the other source's on-chain registration as an
-		// orphan. We persist whatever succeeded BEFORE throwing so teardown
-		// can deregister succeeded agents. Pass the signal so per-agent
-		// pollUntil loops bail out when the global timeout fires instead of
-		// continuing on-chain work whose result will be discarded.
+		// Flow files run concurrently, so their funds-locks are packed into one
+		// transaction from one purchasing wallet instead of arriving one at a
+		// time. `maxWorkers` bounds how many can land in a single batch. Checked
+		// here, before any on-chain work: the batch builder parks requests it
+		// cannot fund in WaitingForManualAction/InsufficientFunds, which never
+		// retries, so an underfunded wallet has to surface as a clear message
+		// rather than as a stuck flow ten minutes in.
+		console.log(
+			`🔎 [globalSetup] Checking purchasing wallet funds for ${globalConfig.maxWorkers} concurrent lock(s)...`,
+		);
+		for (const sourceType of uniqueSourceTypes) {
+			await assertPurchasingWalletFunded({
+				network: config.network,
+				paymentSourceType: sourceType,
+				concurrentLocks: globalConfig.maxWorkers,
+				apiClient,
+			});
+		}
+
+		// One agent per selling hot wallet, up to E2E_AGENTS_PER_SOURCE. Flow files
+		// run concurrently and V1 takes one request per hot wallet per scheduler
+		// tick, so giving each flow its own selling wallet lets them overlap
+		// instead of queueing. Opt-in: the default of 1 registers exactly one
+		// agent per source, which is what every flow shared before, and leaves
+		// environments that happen to have several selling wallets untouched.
+		const agentsPerSource = parseAgentsPerSource();
+		const registrationTargets: { sourceType: PaymentSourceType; sellingWalletVkey: string }[] = [];
+		for (const sourceType of uniqueSourceTypes) {
+			const availableVkeys = await getSellingWalletVkeys(config.network, sourceType, apiClient);
+			const sellingWalletVkeys = availableVkeys.slice(0, agentsPerSource);
+			if (availableVkeys.length < agentsPerSource) {
+				console.warn(
+					`⚠️ [globalSetup] ${sourceType}: E2E_AGENTS_PER_SOURCE=${agentsPerSource} but only ` +
+						`${availableVkeys.length} selling wallet(s) are seeded. Flows will share wallets and pipeline. ` +
+						`Seed more with SELLING_WALLET_<NETWORK>_MNEMONIC_2, _3, ... (each must be funded).`,
+				);
+			}
+			console.log(`🔑 [globalSetup] ${sourceType}: registering ${sellingWalletVkeys.length} agent(s)`);
+			for (const sellingWalletVkey of sellingWalletVkeys) {
+				registrationTargets.push({ sourceType, sellingWalletVkey });
+			}
+		}
+
+		console.log(`🧑‍💻 [globalSetup] Registering ${registrationTargets.length} shared E2E agent(s) in parallel...`);
+		// Promise.allSettled (not Promise.all) so a single agent's failure
+		// doesn't strand a sibling's on-chain registration as an orphan. We
+		// persist whatever succeeded BEFORE throwing so teardown can deregister
+		// succeeded agents. Pass the signal so per-agent pollUntil loops bail out
+		// when the global timeout fires instead of continuing on-chain work whose
+		// result will be discarded.
 		const registrationResults = await Promise.allSettled(
-			uniqueSourceTypes.map(async (sourceType) => {
-				const agent = await registerAndConfirmAgent(config.network, sourceType, abortController.signal);
+			registrationTargets.map(async ({ sourceType, sellingWalletVkey }) => {
+				const agent = await registerAndConfirmAgent(
+					config.network,
+					sourceType,
+					abortController.signal,
+					sellingWalletVkey,
+				);
 				return [sourceType, agent] as const;
 			}),
 		);
 
-		const agents: Partial<Record<PaymentSourceType, ConfirmedAgent>> = {};
-		const failures: { sourceType: PaymentSourceType; error: string }[] = [];
+		const agents: Partial<Record<PaymentSourceType, ConfirmedAgent[]>> = {};
+		const failures: { sourceType: PaymentSourceType; sellingWalletVkey: string; error: string }[] = [];
 		for (let i = 0; i < registrationResults.length; i++) {
 			const result = registrationResults[i];
 			if (result.status === 'fulfilled') {
 				const [sourceType, agent] = result.value;
-				agents[sourceType] = agent;
+				(agents[sourceType] ??= []).push(agent);
 			} else {
 				failures.push({
-					sourceType: uniqueSourceTypes[i],
+					sourceType: registrationTargets[i].sourceType,
+					sellingWalletVkey: registrationTargets[i].sellingWalletVkey,
 					error: result.reason instanceof Error ? result.reason.message : String(result.reason),
 				});
 			}
@@ -178,23 +246,20 @@ And accessible at: ${config.apiUrl}
 		// state and deregister the agents that did succeed.
 		process.env[E2E_GLOBAL_STATE_ENV_KEY] = encodeE2EGlobalState(state);
 
+		const registeredCount = Object.values(agents).reduce((total, list) => total + list.length, 0);
+
 		if (failures.length > 0) {
 			console.error('❌ [globalSetup] One or more agent registrations failed:');
-			for (const { sourceType, error } of failures) {
-				console.error(`   - ${sourceType}: ${error}`);
+			for (const { sourceType, sellingWalletVkey, error } of failures) {
+				console.error(`   - ${sourceType} (selling wallet ${sellingWalletVkey}): ${error}`);
 			}
-			console.error(
-				`✅ [globalSetup] ${Object.keys(agents).length} succeeded — teardown will deregister those if reached.`,
-			);
-			throw new Error(
-				`Agent registration failed for ${failures.length} of ${uniqueSourceTypes.length} source types`,
-			);
+			console.error(`✅ [globalSetup] ${registeredCount} succeeded — teardown will deregister those if reached.`);
+			throw new Error(`Agent registration failed for ${failures.length} of ${registrationTargets.length} agents`);
 		}
 
 		console.log('✅ [globalSetup] Shared agents ready:');
 		for (const sourceType of uniqueSourceTypes) {
-			const agent = agents[sourceType];
-			if (agent != null) {
+			for (const agent of agents[sourceType] ?? []) {
 				console.log(`    - ${sourceType}: ${agent.name} (${agent.agentIdentifier})`);
 			}
 		}

--- a/tests/e2e/setup/globalTeardown.ts
+++ b/tests/e2e/setup/globalTeardown.ts
@@ -40,9 +40,16 @@ export default async function globalTeardown() {
 
 		const state = await safeReadState();
 		if (state?.agents) {
-			const entries = Object.entries(state.agents) as Array<
-				[PaymentSourceType, NonNullable<E2EGlobalState['agents'][PaymentSourceType]>]
-			>;
+			// Flattened: `agents` holds one entry per selling hot wallet, so a
+			// source seeded with several wallets has several agents to clean up.
+			// They sit on distinct wallets, so deregistering them concurrently
+			// costs no extra wall-clock.
+			const entries = (
+				Object.entries(state.agents) as Array<
+					[PaymentSourceType, NonNullable<E2EGlobalState['agents'][PaymentSourceType]>]
+				>
+			).flatMap(([sourceType, agentsForType]) => agentsForType.map((agent) => [sourceType, agent] as const));
+
 			const results = await Promise.allSettled(
 				entries.map(([sourceType, agent]) => {
 					if (!agent?.agentIdentifier) {
@@ -54,11 +61,14 @@ export default async function globalTeardown() {
 			);
 
 			for (const [index, result] of results.entries()) {
-				const [sourceType] = entries[index];
+				const [sourceType, agent] = entries[index];
 				if (result.status === 'rejected') {
-					console.error(`❌ [globalTeardown] Failed to deregister ${sourceType} agent:`, result.reason);
+					console.error(
+						`❌ [globalTeardown] Failed to deregister ${sourceType} agent ${agent?.agentIdentifier}:`,
+						result.reason,
+					);
 				} else {
-					console.log(`✅ [globalTeardown] Deregistered ${sourceType} agent.`);
+					console.log(`✅ [globalTeardown] Deregistered ${sourceType} agent ${agent?.agentIdentifier}.`);
 				}
 			}
 		}

--- a/tests/e2e/setup/globals.ts
+++ b/tests/e2e/setup/globals.ts
@@ -11,7 +11,7 @@ declare global {
 	// eslint-disable-next-line no-var
 	var testAgent: ConfirmedAgent;
 	// eslint-disable-next-line no-var
-	var testAgents: Partial<Record<PaymentSourceType, ConfirmedAgent>>;
+	var testAgents: Partial<Record<PaymentSourceType, ConfirmedAgent[]>>;
 	// eslint-disable-next-line no-var
 	var __e2eErrorHandlersInstalled: boolean | undefined;
 }

--- a/tests/e2e/setup/testEnvironment.ts
+++ b/tests/e2e/setup/testEnvironment.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
 	// been parameterized yet still has a sensible agent to fall back on. The
 	// `describe.each` blocks overwrite this per iteration with the matching type.
 	const fallbackAgent =
-		state.agents[PaymentSourceType.Web3CardanoV1] ?? state.agents[PaymentSourceType.Web3CardanoV2] ?? undefined;
+		state.agents[PaymentSourceType.Web3CardanoV1]?.[0] ?? state.agents[PaymentSourceType.Web3CardanoV2]?.[0];
 	if (fallbackAgent) {
 		global.testAgent = fallbackAgent;
 	}

--- a/tests/e2e/utils/agentSlots.ts
+++ b/tests/e2e/utils/agentSlots.ts
@@ -1,0 +1,25 @@
+import { PaymentSourceType } from '@/generated/prisma/enums';
+import type { ConfirmedAgent } from '../helperFunctions';
+import '../setup/globals';
+
+/**
+ * Pick the agent that a concurrently running flow file should use.
+ *
+ * `globalSetup` registers one agent per selling hot wallet. A source seeded
+ * with a single selling wallet therefore hands every slot the same agent,
+ * which is exactly what each flow file used before they ran concurrently. A
+ * source seeded with several selling wallets gives the first N slots a wallet
+ * each, and that is what lets concurrent flows overlap: V1 processes one
+ * request per hot wallet per scheduler tick and holds the wallet locked until
+ * the transaction confirms.
+ *
+ * The modulo keeps the mapping total. More flow files than wallets means some
+ * flows share a wallet and pipeline, which is slower but still correct.
+ */
+export function pickAgentForSlot(sourceType: PaymentSourceType, slot: number): ConfirmedAgent {
+	const agents = global.testAgents?.[sourceType] ?? [];
+	if (agents.length === 0) {
+		throw new Error(`No registered agent for ${sourceType}. globalSetup may have skipped this source type.`);
+	}
+	return agents[slot % agents.length];
+}

--- a/tests/e2e/utils/paymentSourceHelper.ts
+++ b/tests/e2e/utils/paymentSourceHelper.ts
@@ -111,6 +111,41 @@ export async function getActiveWalletVKey(
 	return wallet.walletVkey;
 }
 
+/**
+ * Every selling wallet vkey configured for a payment source (first 50).
+ *
+ * `globalSetup` registers one agent per entry so concurrent flow files can each
+ * drive their own selling wallet. Order does not matter: the wallets are
+ * interchangeable for the suite, and `globalSetup` queries once and shares the
+ * result, so every worker sees the same list.
+ */
+export async function getSellingWalletVkeys(
+	network: Network,
+	paymentSourceType?: PaymentSourceType,
+	apiClient?: ApiClient,
+): Promise<string[]> {
+	const client = apiClient || global.testApiClient;
+	if (!client) {
+		throw new Error('ApiClient not provided and global.testApiClient is not available');
+	}
+	const resolvedPaymentSourceType = resolvePaymentSourceType(paymentSourceType);
+	const paymentSource = await getE2EPaymentSource(network, resolvedPaymentSourceType, client);
+
+	const { Wallets: wallets } = await client.queryWallets({
+		paymentSourceId: paymentSource.id,
+		walletType: HotWalletType.Selling,
+		take: 50,
+	});
+
+	if (wallets.length === 0) {
+		throw new Error(
+			`No active selling wallet found for ${resolvedPaymentSourceType} on ${network}. Please run database seeding first.`,
+		);
+	}
+
+	return wallets.map((wallet) => wallet.walletVkey);
+}
+
 export async function validateE2EPaymentSourceWallets(
 	network: Network,
 	paymentSourceType?: PaymentSourceType,
@@ -191,6 +226,7 @@ export default {
 	getE2EPaymentSource,
 	getActiveSmartContractAddress,
 	getActiveWalletVKey,
+	getSellingWalletVkeys,
 	validateE2EPaymentSourceWallets,
 	getTestWalletFromDatabase,
 };

--- a/tests/e2e/utils/walletFunding.ts
+++ b/tests/e2e/utils/walletFunding.ts
@@ -1,0 +1,88 @@
+import { HotWalletType, Network, PaymentSourceType } from '@/generated/prisma/enums';
+import type { ApiClient } from './apiClient';
+import '../setup/globals';
+
+/**
+ * Preflight funding floor for a batched funds-lock: N × per-lock min-UTxO
+ * (~5 ADA) + batch overhead (2 ADA fee buffer + 5 ADA splitter). Conservative
+ * round numbers — this only needs to catch a grossly underfunded wallet before
+ * a long poll, not to predict the exact fee.
+ */
+const PER_LOCK_LOVELACE_ESTIMATE = 5_000_000n;
+const BATCH_TX_OVERHEAD_LOVELACE = 7_000_000n;
+
+function blockfrostBaseUrl(network: Network): string {
+	return network === Network.Mainnet
+		? 'https://cardano-mainnet.blockfrost.io/api/v0'
+		: 'https://cardano-preprod.blockfrost.io/api/v0';
+}
+
+/** Total lovelace at an address per Blockfrost. Returns 0 for an unused (404) address. */
+async function getAddressLovelace(address: string, projectId: string, network: Network): Promise<bigint> {
+	const res = await fetch(`${blockfrostBaseUrl(network)}/addresses/${address}`, {
+		headers: { project_id: projectId },
+	});
+	if (res.status === 404) return 0n;
+	if (!res.ok) {
+		throw new Error(`Blockfrost address lookup failed (${res.status}) for ${address}`);
+	}
+	const body = (await res.json()) as { amount?: Array<{ unit: string; quantity: string }> };
+	const lovelace = body.amount?.find((a) => a.unit === 'lovelace')?.quantity ?? '0';
+	return BigInt(lovelace);
+}
+
+/**
+ * Fail fast, with an actionable message, when no single purchasing wallet can
+ * fund `concurrentLocks` locks at once.
+ *
+ * Concurrency raises this bar. Flows that lock one after another only ever need
+ * one lock's worth in the wallet at a time; flows that lock together are packed
+ * into one transaction by the batch builder, which fills the FIRST eligible
+ * wallet before it reaches for a second. So the requirement is one wallet at or
+ * above the floor, not the sum across wallets.
+ *
+ * Without this check a thin wallet does not merely slow the suite down: the
+ * batch builder parks the requests it cannot fund in WaitingForManualAction
+ * with InsufficientFunds, which never retries.
+ */
+export async function assertPurchasingWalletFunded(options: {
+	network: Network;
+	paymentSourceType: PaymentSourceType;
+	concurrentLocks: number;
+	apiClient?: ApiClient;
+}): Promise<void> {
+	const { network, paymentSourceType, concurrentLocks } = options;
+	const client = options.apiClient ?? global.testApiClient;
+	const requiredLovelace = BigInt(concurrentLocks) * PER_LOCK_LOVELACE_ESTIMATE + BATCH_TX_OVERHEAD_LOVELACE;
+
+	const { ExtendedPaymentSources } = await client.queryPaymentSources({ take: 100 });
+	const source = ExtendedPaymentSources.find((s) => s.paymentSourceType === paymentSourceType && s.network === network);
+	if (!source) {
+		throw new Error(`Preflight: no ${paymentSourceType} payment source found on ${network} to check funding.`);
+	}
+
+	const projectId = source.PaymentSourceConfig.rpcProviderApiKey;
+	const { Wallets: purchasingWallets } = await client.queryWallets({
+		paymentSourceId: source.id,
+		walletType: HotWalletType.Purchasing,
+		take: 100,
+	});
+
+	const observed: string[] = [];
+	for (const wallet of purchasingWallets) {
+		const lovelace = await getAddressLovelace(wallet.walletAddress, projectId, network);
+		observed.push(`${wallet.walletAddress} = ${(Number(lovelace) / 1e6).toFixed(2)} ADA`);
+		if (lovelace >= requiredLovelace) {
+			return;
+		}
+	}
+
+	throw new Error(
+		`Preflight: ${paymentSourceType} purchasing wallet underfunded for a ${concurrentLocks}-lock batch. ` +
+			`Need ≥ ${(Number(requiredLovelace) / 1e6).toFixed(2)} ADA in a SINGLE purchasing wallet. ` +
+			`Observed: ${observed.join('; ') || '(no purchasing wallets)'}. ` +
+			`Fund one of these addresses via the Cardano preprod faucet ` +
+			`(https://docs.cardano.org/cardano-testnet/tools/faucet/) — this is the seeded purchasing hot wallet, ` +
+			`not the buyer fixture vkey.`,
+	);
+}

--- a/tests/e2e/v2/flows/batch-verification.test.ts
+++ b/tests/e2e/v2/flows/batch-verification.test.ts
@@ -20,7 +20,7 @@
  * TEST_PAYMENT_SOURCE_TYPE, the whole suite is `describe.skip`-ed.
  */
 
-import { Network, PaymentSourceType, HotWalletType } from '@/generated/prisma/enums';
+import { Network, PaymentSourceType } from '@/generated/prisma/enums';
 import { validateTestWallets } from '../../fixtures/testWallets';
 import {
 	allWithAbortOnFailure,
@@ -35,6 +35,8 @@ import {
 	waitForResultSubmitted,
 } from '../../helperFunctions';
 import { PaymentResponse, PurchaseResponse } from '../../utils/apiClient';
+import { pickAgentForSlot } from '../../utils/agentSlots';
+import { assertPurchasingWalletFunded } from '../../utils/walletFunding';
 
 class FatalPollError extends Error {
 	constructor(message: string) {
@@ -50,73 +52,6 @@ const describeFn = envFilter && envFilter !== PaymentSourceType.Web3CardanoV2 ? 
 
 const BATCH_SIZE = 3;
 const BATCH_PHASE_TIMEOUT_MS = 10 * 60 * 1000;
-
-// Preflight funding floor for the funds-lock batch, mirroring the batch
-// service's wallet-fit gate: N × per-lock min-UTxO (~5 ADA) + batch overhead
-// (2 ADA fee buffer + 5 ADA splitter). Conservative round numbers — only needs
-// to catch a grossly underfunded wallet before the 600s poll.
-const PER_LOCK_LOVELACE_ESTIMATE = 5_000_000n;
-const BATCH_TX_OVERHEAD_LOVELACE = 7_000_000n;
-const MIN_PURCHASING_WALLET_LOVELACE = BigInt(BATCH_SIZE) * PER_LOCK_LOVELACE_ESTIMATE + BATCH_TX_OVERHEAD_LOVELACE;
-
-function blockfrostBaseUrl(network: Network): string {
-	return network === Network.Mainnet
-		? 'https://cardano-mainnet.blockfrost.io/api/v0'
-		: 'https://cardano-preprod.blockfrost.io/api/v0';
-}
-
-/** Total lovelace at an address per Blockfrost. Returns 0 for an unused (404) address. */
-async function getAddressLovelace(address: string, projectId: string, network: Network): Promise<bigint> {
-	const res = await fetch(`${blockfrostBaseUrl(network)}/addresses/${address}`, {
-		headers: { project_id: projectId },
-	});
-	if (res.status === 404) return 0n;
-	if (!res.ok) {
-		throw new Error(`Blockfrost address lookup failed (${res.status}) for ${address}`);
-	}
-	const body = (await res.json()) as { amount?: Array<{ unit: string; quantity: string }> };
-	const lovelace = body.amount?.find((a) => a.unit === 'lovelace')?.quantity ?? '0';
-	return BigInt(lovelace);
-}
-
-/**
- * Fail fast (actionable message) if no single V2 purchasing wallet can fund the
- * whole batch, instead of a silent 600s FundsLockingInitiated poll timeout. The
- * batch locks ALL requests from ONE wallet (single shared txHash), so we need
- * one wallet at/above the floor — not the sum. This is the seeded
- * PURCHASE_WALLET_V2_PREPROD_MNEMONIC wallet, not the buyer fixture vkey.
- */
-async function assertPurchasingWalletFunded(): Promise<void> {
-	const { ExtendedPaymentSources } = await global.testApiClient.queryPaymentSources();
-	const source = ExtendedPaymentSources.find(
-		(s) => s.paymentSourceType === PaymentSourceType.Web3CardanoV2 && s.network === testNetwork,
-	);
-	if (!source) {
-		throw new Error(`Preflight: no Web3CardanoV2 payment source found on ${testNetwork} to check funding.`);
-	}
-	const projectId = source.PaymentSourceConfig.rpcProviderApiKey;
-	const { Wallets: purchasingWallets } = await global.testApiClient.queryWallets({
-		paymentSourceId: source.id,
-		walletType: HotWalletType.Purchasing,
-		take: 100,
-	});
-	const observed: string[] = [];
-	for (const wallet of purchasingWallets) {
-		const lovelace = await getAddressLovelace(wallet.walletAddress, projectId, testNetwork);
-		observed.push(`${wallet.walletAddress} = ${(Number(lovelace) / 1e6).toFixed(2)} ADA`);
-		if (lovelace >= MIN_PURCHASING_WALLET_LOVELACE) {
-			return;
-		}
-	}
-	throw new Error(
-		`Preflight: V2 purchasing wallet underfunded for a ${BATCH_SIZE}-batch funds-lock. ` +
-			`Need ≥ ${(Number(MIN_PURCHASING_WALLET_LOVELACE) / 1e6).toFixed(2)} ADA in a SINGLE purchasing wallet. ` +
-			`Observed: ${observed.join('; ') || '(no purchasing wallets)'}. ` +
-			`Fund one of these addresses via the Cardano preprod faucet ` +
-			`(https://docs.cardano.org/cardano-testnet/tools/faucet/) — this is the seeded V2 ` +
-			`purchasing hot wallet (PURCHASE_WALLET_V2_PREPROD_MNEMONIC), not the buyer fixture vkey.`,
-	);
-}
 
 /** Sleep helper. We use this to space out scheduler polls. */
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -299,12 +234,10 @@ describeFn(`Web3CardanoV2 batch action verification (${testNetwork})`, () => {
 		// (without an explicit override) resolves to V2 inside this suite.
 		global.testConfig.paymentSourceType = PaymentSourceType.Web3CardanoV2;
 
-		const agent = global.testAgents?.[PaymentSourceType.Web3CardanoV2];
-		if (!agent) {
-			throw new Error(
-				`No registered V2 agent — globalSetup probably skipped V2 (no V2 PaymentSource for ${testNetwork}?).`,
-			);
-		}
+		// Slot 0: this suite asserts that all BATCH_SIZE items land in ONE tx, so
+		// every item must share one selling wallet. Spreading them over several
+		// agents would split the batch and fail the assertion by design.
+		const agent = pickAgentForSlot(PaymentSourceType.Web3CardanoV2, 0);
 		global.testAgent = agent;
 
 		const walletValidation = await validateTestWallets(testNetwork, PaymentSourceType.Web3CardanoV2);
@@ -324,7 +257,11 @@ describeFn(`Web3CardanoV2 batch action verification (${testNetwork})`, () => {
 			// wallet can't fund the batch, instead of a silent 600s funds-lock poll
 			// timeout downstream.
 			console.log('🔎 Preflight: checking V2 purchasing wallet balance…');
-			await assertPurchasingWalletFunded();
+			await assertPurchasingWalletFunded({
+				network: testNetwork,
+				paymentSourceType: PaymentSourceType.Web3CardanoV2,
+				concurrentLocks: BATCH_SIZE,
+			});
 			console.log('✅ Preflight: purchasing wallet funded for batch.');
 
 			console.log(`🚀 V2 batch verification (${testNetwork}): creating ${BATCH_SIZE} concurrent payments…`);


### PR DESCRIPTION
## Why

The V1 e2e job takes ~23 min (measured on run 33335985384; V2 takes ~7.5 min), because `jest.e2e.config.ts` pinned `maxWorkers: 1` and the three ~6 min flow files ran one after another.

The reason the config gave for that pin does not hold. Jest gives every test file its own module registry and its own `global`, and worker processes inherit `process.env` at fork time, so `global.testConfig.paymentSourceType` cannot race across files. What actually serializes is on chain: V1 takes one request per hot wallet per scheduler tick and holds the wallet locked until the transaction confirms.

## What changed

**1. Flow files run concurrently.** `maxWorkers` defaults to 3, one per V1 flow file, overridable with `E2E_MAX_WORKERS`. Set it to 1 for serial, live-streamed logs when a run is stuck: a worker buffers its console output until its file finishes.

**2. One selling wallet per flow, opt-in.** `globalSetup` registers `E2E_AGENTS_PER_SOURCE` agents per payment source, one per selling hot wallet, and each flow file claims a slot through `pickAgentForSlot`. This is what converts pipelining into real parallelism.

The default is 1, which is exactly today's behaviour: one agent per source, shared by every flow, on the same wallet the previous code picked (same endpoint, same `orderBy: createdAt desc`, index 0). `prisma/seed.ts` reads the optional `SELLING_WALLET_PREPROD_MNEMONIC_2`, `_3`, ... and seeds them as extra Preprod V1 selling wallets. Nothing changes until those secrets are set and the count is raised.

**3. Scheduler intervals at their floors in CI.** The e2e API server ran the production defaults (30s batching, 20s tx-sync, 15s for most actions), and every on-chain hop paid that twice: once for the action job that builds the transaction and once for the tx-sync pass that observes it. The workflow now sets the 14 interval variables to the floors `parseNumberEnv` enforces in `packages/payment-core/src/config.ts`. Preprod block time still dominates, so this trims minutes, not hops.

## Funding preflight

Concurrent flows lock funds together, in one batched transaction from one purchasing wallet, so that wallet needs `maxWorkers` locks' worth at once instead of one lock at a time. `globalSetup` checks this before any on-chain work and fails with the required amount and the observed balances.

The check is necessary rather than cosmetic: the V1 batch builder parks requests it cannot fund in `WaitingForManualAction` with `InsufficientFunds` (`packages/payment-source-v1/src/services/purchases/batch-payments/service.ts:831`), and that state never retries. The logic is the V2 batch test's own preflight, extracted to `tests/e2e/utils/walletFunding.ts` and shared.

**Before this merges, a V1 purchasing wallet needs at least 22 ADA** (3 workers x 5 + 7). Below that the job now fails during setup with an actionable message, where it previously started and stalled.

## Verification

- `pnpm exec tsc --noEmit`: exit 0.
- `pnpm run lint:backend`: clean.
- `prettier --check` on every file created or reformatted here: clean.
- `jest --listTests` finds the 3 V1 flow files; `--showConfig` reports `maxWorkers: 3`, and 1 under `E2E_MAX_WORKERS=1`; `E2E_MAX_WORKERS=0` throws.
- Traced end to end that `sellingWalletVkey` binds an agent to a wallet (`src/routes/api/registry/index.ts:107`) and that payment creation resolves the selling wallet from the registry-NFT holder (`src/routes/api/payments/index.ts:272`), so an agent bound to wallet N drives every later action on wallet N.
- The V2 invocation now runs its two files together. `source-isolation.test.ts` does no on-chain work, so it cannot disturb `batch-verification`'s single-transaction assertion.

Not measured on chain yet. The wall-clock claim is an expectation from the serialization analysis, not a recorded run; this PR's own e2e job is the first measurement.

## Follow-ups (not in this PR)

- Add `SELLING_WALLET_PREPROD_MNEMONIC_2` / `_3` as repository secrets and raise `E2E_AGENTS_PER_SOURCE` to 3 to collect the second half of the speed-up.
- Buyer-side actions still queue. Pinning a purchase to a wallet needs a wallet-scoped API key per flow.
- `tests/e2e/helperFunctions.ts` is 1161 lines and wants a split.