### PR TITLE
fix(frontend): clear tag validation after adding a tag

### DIFF
--- a/frontend/src/components/ai-agents/RegisterAgentDetailsSection.tsx
+++ b/frontend/src/components/ai-agents/RegisterAgentDetailsSection.tsx
@@ -42,7 +42,7 @@ export function RegisterAgentDetailsSection({
     }
 
     if (tag && !tags.includes(tag)) {
-      setValue('tags', [...tags, tag]);
+      setValue('tags', [...tags, tag], { shouldValidate: true });
     }
     setTagInput('');
   };
@@ -51,6 +51,7 @@ export function RegisterAgentDetailsSection({
     setValue(
       'tags',
       tags.filter((tag) => tag !== tagToRemove),
+      { shouldValidate: true },
     );
   };
 

--- a/frontend/src/components/setup/screens/AddAiAgentScreen.tsx
+++ b/frontend/src/components/setup/screens/AddAiAgentScreen.tsx
@@ -234,7 +234,7 @@ export function AddAiAgentScreen({
     }
 
     if (tag && !tags.includes(tag)) {
-      setValue('tags', [...tags, tag]);
+      setValue('tags', [...tags, tag], { shouldValidate: true });
     }
     setTagInput('');
   };
@@ -243,6 +243,7 @@ export function AddAiAgentScreen({
     setValue(
       'tags',
       tags.filter((tag) => tag !== tagToRemove),
+      { shouldValidate: true },
     );
   };
 


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Revalidate the tags field when tags are added or removed in agent registration and setup wizard forms. Clears the required-tag error once at least one tag is present.

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-483

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

Submit registration with zero tags, add a tag, and confirm the validation error clears without resubmitting.