### PR TITLE
fix(frontend): keep admin table actions visible during horizontal scroll

### DIFF
--- a/frontend/src/components/dashboard/FinancialWalletTable.tsx
+++ b/frontend/src/components/dashboard/FinancialWalletTable.tsx
@@ -13,6 +13,7 @@ import {
 import { REPORT_METRIC_LABELS } from '@/lib/transaction-report/report-labels';
 import { shortenAddress } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   Table,
   TableBody,
@@ -233,7 +234,7 @@ export function FinancialWalletTable({
 
   return (
     <>
-      <div className="overflow-x-auto rounded-lg border">
+      <HorizontalScrollArea className="rounded-lg border">
         <Table>
           <TableHeader>
             <TableRow>
@@ -344,7 +345,7 @@ export function FinancialWalletTable({
             )}
           </TableBody>
         </Table>
-      </div>
+      </HorizontalScrollArea>
       <p className="mt-2 text-xs text-muted-foreground">
         A wallet that both sells and buys gets one row per side. Payment counts are per row, so they
         do not add up to the total above.

--- a/frontend/src/components/dashboard/FinancialWalletTable.tsx
+++ b/frontend/src/components/dashboard/FinancialWalletTable.tsx
@@ -14,14 +14,7 @@ import { REPORT_METRIC_LABELS } from '@/lib/transaction-report/report-labels';
 import { shortenAddress } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
   paginateReportRows,
   resetReportTablePageState,
@@ -235,7 +228,7 @@ export function FinancialWalletTable({
   return (
     <>
       <HorizontalScrollArea className="rounded-lg border">
-        <Table>
+        <table className="w-full caption-bottom text-sm">
           <TableHeader>
             <TableRow>
               <TableHead scope="col">Wallet</TableHead>
@@ -344,7 +337,7 @@ export function FinancialWalletTable({
               })
             )}
           </TableBody>
-        </Table>
+        </table>
       </HorizontalScrollArea>
       <p className="mt-2 text-xs text-muted-foreground">
         A wallet that both sells and buys gets one row per side. Payment counts are per row, so they

--- a/frontend/src/components/dashboard/report/ReportHistoryTable.tsx
+++ b/frontend/src/components/dashboard/report/ReportHistoryTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { cn } from '@/lib/utils';
 import type { ReportChartRow } from '@/lib/transaction-report/chart-data';
 import {
@@ -53,7 +54,7 @@ export function ReportHistoryTable({
 
       {isOpen && (
         <div className="mt-2 rounded-lg border">
-          <div className="overflow-x-auto">
+          <HorizontalScrollArea>
             <table className="w-full text-left text-xs">
               <caption className="sr-only">{label}</caption>
               <thead className="bg-muted/30 text-muted-foreground">
@@ -93,7 +94,7 @@ export function ReportHistoryTable({
                 ))}
               </tbody>
             </table>
-          </div>
+          </HorizontalScrollArea>
           <ReportTablePagination
             page={page.page}
             pageCount={page.pageCount}

--- a/frontend/src/components/hydra/HydraHeadTable.tsx
+++ b/frontend/src/components/hydra/HydraHeadTable.tsx
@@ -9,6 +9,11 @@ import { Ticket } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { CopyButton } from '@/components/ui/copy-button';
 import { cn, shortenAddress } from '@/lib/utils';
 import type { HydraHead, HydraInvite } from '@/lib/hooks/useHydraHeads';
@@ -89,7 +94,7 @@ export function HydraHeadTable({
   }
 
   return (
-    <div className="rounded-lg border overflow-x-auto">
+    <HorizontalScrollArea className="rounded-lg border">
       <table className="w-full min-w-[720px]">
         <thead className="bg-muted/30 dark:bg-muted/15">
           <tr className="border-b">
@@ -108,8 +113,8 @@ export function HydraHeadTable({
             <th scope="col" className="p-4 text-left text-sm font-medium">
               Activity
             </th>
-            <th scope="col" className="p-4 pr-6 text-right text-sm font-medium">
-              Action
+            <th scope="col" className={tableActionsHeadWideClass}>
+              Actions
             </th>
           </tr>
         </thead>
@@ -142,7 +147,7 @@ export function HydraHeadTable({
                 Its node and peer port are reserved. It becomes a head when the counterparty redeems
                 it, or expires {formatDate(invite.expiresAt)}.
               </td>
-              <td className="p-4 pr-6 text-right">
+              <td className={tableActionsCellWideClass}>
                 <Button type="button" variant="ghost" size="sm" onClick={onManageInvites}>
                   Manage
                 </Button>
@@ -159,7 +164,7 @@ export function HydraHeadTable({
                 role="button"
                 tabIndex={0}
                 aria-label={`Open details for Hydra head ${head.headIdentifier ?? head.id}`}
-                className="group border-b last:border-0 align-top animate-fade-in opacity-0 cursor-pointer transition-colors hover:bg-muted/30 focus-visible:bg-muted/30 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+                className="group border-b last:border-0 align-top animate-fade-in opacity-0 cursor-pointer transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
                 style={{ animationDelay: `${Math.min(index, 9) * 35}ms` }}
                 onClick={() => onOpenHead(head)}
                 onKeyDown={(event) => {
@@ -254,7 +259,7 @@ export function HydraHeadTable({
                     )}
                   </div>
                 </td>
-                <td className="p-4 pr-6">
+                <td className={tableActionsCellWideClass}>
                   <div
                     className="flex justify-end"
                     onClick={(event) => event.stopPropagation()}
@@ -272,6 +277,6 @@ export function HydraHeadTable({
           })}
         </tbody>
       </table>
-    </div>
+    </HorizontalScrollArea>
   );
 }

--- a/frontend/src/components/payment-sources/X402SourcesSection.tsx
+++ b/frontend/src/components/payment-sources/X402SourcesSection.tsx
@@ -9,6 +9,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { ChainDialog } from '@/components/x402/ChainsTab';
 import { X402Network } from '@/lib/api/generated';
 
@@ -58,7 +63,7 @@ export function X402SourcesSection({
         </Badge>
       </div>
 
-      <div className="rounded-lg border overflow-x-auto">
+      <HorizontalScrollArea className="rounded-lg border">
         <table className="w-full">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -74,7 +79,9 @@ export function X402SourcesSection({
               <th scope="col" className="p-4 text-left text-sm font-medium text-muted-foreground">
                 Facilitator
               </th>
-              <th scope="col" className="w-20 p-4 pr-8"></th>
+              <th scope="col" className={tableActionsHeadWideClass}>
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -118,7 +125,7 @@ export function X402SourcesSection({
                   <tr
                     key={chain.id}
                     className={cn(
-                      'border-b last:border-b-0',
+                      'group border-b last:border-b-0 hover:bg-muted/50',
                       isActive && 'bg-green-50 dark:bg-green-950/20',
                     )}
                   >
@@ -149,7 +156,7 @@ export function X402SourcesSection({
                         <span className="text-xs text-muted-foreground">—</span>
                       )}
                     </td>
-                    <td className="p-4 pr-8">
+                    <td className={tableActionsCellWideClass}>
                       <div className="flex justify-end gap-2">
                         <Button
                           variant="ghost"
@@ -195,7 +202,7 @@ export function X402SourcesSection({
             )}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
 
       <ChainDialog
         key={isChainDialogOpen ? (editingChain?.id ?? 'new') : 'closed'}

--- a/frontend/src/components/skeletons/AIAgentTableSkeleton.tsx
+++ b/frontend/src/components/skeletons/AIAgentTableSkeleton.tsx
@@ -1,4 +1,8 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  tableActionsCellClass,
+  tableActionsCellCompactClass,
+} from '@/components/ui/table-actions-column';
 
 // Placeholder bar widths for the leading data columns, in order. Shorter than
 // the maximum column count on purpose: cells past the end fall back to a
@@ -19,6 +23,8 @@ export function AIAgentTableSkeleton({
   rows?: number;
   columns?: number;
 }) {
+  const actionsCellClass = columns >= 9 ? tableActionsCellClass : tableActionsCellCompactClass;
+
   return (
     <>
       {Array.from({ length: rows }).map((_, rowIndex) => (
@@ -28,7 +34,7 @@ export function AIAgentTableSkeleton({
               <Skeleton className={`h-4 ${CELL_WIDTHS[cellIndex] ?? 'w-24'}`} />
             </td>
           ))}
-          <td className="w-20 p-4">
+          <td className={actionsCellClass}>
             <Skeleton className="h-4 w-8" />
           </td>
         </tr>

--- a/frontend/src/components/tx-sync-quarantine/QuarantineTable.tsx
+++ b/frontend/src/components/tx-sync-quarantine/QuarantineTable.tsx
@@ -4,6 +4,12 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/ui/copy-button';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsCellWideDestructiveClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { cn } from '@/lib/utils';
 import { formatDateTime } from '@/lib/format-date';
 import type { QuarantineEntry } from '@/lib/hooks/useTxSyncQuarantine';
@@ -104,7 +110,7 @@ export function QuarantineTable({
     });
 
   return (
-    <div className="border rounded-lg overflow-x-auto">
+    <HorizontalScrollArea className="border rounded-lg">
       <table className={cn('w-full transition-opacity duration-150', isLoading && 'opacity-70')}>
         <thead className="bg-muted/30 dark:bg-muted/15">
           <tr className="border-b">
@@ -118,9 +124,7 @@ export function QuarantineTable({
             <th className="p-4 text-left text-sm font-medium text-muted-foreground">Next Retry</th>
             <th className="p-4 text-left text-sm font-medium text-muted-foreground">Age</th>
             <th className="p-4 text-left text-sm font-medium text-muted-foreground">Network</th>
-            <th className="p-4 pr-8 text-right text-sm font-medium text-muted-foreground">
-              Actions
-            </th>
+            <th className={tableActionsHeadWideClass}>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -139,7 +143,7 @@ export function QuarantineTable({
                 <tr
                   key={entry.id}
                   className={cn(
-                    'border-b animate-fade-in opacity-0 transition-[background-color,opacity] duration-150',
+                    'group border-b animate-fade-in opacity-0 transition-[background-color,opacity] duration-150 hover:bg-muted/50',
                     entry.needsOperator && 'bg-destructive/10 border-l-2 border-l-destructive',
                   )}
                   style={{ animationDelay: `${Math.min(index, 9) * 40}ms` }}
@@ -178,7 +182,13 @@ export function QuarantineTable({
                     {nowMs === 0 ? '—' : formatElapsed(new Date(entry.createdAt).getTime(), nowMs)}
                   </td>
                   <td className="p-4 text-sm">{entry.PaymentSource.network}</td>
-                  <td className="p-4 pr-8">
+                  <td
+                    className={
+                      entry.needsOperator
+                        ? tableActionsCellWideDestructiveClass
+                        : tableActionsCellWideClass
+                    }
+                  >
                     <div className="flex justify-end gap-2">
                       <Button
                         variant="secondary"
@@ -258,6 +268,6 @@ export function QuarantineTable({
           )}
         </tbody>
       </table>
-    </div>
+    </HorizontalScrollArea>
   );
 }

--- a/frontend/src/components/ui/horizontal-scroll-area.tsx
+++ b/frontend/src/components/ui/horizontal-scroll-area.tsx
@@ -1,20 +1,24 @@
-import type { ComponentProps } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 
 import { useDragToScroll } from '@/lib/hooks/useDragToScroll';
 import { cn } from '@/lib/utils';
 
-export function HorizontalScrollArea({ className, children, ...props }: ComponentProps<'div'>) {
+export function HorizontalScrollArea({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<'div'>) {
   const { ref, isScrollable, isDragging } = useDragToScroll();
 
   return (
     <div
+      {...props}
       ref={ref}
       className={cn(
-        'overflow-x-auto',
+        '@container/table-scroll overflow-x-auto',
         isScrollable && (isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'),
         className,
       )}
-      {...props}
     >
       {children}
     </div>

--- a/frontend/src/components/ui/horizontal-scroll-area.tsx
+++ b/frontend/src/components/ui/horizontal-scroll-area.tsx
@@ -1,0 +1,22 @@
+import type { ComponentProps } from 'react';
+
+import { useDragToScroll } from '@/lib/hooks/useDragToScroll';
+import { cn } from '@/lib/utils';
+
+export function HorizontalScrollArea({ className, children, ...props }: ComponentProps<'div'>) {
+  const { ref, isScrollable, isDragging } = useDragToScroll();
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'overflow-x-auto',
+        isScrollable && (isDragging ? 'cursor-grabbing select-none' : 'cursor-grab'),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/table-actions-column.ts
+++ b/frontend/src/components/ui/table-actions-column.ts
@@ -1,0 +1,18 @@
+/** Sticky trailing column so row actions stay visible during horizontal scroll. */
+export const tableActionsHeadClass =
+  'sticky right-0 z-10 w-48 min-w-48 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background';
+
+export const tableActionsCellClass =
+  'sticky right-0 z-10 w-48 min-w-48 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';
+
+export const tableActionsHeadCompactClass =
+  'sticky right-0 z-10 w-24 min-w-24 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background';
+
+export const tableActionsCellCompactClass =
+  'sticky right-0 z-10 w-24 min-w-24 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';
+
+export const tableActionsHeadWideClass =
+  'sticky right-0 z-10 w-64 min-w-64 p-4 pr-6 text-right bg-gradient-to-r from-transparent via-background/80 to-background';
+
+export const tableActionsCellWideClass =
+  'sticky right-0 z-10 w-64 min-w-64 p-4 pr-6 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';

--- a/frontend/src/components/ui/table-actions-column.ts
+++ b/frontend/src/components/ui/table-actions-column.ts
@@ -1,5 +1,6 @@
 /** Sticky trailing column so row actions stay visible during horizontal scroll. */
-const tableActionsSticky = 'sticky right-0 z-10';
+// Pin actions only when the table container is at least 32rem wide.
+const tableActionsSticky = '@lg/table-scroll:sticky right-0 z-10';
 
 const tableActionsGradientDefault =
   'bg-[linear-gradient(to_right,transparent_0%,hsl(var(--background)/0.85)_14%,hsl(var(--background))_32%,hsl(var(--background))_100%)]';
@@ -13,10 +14,7 @@ const tableActionsGradientHover =
 const tableActionsHeadTypography =
   'text-right text-sm font-medium text-muted-foreground whitespace-nowrap';
 
-/** Fade zone passes clicks through; action controls stay interactive. */
-const tableActionsCellInteraction = 'pointer-events-none [&>*]:pointer-events-auto';
-
-const tableActionsCellShared = `${tableActionsSticky} ${tableActionsGradientDefault} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellInteraction}`;
+const tableActionsCellShared = `${tableActionsSticky} ${tableActionsGradientDefault} ${tableActionsGradientHover} transition-[background] duration-150`;
 
 export const tableActionsHeadClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-48 min-w-48 p-4 pr-4 ${tableActionsHeadTypography}`;
 
@@ -31,6 +29,6 @@ export const tableActionsCellCompactLowBalanceHoverClass =
 
 export const tableActionsHeadWideClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-64 min-w-64 p-4 pr-4 ${tableActionsHeadTypography}`;
 
-export const tableActionsCellWideClass = `${tableActionsCellShared} w-64 min-w-64 p-4 pr-4`;
+export const tableActionsCellWideClass = `${tableActionsCellShared} w-64 min-w-64 p-4 pr-4 text-right`;
 
-export const tableActionsCellWideDestructiveClass = `${tableActionsSticky} ${tableActionsGradientDestructive} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellInteraction} w-64 min-w-64 p-4 pr-4`;
+export const tableActionsCellWideDestructiveClass = `${tableActionsSticky} ${tableActionsGradientDestructive} ${tableActionsGradientHover} transition-[background] duration-150 w-64 min-w-64 p-4 pr-4`;

--- a/frontend/src/components/ui/table-actions-column.ts
+++ b/frontend/src/components/ui/table-actions-column.ts
@@ -1,18 +1,36 @@
 /** Sticky trailing column so row actions stay visible during horizontal scroll. */
-export const tableActionsHeadClass =
-  'sticky right-0 z-10 w-48 min-w-48 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background';
+const tableActionsSticky = 'sticky right-0 z-10';
 
-export const tableActionsCellClass =
-  'sticky right-0 z-10 w-48 min-w-48 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';
+const tableActionsGradientDefault =
+  'bg-[linear-gradient(to_right,transparent_0%,hsl(var(--background)/0.85)_14%,hsl(var(--background))_32%,hsl(var(--background))_100%)]';
 
-export const tableActionsHeadCompactClass =
-  'sticky right-0 z-10 w-24 min-w-24 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background';
+const tableActionsGradientDestructive =
+  'bg-[linear-gradient(to_right,transparent_0%,var(--table-actions-destructive-row-fade)_14%,var(--table-actions-destructive-row-fill)_32%,var(--table-actions-destructive-row-fill)_100%)]';
 
-export const tableActionsCellCompactClass =
-  'sticky right-0 z-10 w-24 min-w-24 p-4 pr-8 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';
+const tableActionsGradientHover =
+  'group-hover:bg-[linear-gradient(to_right,transparent_0%,var(--table-actions-row-hover-fade)_14%,var(--table-actions-row-hover-fill)_32%,var(--table-actions-row-hover-fill)_100%)]';
 
-export const tableActionsHeadWideClass =
-  'sticky right-0 z-10 w-64 min-w-64 p-4 pr-6 text-right bg-gradient-to-r from-transparent via-background/80 to-background';
+const tableActionsHeadTypography =
+  'text-right text-sm font-medium text-muted-foreground whitespace-nowrap';
 
-export const tableActionsCellWideClass =
-  'sticky right-0 z-10 w-64 min-w-64 p-4 pr-6 bg-gradient-to-r from-transparent via-background/80 to-background pointer-events-none [&>*]:pointer-events-auto';
+/** Fade zone passes clicks through; action controls stay interactive. */
+const tableActionsCellInteraction = 'pointer-events-none [&>*]:pointer-events-auto';
+
+const tableActionsCellShared = `${tableActionsSticky} ${tableActionsGradientDefault} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellInteraction}`;
+
+export const tableActionsHeadClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-48 min-w-48 p-4 pr-4 ${tableActionsHeadTypography}`;
+
+export const tableActionsCellClass = `${tableActionsCellShared} w-48 min-w-48 p-4 pr-4`;
+
+export const tableActionsHeadCompactClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-28 min-w-28 p-4 pr-4 ${tableActionsHeadTypography}`;
+
+export const tableActionsCellCompactClass = `${tableActionsCellShared} w-28 min-w-28 p-4 pr-4`;
+
+export const tableActionsCellCompactLowBalanceHoverClass =
+  'group-hover:!bg-[linear-gradient(to_right,transparent_0%,var(--table-actions-low-balance-hover-fade)_14%,var(--table-actions-low-balance-hover-fill)_32%,var(--table-actions-low-balance-hover-fill)_100%)]';
+
+export const tableActionsHeadWideClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-64 min-w-64 p-4 pr-4 ${tableActionsHeadTypography}`;
+
+export const tableActionsCellWideClass = `${tableActionsCellShared} w-64 min-w-64 p-4 pr-4`;
+
+export const tableActionsCellWideDestructiveClass = `${tableActionsSticky} ${tableActionsGradientDestructive} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellInteraction} w-64 min-w-64 p-4 pr-4`;

--- a/frontend/src/components/x402/AlertsTab.tsx
+++ b/frontend/src/components/x402/AlertsTab.tsx
@@ -10,6 +10,11 @@ import { Input } from '@/components/ui/input';
 import { Badge, type BadgeProps } from '@/components/ui/badge';
 import { CopyButton } from '@/components/ui/copy-button';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import {
   Dialog,
@@ -155,7 +160,7 @@ export function AlertsTab({ wallet }: { wallet?: X402Wallet }) {
         </div>
       </div>
 
-      <div className="border rounded-lg overflow-x-auto">
+      <HorizontalScrollArea className="border rounded-lg">
         <table className="w-full">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -177,7 +182,7 @@ export function AlertsTab({ wallet }: { wallet?: X402Wallet }) {
               <th scope="col" className="p-4 text-left text-sm font-medium text-muted-foreground">
                 Status
               </th>
-              <th scope="col" className="p-4 text-right text-sm font-medium text-muted-foreground">
+              <th scope="col" className={tableActionsHeadWideClass}>
                 Actions
               </th>
             </tr>
@@ -215,7 +220,10 @@ export function AlertsTab({ wallet }: { wallet?: X402Wallet }) {
               visibleRules.map((rule) => (
                 <tr
                   key={rule.id}
-                  className={cn('border-b last:border-0', !rule.enabled && 'opacity-50')}
+                  className={cn(
+                    'group border-b last:border-0 hover:bg-muted/50',
+                    !rule.enabled && 'opacity-50',
+                  )}
                 >
                   <td className="p-4">
                     <div className="flex items-center gap-1">
@@ -238,7 +246,7 @@ export function AlertsTab({ wallet }: { wallet?: X402Wallet }) {
                   <td className="p-4">
                     <Badge variant={STATUS_VARIANT[rule.status]}>{rule.status}</Badge>
                   </td>
-                  <td className="p-4 text-right">
+                  <td className={tableActionsCellWideClass}>
                     <div className="flex items-center justify-end gap-1">
                       <Button
                         variant="ghost"
@@ -276,7 +284,7 @@ export function AlertsTab({ wallet }: { wallet?: X402Wallet }) {
             )}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
 
       <AlertDialog
         key={dialogOpen ? (editing?.id ?? 'new') : 'closed'}

--- a/frontend/src/components/x402/ChainsTab.tsx
+++ b/frontend/src/components/x402/ChainsTab.tsx
@@ -10,6 +10,11 @@ import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
 import { CopyButton } from '@/components/ui/copy-button';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import {
   Dialog,
@@ -147,7 +152,7 @@ export function ChainsTab() {
         </div>
       </div>
 
-      <div className="border rounded-lg overflow-x-auto">
+      <HorizontalScrollArea className="border rounded-lg">
         <table className="w-full">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -166,7 +171,7 @@ export function ChainsTab() {
               <th scope="col" className="p-4 text-left text-sm font-medium text-muted-foreground">
                 Facilitator
               </th>
-              <th scope="col" className="p-4 text-right text-sm font-medium text-muted-foreground">
+              <th scope="col" className={tableActionsHeadWideClass}>
                 Actions
               </th>
             </tr>
@@ -191,7 +196,7 @@ export function ChainsTab() {
               </tr>
             ) : (
               networks.map((network) => (
-                <tr key={network.id} className="border-b last:border-0">
+                <tr key={network.id} className="group border-b last:border-0 hover:bg-muted/50">
                   <td className="p-4">
                     <div className="font-medium">{network.displayName}</div>
                     <div className="text-xs text-muted-foreground font-mono">{network.caip2Id}</div>
@@ -249,7 +254,7 @@ export function ChainsTab() {
                       <Badge variant="warning">Not set</Badge>
                     )}
                   </td>
-                  <td className="p-4 text-right">
+                  <td className={tableActionsCellWideClass}>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -264,7 +269,7 @@ export function ChainsTab() {
             )}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
 
       <ChainDialog
         key={dialogOpen ? (editing?.id ?? 'new') : 'closed'}

--- a/frontend/src/components/x402/PaymentsTab.tsx
+++ b/frontend/src/components/x402/PaymentsTab.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge, type BadgeProps } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { Spinner } from '@/components/ui/spinner';
 import { CopyButton } from '@/components/ui/copy-button';
 import {
@@ -185,7 +186,7 @@ export function PaymentsTab() {
         <RefreshButton onRefresh={refetch} isRefreshing={isRefetching} />
       </div>
 
-      <div className="border rounded-lg overflow-x-auto">
+      <HorizontalScrollArea className="border rounded-lg">
         <table className="w-full">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -253,7 +254,7 @@ export function PaymentsTab() {
             )}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
 
       {hasMore && (
         <div className="flex justify-center">

--- a/frontend/src/components/x402/WalletsTab.tsx
+++ b/frontend/src/components/x402/WalletsTab.tsx
@@ -24,6 +24,11 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import { CopyButton } from '@/components/ui/copy-button';
 import {
@@ -148,7 +153,7 @@ export function WalletsTab() {
         </div>
       </div>
 
-      <div className="border rounded-lg overflow-x-auto">
+      <HorizontalScrollArea className="border rounded-lg">
         <table className="w-full">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -167,7 +172,7 @@ export function WalletsTab() {
               <th scope="col" className="p-4 text-left text-sm font-medium text-muted-foreground">
                 Created
               </th>
-              <th scope="col" className="p-4 text-right text-sm font-medium text-muted-foreground">
+              <th scope="col" className={tableActionsHeadWideClass}>
                 Actions
               </th>
             </tr>
@@ -196,7 +201,7 @@ export function WalletsTab() {
               </tr>
             ) : (
               wallets.map((wallet) => (
-                <tr key={wallet.id} className="border-b last:border-0">
+                <tr key={wallet.id} className="group border-b last:border-0 hover:bg-muted/50">
                   <td className="p-4">
                     <div className="flex items-center gap-1">
                       <span className="font-mono text-sm" title={wallet.address}>
@@ -213,7 +218,7 @@ export function WalletsTab() {
                   <td className="p-4 text-sm text-muted-foreground">
                     {formatDateTime(wallet.createdAt)}
                   </td>
-                  <td className="p-4 text-right">
+                  <td className={tableActionsCellWideClass}>
                     <div className="flex items-center justify-end gap-1">
                       <Button variant="ghost" size="sm" onClick={() => setDetailsWallet(wallet)}>
                         <WalletIcon className="h-4 w-4" />
@@ -249,7 +254,7 @@ export function WalletsTab() {
             )}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
 
       {hasMore && (
         <div className="flex justify-center">

--- a/frontend/src/lib/drag-to-scroll.test.ts
+++ b/frontend/src/lib/drag-to-scroll.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+import { setTimeout as nextTask } from 'node:timers/promises';
+import { attachDragToScroll } from './drag-to-scroll';
+
+class ScrollElement extends EventTarget {
+  scrollWidth = 1000;
+  clientWidth = 500;
+  scrollLeft = 0;
+  interactive = false;
+  closest() {
+    return this.interactive ? this : null;
+  }
+}
+
+let element: ScrollElement;
+let documentTarget: EventTarget;
+let dragging: boolean;
+let detach: () => void;
+const originalGlobals = ['document', 'Element', 'HTMLTableRowElement'].map((name) => ({
+  name,
+  descriptor: Object.getOwnPropertyDescriptor(globalThis, name),
+}));
+
+beforeEach(() => {
+  documentTarget = new EventTarget();
+  element = new ScrollElement();
+  dragging = false;
+  Object.defineProperty(globalThis, 'document', { configurable: true, value: documentTarget });
+  Object.defineProperty(globalThis, 'Element', { configurable: true, value: ScrollElement });
+  Object.defineProperty(globalThis, 'HTMLTableRowElement', {
+    configurable: true,
+    value: class extends ScrollElement {},
+  });
+  detach = attachDragToScroll(element as unknown as HTMLElement, (value) => {
+    dragging = value;
+  });
+});
+
+afterEach(() => {
+  detach();
+  for (const { name, descriptor } of originalGlobals) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else Reflect.deleteProperty(globalThis, name);
+  }
+});
+
+function pointer(target: EventTarget, type: string, pageX: number, pageY = 0) {
+  target.dispatchEvent(
+    Object.assign(new Event(type, { cancelable: true }), {
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 0,
+      pageX,
+      pageY,
+    }),
+  );
+}
+
+function click() {
+  const event = Object.assign(new Event('click', { cancelable: true }), { detail: 1 });
+  element.dispatchEvent(event);
+  return event;
+}
+
+function startDrag() {
+  pointer(element, 'pointerdown', 300);
+  pointer(documentTarget, 'pointermove', 100);
+  assert.equal(element.scrollLeft, 200);
+  assert.equal(dragging, true);
+}
+
+test('a completed drag suppresses its own click but not the next click', () => {
+  startDrag();
+  pointer(documentTarget, 'pointerup', 100);
+  assert.equal(dragging, false);
+  assert.equal(click().defaultPrevented, true);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('release outside the table does not suppress a later action click', async () => {
+  startDrag();
+  pointer(documentTarget, 'pointerup', 100);
+  // The release outside has no click on this element during the current task.
+  await nextTask(10);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('pointer cancellation does not suppress an unrelated action click', () => {
+  startDrag();
+  pointer(documentTarget, 'pointercancel', 100);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('detaching removes pending click suppression', () => {
+  startDrag();
+  pointer(documentTarget, 'pointerup', 100);
+  detach();
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('movement below the drag threshold preserves row activation', () => {
+  pointer(element, 'pointerdown', 300);
+  pointer(documentTarget, 'pointermove', 298);
+  pointer(documentTarget, 'pointerup', 298);
+  assert.equal(element.scrollLeft, 0);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('vertical gestures preserve native scrolling and row activation', () => {
+  pointer(element, 'pointerdown', 300);
+  pointer(documentTarget, 'pointermove', 298, 30);
+  pointer(documentTarget, 'pointermove', 100, 30);
+  pointer(documentTarget, 'pointerup', 100, 30);
+  assert.equal(element.scrollLeft, 0);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('interactive controls never start a table drag', () => {
+  element.interactive = true;
+  pointer(element, 'pointerdown', 300);
+  pointer(documentTarget, 'pointermove', 100);
+  pointer(documentTarget, 'pointerup', 100);
+  assert.equal(element.scrollLeft, 0);
+  assert.equal(dragging, false);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('a new pointer gesture clears suppression from an outside release immediately', () => {
+  startDrag();
+  pointer(documentTarget, 'pointerup', 100);
+  element.interactive = true;
+  pointer(element, 'pointerdown', 300);
+  assert.equal(click().defaultPrevented, false);
+});
+
+test('a table without horizontal overflow keeps native behavior', () => {
+  element.scrollWidth = element.clientWidth;
+  pointer(element, 'pointerdown', 300);
+  pointer(documentTarget, 'pointermove', 100);
+  pointer(documentTarget, 'pointerup', 100);
+  assert.equal(element.scrollLeft, 0);
+  assert.equal(click().defaultPrevented, false);
+});

--- a/frontend/src/lib/drag-to-scroll.ts
+++ b/frontend/src/lib/drag-to-scroll.ts
@@ -1,0 +1,116 @@
+const DRAG_THRESHOLD_PX = 5;
+
+const INTERACTIVE_SELECTOR =
+  'button, a, input, textarea, select, label, [role="button"], [contenteditable="true"], [data-no-drag-scroll]';
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const interactive = target.closest(INTERACTIVE_SELECTOR);
+  if (!interactive) return false;
+  // rowActivation sets role="button" on clickable table rows for keyboard a11y.
+  // Row chrome should still support drag-to-scroll; nested buttons/links stay excluded.
+  if (interactive instanceof HTMLTableRowElement && interactive.getAttribute('role') === 'button') {
+    return false;
+  }
+  return true;
+}
+
+export function attachDragToScroll(element: HTMLElement, setIsDragging: (value: boolean) => void) {
+  let state: {
+    pointerId: number | null;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    didDrag: boolean;
+  } = {
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    scrollLeft: 0,
+    didDrag: false,
+  };
+  let clickSuppressionTimeout: ReturnType<typeof setTimeout> | undefined;
+  const clearClickSuppression = () => {
+    clearTimeout(clickSuppressionTimeout);
+    element.removeEventListener('click', suppressClick, { capture: true });
+  };
+  const suppressClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    clearClickSuppression();
+  };
+  const removeDocumentListeners = () => {
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerEnd);
+    document.removeEventListener('pointercancel', onPointerEnd);
+  };
+
+  const resetDragState = () => {
+    removeDocumentListeners();
+    state.pointerId = null;
+    state.didDrag = false;
+    setIsDragging(false);
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (state.pointerId !== event.pointerId) return;
+
+    const deltaX = event.pageX - state.startX;
+    const deltaY = event.pageY - state.startY;
+
+    if (!state.didDrag) {
+      if (Math.hypot(deltaX, deltaY) < DRAG_THRESHOLD_PX) return;
+      if (Math.abs(deltaY) > Math.abs(deltaX)) {
+        resetDragState();
+        return;
+      }
+
+      state.didDrag = true;
+      setIsDragging(true);
+    }
+
+    event.preventDefault();
+    element.scrollLeft = state.scrollLeft - deltaX;
+  };
+
+  const onPointerEnd = (event: PointerEvent) => {
+    if (state.pointerId !== event.pointerId) return;
+
+    clearClickSuppression();
+    if (state.didDrag && event.type === 'pointerup') {
+      element.addEventListener('click', suppressClick, { capture: true });
+      // A mouse click follows pointerup in the same task. Outside releases have no local click.
+      clickSuppressionTimeout = setTimeout(clearClickSuppression, 0);
+    }
+
+    resetDragState();
+  };
+
+  const onPointerDown = (event: PointerEvent) => {
+    clearClickSuppression();
+    if (event.button !== 0) return;
+    if (event.pointerType === 'touch') return;
+    if (element.scrollWidth <= element.clientWidth + 1) return;
+    if (isInteractiveTarget(event.target)) return;
+
+    state = {
+      pointerId: event.pointerId,
+      startX: event.pageX,
+      startY: event.pageY,
+      scrollLeft: element.scrollLeft,
+      didDrag: false,
+    };
+
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerEnd);
+    document.addEventListener('pointercancel', onPointerEnd);
+  };
+
+  element.addEventListener('pointerdown', onPointerDown);
+
+  return () => {
+    element.removeEventListener('pointerdown', onPointerDown);
+    removeDocumentListeners();
+    clearClickSuppression();
+  };
+}

--- a/frontend/src/lib/hooks/useDragToScroll.ts
+++ b/frontend/src/lib/hooks/useDragToScroll.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DRAG_THRESHOLD_PX = 5;
+
+const INTERACTIVE_SELECTOR =
+  'button, a, input, textarea, select, label, [role="button"], [contenteditable="true"], [data-no-drag-scroll]';
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const interactive = target.closest(INTERACTIVE_SELECTOR);
+  if (!interactive) return false;
+  // rowActivation sets role="button" on clickable table rows for keyboard a11y.
+  // Row chrome should still support drag-to-scroll; nested buttons/links stay excluded.
+  if (interactive instanceof HTMLTableRowElement && interactive.getAttribute('role') === 'button') {
+    return false;
+  }
+  return true;
+}
+
+export function useDragToScroll<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null);
+  const isScrollableRef = useRef(false);
+  const dragState = useRef<{
+    pointerId: number | null;
+    startX: number;
+    startY: number;
+    scrollLeft: number;
+    didDrag: boolean;
+  }>({
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    scrollLeft: 0,
+    didDrag: false,
+  });
+  const [isScrollable, setIsScrollable] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const updateScrollable = useCallback(() => {
+    const element = ref.current;
+    if (!element) return;
+    const next = element.scrollWidth > element.clientWidth + 1;
+    isScrollableRef.current = next;
+    setIsScrollable(next);
+  }, []);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    updateScrollable();
+
+    const resizeObserver = new ResizeObserver(updateScrollable);
+    resizeObserver.observe(element);
+
+    const mutationObserver = new MutationObserver(updateScrollable);
+    mutationObserver.observe(element, { childList: true, subtree: true });
+
+    const resetDragState = () => {
+      dragState.current.pointerId = null;
+      dragState.current.didDrag = false;
+      setIsDragging(false);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const state = dragState.current;
+      if (state.pointerId !== event.pointerId) return;
+
+      const deltaX = event.pageX - state.startX;
+      const deltaY = event.pageY - state.startY;
+
+      if (!state.didDrag) {
+        if (Math.hypot(deltaX, deltaY) < DRAG_THRESHOLD_PX) return;
+        if (Math.abs(deltaY) > Math.abs(deltaX)) {
+          resetDragState();
+          return;
+        }
+
+        state.didDrag = true;
+        setIsDragging(true);
+      }
+
+      event.preventDefault();
+      element.scrollLeft = state.scrollLeft - deltaX;
+    };
+
+    const onPointerEnd = (event: PointerEvent) => {
+      const state = dragState.current;
+      if (state.pointerId !== event.pointerId) return;
+
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerEnd);
+      document.removeEventListener('pointercancel', onPointerEnd);
+
+      if (state.didDrag) {
+        const suppressClick = (clickEvent: MouseEvent) => {
+          clickEvent.preventDefault();
+          clickEvent.stopPropagation();
+        };
+        element.addEventListener('click', suppressClick, {
+          capture: true,
+          once: true,
+        });
+      }
+
+      resetDragState();
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      if (event.pointerType === 'touch') return;
+      if (!isScrollableRef.current) return;
+      if (isInteractiveTarget(event.target)) return;
+
+      dragState.current = {
+        pointerId: event.pointerId,
+        startX: event.pageX,
+        startY: event.pageY,
+        scrollLeft: element.scrollLeft,
+        didDrag: false,
+      };
+
+      document.addEventListener('pointermove', onPointerMove);
+      document.addEventListener('pointerup', onPointerEnd);
+      document.addEventListener('pointercancel', onPointerEnd);
+    };
+
+    element.addEventListener('pointerdown', onPointerDown);
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      element.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerEnd);
+      document.removeEventListener('pointercancel', onPointerEnd);
+    };
+  }, [updateScrollable]);
+
+  return { ref, isScrollable, isDragging };
+}

--- a/frontend/src/lib/hooks/useDragToScroll.ts
+++ b/frontend/src/lib/hooks/useDragToScroll.ts
@@ -1,38 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-const DRAG_THRESHOLD_PX = 5;
-
-const INTERACTIVE_SELECTOR =
-  'button, a, input, textarea, select, label, [role="button"], [contenteditable="true"], [data-no-drag-scroll]';
-
-function isInteractiveTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false;
-  const interactive = target.closest(INTERACTIVE_SELECTOR);
-  if (!interactive) return false;
-  // rowActivation sets role="button" on clickable table rows for keyboard a11y.
-  // Row chrome should still support drag-to-scroll; nested buttons/links stay excluded.
-  if (interactive instanceof HTMLTableRowElement && interactive.getAttribute('role') === 'button') {
-    return false;
-  }
-  return true;
-}
+import { attachDragToScroll } from '../drag-to-scroll';
 
 export function useDragToScroll<T extends HTMLElement = HTMLDivElement>() {
   const ref = useRef<T>(null);
-  const isScrollableRef = useRef(false);
-  const dragState = useRef<{
-    pointerId: number | null;
-    startX: number;
-    startY: number;
-    scrollLeft: number;
-    didDrag: boolean;
-  }>({
-    pointerId: null,
-    startX: 0,
-    startY: 0,
-    scrollLeft: 0,
-    didDrag: false,
-  });
   const [isScrollable, setIsScrollable] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -40,7 +11,6 @@ export function useDragToScroll<T extends HTMLElement = HTMLDivElement>() {
     const element = ref.current;
     if (!element) return;
     const next = element.scrollWidth > element.clientWidth + 1;
-    isScrollableRef.current = next;
     setIsScrollable(next);
   }, []);
 
@@ -56,84 +26,12 @@ export function useDragToScroll<T extends HTMLElement = HTMLDivElement>() {
     const mutationObserver = new MutationObserver(updateScrollable);
     mutationObserver.observe(element, { childList: true, subtree: true });
 
-    const resetDragState = () => {
-      dragState.current.pointerId = null;
-      dragState.current.didDrag = false;
-      setIsDragging(false);
-    };
-
-    const onPointerMove = (event: PointerEvent) => {
-      const state = dragState.current;
-      if (state.pointerId !== event.pointerId) return;
-
-      const deltaX = event.pageX - state.startX;
-      const deltaY = event.pageY - state.startY;
-
-      if (!state.didDrag) {
-        if (Math.hypot(deltaX, deltaY) < DRAG_THRESHOLD_PX) return;
-        if (Math.abs(deltaY) > Math.abs(deltaX)) {
-          resetDragState();
-          return;
-        }
-
-        state.didDrag = true;
-        setIsDragging(true);
-      }
-
-      event.preventDefault();
-      element.scrollLeft = state.scrollLeft - deltaX;
-    };
-
-    const onPointerEnd = (event: PointerEvent) => {
-      const state = dragState.current;
-      if (state.pointerId !== event.pointerId) return;
-
-      document.removeEventListener('pointermove', onPointerMove);
-      document.removeEventListener('pointerup', onPointerEnd);
-      document.removeEventListener('pointercancel', onPointerEnd);
-
-      if (state.didDrag) {
-        const suppressClick = (clickEvent: MouseEvent) => {
-          clickEvent.preventDefault();
-          clickEvent.stopPropagation();
-        };
-        element.addEventListener('click', suppressClick, {
-          capture: true,
-          once: true,
-        });
-      }
-
-      resetDragState();
-    };
-
-    const onPointerDown = (event: PointerEvent) => {
-      if (event.button !== 0) return;
-      if (event.pointerType === 'touch') return;
-      if (!isScrollableRef.current) return;
-      if (isInteractiveTarget(event.target)) return;
-
-      dragState.current = {
-        pointerId: event.pointerId,
-        startX: event.pageX,
-        startY: event.pageY,
-        scrollLeft: element.scrollLeft,
-        didDrag: false,
-      };
-
-      document.addEventListener('pointermove', onPointerMove);
-      document.addEventListener('pointerup', onPointerEnd);
-      document.addEventListener('pointercancel', onPointerEnd);
-    };
-
-    element.addEventListener('pointerdown', onPointerDown);
+    const detachDragToScroll = attachDragToScroll(element, setIsDragging);
 
     return () => {
       resizeObserver.disconnect();
       mutationObserver.disconnect();
-      element.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('pointermove', onPointerMove);
-      document.removeEventListener('pointerup', onPointerEnd);
-      document.removeEventListener('pointercancel', onPointerEnd);
+      detachDragToScroll();
     };
   }, [updateScrollable]);
 

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -17,6 +17,7 @@ import { toast } from 'react-toastify';
 import { useApiMutation } from '@/lib/hooks/useApiMutation';
 import Head from 'next/head';
 import { AIAgentTableSkeleton } from '@/components/skeletons/AIAgentTableSkeleton';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { tableActionsCellClass, tableActionsHeadClass } from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import { useQueryClient } from '@tanstack/react-query';
@@ -522,7 +523,7 @@ export default function AIAgentsPage() {
               </div>
             )}
 
-            <div className="rounded-lg border overflow-x-auto">
+            <HorizontalScrollArea className="rounded-lg border">
               <table
                 className={cn(
                   'w-full transition-opacity duration-150',
@@ -579,7 +580,9 @@ export default function AIAgentsPage() {
                     >
                       Status
                     </th>
-                    <th scope="col" className={tableActionsHeadClass}></th>
+                    <th scope="col" className={tableActionsHeadClass}>
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -619,7 +622,7 @@ export default function AIAgentsPage() {
                         <tr
                           key={agent.id}
                           className={cn(
-                            'border-b cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 opacity-0',
+                            'group border-b cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 opacity-0',
                             agent.state === 'DeregistrationConfirmed'
                               ? 'animate-fade-in-to-muted'
                               : 'animate-fade-in',
@@ -795,7 +798,7 @@ export default function AIAgentsPage() {
                                     e.stopPropagation();
                                     openAgentDetails(agent, { initialTab: 'Earnings' });
                                   }}
-                                  className="text-white hover:text-gray-200 hover:bg-gray-600"
+                                  className="text-primary hover:text-primary hover:bg-primary/10"
                                   title="View Details & Earnings"
                                 >
                                   <ExternalLink className="h-4 w-4" />
@@ -855,7 +858,7 @@ export default function AIAgentsPage() {
                   )}
                 </tbody>
               </table>
-            </div>
+            </HorizontalScrollArea>
 
             <div className="flex flex-col gap-4 items-center">
               {!(isLoading && !agents.length) && (

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -17,6 +17,7 @@ import { toast } from 'react-toastify';
 import { useApiMutation } from '@/lib/hooks/useApiMutation';
 import Head from 'next/head';
 import { AIAgentTableSkeleton } from '@/components/skeletons/AIAgentTableSkeleton';
+import { tableActionsCellClass, tableActionsHeadClass } from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import { useQueryClient } from '@tanstack/react-query';
 import { useContextAgents, type AgentRelation } from '@/lib/queries/useContextAgents';
@@ -578,7 +579,7 @@ export default function AIAgentsPage() {
                     >
                       Status
                     </th>
-                    <th scope="col" className="w-20 p-4 pr-8"></th>
+                    <th scope="col" className={tableActionsHeadClass}></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -767,7 +768,7 @@ export default function AIAgentsPage() {
                               {parseAgentStatus(agent.state)}
                             </Badge>
                           </td>
-                          <td className="p-4 pr-8">
+                          <td className={tableActionsCellClass}>
                             {isDeregisterableAgentState(agent.state) ? (
                               <div className="flex items-center gap-1">
                                 {/* Manage actions (verify/update/delete) only apply to agents

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -832,9 +832,9 @@ export default function AIAgentsPage() {
                                         e.stopPropagation();
                                         handleDeleteClick(agent);
                                       }}
-                                      className="text-destructive hover:text-destructive hover:bg-destructive/10 group"
+                                      className="text-destructive hover:text-destructive hover:bg-destructive/10 group/delete"
                                     >
-                                      <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                                      <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover/delete:scale-110" />
                                     </Button>
                                   )}
                               </div>

--- a/frontend/src/pages/api-keys.tsx
+++ b/frontend/src/pages/api-keys.tsx
@@ -14,6 +14,8 @@ import { useApiMutation } from '@/lib/hooks/useApiMutation';
 import { AddApiKeyDialog } from '@/components/api-keys/AddApiKeyDialog';
 import { UpdateApiKeyDialog } from '@/components/api-keys/UpdateApiKeyDialog';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
+import { tableActionsCellClass, tableActionsHeadClass } from '@/components/ui/table-actions-column';
 import { ApiKeyTableSkeleton } from '@/components/skeletons/ApiKeyTableSkeleton';
 import { Search, Plus } from 'lucide-react';
 import { Tabs } from '@/components/ui/tabs';
@@ -229,7 +231,7 @@ export default function ApiKeys() {
             </div>
           </div>
 
-          <div className="border rounded-lg overflow-x-auto">
+          <HorizontalScrollArea className="border rounded-lg">
             <table className="w-full">
               <thead>
                 <tr className="border-b">
@@ -246,7 +248,7 @@ export default function ApiKeys() {
                   <th className="p-4 text-left text-sm font-medium">Networks</th>
                   <th className="p-4 text-left text-sm font-medium">Usage Limits</th>
                   <th className="p-4 text-left text-sm font-medium">Status</th>
-                  <th className="w-12 p-4"></th>
+                  <th className={tableActionsHeadClass}>Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -312,7 +314,7 @@ export default function ApiKeys() {
                           {key.status}
                         </span>
                       </td>
-                      <td className="p-4">
+                      <td className={tableActionsCellClass}>
                         <Select
                           onValueChange={(value) => {
                             if (value === 'update') {
@@ -343,7 +345,7 @@ export default function ApiKeys() {
                 )}
               </tbody>
             </table>
-          </div>
+          </HorizontalScrollArea>
 
           <div className="flex flex-col gap-4 items-center">
             {!isLoading && (

--- a/frontend/src/pages/inbox-agents.tsx
+++ b/frontend/src/pages/inbox-agents.tsx
@@ -505,14 +505,14 @@ export default function InboxAgentsPage() {
                                     event.stopPropagation();
                                     handleDeleteClick(agent);
                                   }}
-                                  className="text-destructive hover:text-destructive hover:bg-destructive/10 group"
+                                  className="text-destructive hover:text-destructive hover:bg-destructive/10 group/delete"
                                   title={
                                     agent.state === 'RegistrationConfirmed'
                                       ? 'Deregister inbox agent'
                                       : 'Delete inbox agent'
                                   }
                                 >
-                                  <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                                  <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover/delete:scale-110" />
                                 </Button>
                               ) : agent.state === 'RegistrationInitiated' ||
                                 agent.state === 'DeregistrationInitiated' ? (

--- a/frontend/src/pages/inbox-agents.tsx
+++ b/frontend/src/pages/inbox-agents.tsx
@@ -18,6 +18,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { Tabs } from '@/components/ui/tabs';
 import { WalletDetailsDialog, WalletWithBalance } from '@/components/wallets/WalletDetailsDialog';
 import { AIAgentTableSkeleton } from '@/components/skeletons/AIAgentTableSkeleton';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   tableActionsCellCompactClass,
   tableActionsHeadCompactClass,
@@ -308,7 +309,7 @@ export default function InboxAgentsPage() {
               </div>
             </div>
 
-            <div className="rounded-lg border overflow-x-auto">
+            <HorizontalScrollArea className="rounded-lg border">
               <table
                 className={cn(
                   'w-full transition-opacity duration-150',
@@ -338,7 +339,7 @@ export default function InboxAgentsPage() {
                     <th className="p-4 text-left text-sm font-medium text-muted-foreground">
                       Status
                     </th>
-                    <th className={tableActionsHeadCompactClass}></th>
+                    <th className={tableActionsHeadCompactClass}>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -384,7 +385,7 @@ export default function InboxAgentsPage() {
                         <tr
                           key={agent.id}
                           className={cn(
-                            'border-b cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 opacity-0',
+                            'group border-b cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 opacity-0',
                             agent.state === 'DeregistrationConfirmed'
                               ? 'animate-fade-in-to-muted'
                               : 'animate-fade-in',
@@ -532,7 +533,7 @@ export default function InboxAgentsPage() {
                   )}
                 </tbody>
               </table>
-            </div>
+            </HorizontalScrollArea>
 
             <div className="flex flex-col gap-4 items-center">
               {!((isLoading || isSourceResolving) && !inboxAgents.length) && (

--- a/frontend/src/pages/inbox-agents.tsx
+++ b/frontend/src/pages/inbox-agents.tsx
@@ -18,6 +18,10 @@ import { Spinner } from '@/components/ui/spinner';
 import { Tabs } from '@/components/ui/tabs';
 import { WalletDetailsDialog, WalletWithBalance } from '@/components/wallets/WalletDetailsDialog';
 import { AIAgentTableSkeleton } from '@/components/skeletons/AIAgentTableSkeleton';
+import {
+  tableActionsCellCompactClass,
+  tableActionsHeadCompactClass,
+} from '@/components/ui/table-actions-column';
 import { RefreshButton } from '@/components/RefreshButton';
 import { InboxAgentDetailsDialog } from '@/components/inbox-agents/InboxAgentDetailsDialog';
 import { RegisterInboxAgentDialog } from '@/components/inbox-agents/RegisterInboxAgentDialog';
@@ -334,7 +338,7 @@ export default function InboxAgentsPage() {
                     <th className="p-4 text-left text-sm font-medium text-muted-foreground">
                       Status
                     </th>
-                    <th className="w-24 p-4 pr-8"></th>
+                    <th className={tableActionsHeadCompactClass}></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -478,7 +482,7 @@ export default function InboxAgentsPage() {
                               {parseInboxAgentStatus(agent.state)}
                             </Badge>
                           </td>
-                          <td className="p-4 pr-8">
+                          <td className={tableActionsCellCompactClass}>
                             <div className="flex items-center gap-1">
                               <Button
                                 variant="ghost"

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -43,6 +43,7 @@ import { CopyButton } from '@/components/ui/copy-button';
 import { AnimatedPage } from '@/components/ui/animated-page';
 import { StatCard } from '@/components/ui/stat-card';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { WelcomeBanner } from '@/components/ui/welcome-banner';
 import { isWalletFundStepComplete } from '@/components/ui/welcome-banner-fund-step';
 import { SetupV2Banner } from '@/components/setup/SetupV2Banner';
@@ -466,7 +467,7 @@ export default function Overview() {
                       {walletsSectionLoading ? (
                         <WalletListSkeleton rows={2} />
                       ) : (
-                        <div className="animate-content-reveal mb-4 max-h-125 overflow-y-auto overflow-x-auto w-full">
+                        <HorizontalScrollArea className="animate-content-reveal mb-4 max-h-125 overflow-y-auto w-full">
                           <table className="w-full">
                             <thead className="sticky top-0 bg-muted/30 dark:bg-muted/15 z-10">
                               <tr className="text-sm text-muted-foreground border-b">
@@ -606,7 +607,7 @@ export default function Overview() {
                               )}
                             </tbody>
                           </table>
-                        </div>
+                        </HorizontalScrollArea>
                       )}
                     </div>
 

--- a/frontend/src/pages/invoices.tsx
+++ b/frontend/src/pages/invoices.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import { AnimatedPage } from '@/components/ui/animated-page';
 import { SearchInput } from '@/components/ui/search-input';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { MonthPicker } from '@/components/ui/month-picker';
 import { useInvoices, type InvoiceSummary } from '@/lib/hooks/useInvoices';
 import { useUninvoicedPayments, type UninvoicedPayment } from '@/lib/hooks/useUninvoicedPayments';
@@ -317,7 +318,7 @@ export default function Invoices() {
                   {invoicesErrorMessage}
                 </div>
               )}
-              <div className="border rounded-lg overflow-x-auto">
+              <HorizontalScrollArea className="border rounded-lg">
                 <table className="w-full">
                   <thead className="bg-muted/30 dark:bg-muted/15">
                     <tr className="border-b">
@@ -382,7 +383,7 @@ export default function Invoices() {
                         <tr
                           key={invoice.id}
                           className={cn(
-                            'border-b last:border-b-0 animate-fade-in opacity-0 transition-[background-color,opacity] duration-150',
+                            'group border-b last:border-b-0 animate-fade-in opacity-0 transition-[background-color,opacity] duration-150',
                             'cursor-pointer hover:bg-muted/50',
                           )}
                           style={{ animationDelay: `${Math.min(index, 9) * 40}ms` }}
@@ -423,7 +424,7 @@ export default function Invoices() {
                     )}
                   </tbody>
                 </table>
-              </div>
+              </HorizontalScrollArea>
 
               <div className="flex flex-col gap-4 items-center">
                 {!isLoadingInvoices && (

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -24,6 +24,7 @@ import { toast } from 'react-toastify';
 import { shortenAddress, cn } from '@/lib/utils';
 import Head from 'next/head';
 import { PaymentSourceTableSkeleton } from '@/components/skeletons/PaymentSourceTableSkeleton';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   tableActionsCellCompactClass,
   tableActionsHeadCompactClass,
@@ -399,7 +400,7 @@ export default function PaymentSourcesPage() {
               </Badge>
             </div>
 
-            <div className="rounded-lg border overflow-x-auto">
+            <HorizontalScrollArea className="rounded-lg border">
               <table className="w-full">
                 <thead>
                   <tr className="border-b">
@@ -424,7 +425,9 @@ export default function PaymentSourcesPage() {
                     <th scope="col" className="p-4 text-left text-sm font-medium">
                       Wallets
                     </th>
-                    <th scope="col" className={tableActionsHeadCompactClass}></th>
+                    <th scope="col" className={tableActionsHeadCompactClass}>
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -453,7 +456,7 @@ export default function PaymentSourcesPage() {
                       <tr
                         key={source.id}
                         className={cn(
-                          'border-b last:border-b-0 cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 animate-fade-in opacity-0',
+                          'group border-b last:border-b-0 cursor-pointer hover:bg-muted/50 transition-[background-color,opacity] duration-150 animate-fade-in opacity-0',
                           selectedPaymentSourceId === source.id &&
                             'bg-green-50 dark:bg-green-950/20',
                         )}
@@ -571,7 +574,7 @@ export default function PaymentSourcesPage() {
                   )}
                 </tbody>
               </table>
-            </div>
+            </HorizontalScrollArea>
 
             <X402SourcesSection network={network} searchQuery={searchQuery} />
           </div>

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -24,6 +24,10 @@ import { toast } from 'react-toastify';
 import { shortenAddress, cn } from '@/lib/utils';
 import Head from 'next/head';
 import { PaymentSourceTableSkeleton } from '@/components/skeletons/PaymentSourceTableSkeleton';
+import {
+  tableActionsCellCompactClass,
+  tableActionsHeadCompactClass,
+} from '@/components/ui/table-actions-column';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Dialog,
@@ -420,7 +424,7 @@ export default function PaymentSourcesPage() {
                     <th scope="col" className="p-4 text-left text-sm font-medium">
                       Wallets
                     </th>
-                    <th scope="col" className="w-20 p-4 pr-8"></th>
+                    <th scope="col" className={tableActionsHeadCompactClass}></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -511,7 +515,10 @@ export default function PaymentSourcesPage() {
                             </span>
                           </div>
                         </td>
-                        <td className="p-4 pr-8" onClick={(e) => e.stopPropagation()}>
+                        <td
+                          className={tableActionsCellCompactClass}
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <div className="flex gap-2">
                             <Button
                               variant="ghost"

--- a/frontend/src/pages/payment-sources.tsx
+++ b/frontend/src/pages/payment-sources.tsx
@@ -535,9 +535,9 @@ export default function PaymentSourcesPage() {
                               variant="ghost"
                               size="sm"
                               onClick={() => setSourceToDelete(source)}
-                              className="text-destructive hover:text-destructive hover:bg-destructive/10 group"
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10 group/delete"
                             >
-                              <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />
+                              <Trash2 className="h-4 w-4 transition-transform duration-200 group-hover/delete:scale-110" />
                             </Button>
 
                             {selectedPaymentSourceId === source.id ? (

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -8,6 +8,10 @@ import { RefreshButton } from '@/components/RefreshButton';
 import Head from 'next/head';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { TransactionTableSkeleton } from '@/components/skeletons/TransactionTableSkeleton';
+import {
+  tableActionsCellCompactClass,
+  tableActionsHeadCompactClass,
+} from '@/components/ui/table-actions-column';
 import { MoreHorizontal, FlaskConical } from 'lucide-react';
 import { Tabs } from '@/components/ui/tabs';
 import { Pagination } from '@/components/ui/pagination';
@@ -513,7 +517,7 @@ export default function Transactions() {
                     Unlock Time
                   </th>
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">Date</th>
-                  <th className="p-4 text-left text-sm font-medium text-muted-foreground pr-8"></th>
+                  <th className={tableActionsHeadCompactClass}></th>
                 </tr>
               </thead>
               <tbody>
@@ -668,7 +672,7 @@ export default function Transactions() {
                           : '—'}
                       </td>
                       <td className="p-4">{formatDateTime(transaction.createdAt)}</td>
-                      <td className="p-4 pr-8">
+                      <td className={tableActionsCellCompactClass}>
                         <Button
                           variant="ghost"
                           size="icon"

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -8,6 +8,7 @@ import { RefreshButton } from '@/components/RefreshButton';
 import Head from 'next/head';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { TransactionTableSkeleton } from '@/components/skeletons/TransactionTableSkeleton';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   tableActionsCellCompactClass,
   tableActionsHeadCompactClass,
@@ -473,7 +474,7 @@ export default function Transactions() {
             </div>
           )}
 
-          <div className="border rounded-lg overflow-x-auto">
+          <HorizontalScrollArea className="border rounded-lg">
             <table
               className={cn(
                 'w-full transition-opacity duration-150',
@@ -517,7 +518,7 @@ export default function Transactions() {
                     Unlock Time
                   </th>
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">Date</th>
-                  <th className={tableActionsHeadCompactClass}></th>
+                  <th className={tableActionsHeadCompactClass}>Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -557,7 +558,7 @@ export default function Transactions() {
                     <tr
                       key={transaction.id}
                       className={cn(
-                        'border-b last:border-b-0 animate-fade-in opacity-0 transition-[background-color,opacity] duration-150',
+                        'group border-b last:border-b-0 animate-fade-in opacity-0 transition-[background-color,opacity] duration-150',
                         transaction.NextAction?.errorType
                           ? 'bg-destructive/10 border-l-2 border-l-destructive'
                           : '',
@@ -687,7 +688,7 @@ export default function Transactions() {
                 )}
               </tbody>
             </table>
-          </div>
+          </HorizontalScrollArea>
 
           <div className="flex flex-col gap-4 items-center">
             {!isInitialLoading && (

--- a/frontend/src/pages/tx-sync-quarantine.tsx
+++ b/frontend/src/pages/tx-sync-quarantine.tsx
@@ -5,6 +5,7 @@ import { AnimatedPage } from '@/components/ui/animated-page';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { EmptyState } from '@/components/ui/empty-state';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import { Pagination } from '@/components/ui/pagination';
 import {
   Select,
@@ -159,13 +160,13 @@ export default function TxSyncQuarantinePage() {
           </div>
 
           {isInitialLoading ? (
-            <div className="border rounded-lg overflow-x-auto">
+            <HorizontalScrollArea className="border rounded-lg">
               <table className="w-full">
                 <tbody>
                   <TransactionTableSkeleton rows={5} />
                 </tbody>
               </table>
-            </div>
+            </HorizontalScrollArea>
           ) : isError ? (
             <div className="rounded-lg border">
               <EmptyState

--- a/frontend/src/pages/wallets.tsx
+++ b/frontend/src/pages/wallets.tsx
@@ -32,12 +32,14 @@ import {
   type HotWalletType,
 } from '@/lib/wallet-type';
 
-import { formatSixDecimalAmount, shortenAddress } from '@/lib/utils';
+import { formatSixDecimalAmount, shortenAddress, cn } from '@/lib/utils';
 import Head from 'next/head';
 import { useRate } from '@/lib/hooks/useRate';
 import { WalletTableSkeleton } from '@/components/skeletons/WalletTableSkeleton';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   tableActionsCellCompactClass,
+  tableActionsCellCompactLowBalanceHoverClass,
   tableActionsHeadCompactClass,
 } from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
@@ -250,7 +252,7 @@ export default function WalletsPage() {
             </div>
           </div>
 
-          <div className="rounded-lg border overflow-x-auto">
+          <HorizontalScrollArea className="rounded-lg border">
             <table className="w-full">
               <thead className="bg-muted/30 dark:bg-muted/15">
                 <tr className="border-b">
@@ -270,7 +272,7 @@ export default function WalletsPage() {
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">
                     Balance, {network === 'Mainnet' ? 'USDCx' : 'tUSDM'}
                   </th>
-                  <th className={tableActionsHeadCompactClass}></th>
+                  <th className={tableActionsHeadCompactClass}>Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -291,7 +293,7 @@ export default function WalletsPage() {
                     {filteredWallets.map((wallet, index) => (
                       <tr
                         key={wallet.id}
-                        className={`border-b last:border-b-0 cursor-pointer animate-fade-in opacity-0 transition-[background-color,opacity] duration-150 ${
+                        className={`group border-b last:border-b-0 cursor-pointer animate-fade-in opacity-0 transition-[background-color,opacity] duration-150 ${
                           wallet.LowBalanceSummary?.isLow
                             ? 'bg-amber-500/5 hover:bg-amber-500/10'
                             : 'hover:bg-muted/50'
@@ -383,7 +385,13 @@ export default function WalletsPage() {
                             )}
                           </div>
                         </td>
-                        <td className={tableActionsCellCompactClass}>
+                        <td
+                          className={cn(
+                            tableActionsCellCompactClass,
+                            wallet.LowBalanceSummary?.isLow &&
+                              tableActionsCellCompactLowBalanceHoverClass,
+                          )}
+                        >
                           <div className="flex justify-end">
                             {/* Every action here (fund, top up, transfer, swap) is an
                                 admin-only endpoint, so the whole menu is admin-gated. */}
@@ -447,7 +455,7 @@ export default function WalletsPage() {
                 )}
               </tbody>
             </table>
-          </div>
+          </HorizontalScrollArea>
 
           {hasMore && (
             <div className="flex justify-center">

--- a/frontend/src/pages/wallets.tsx
+++ b/frontend/src/pages/wallets.tsx
@@ -36,6 +36,10 @@ import { formatSixDecimalAmount, shortenAddress } from '@/lib/utils';
 import Head from 'next/head';
 import { useRate } from '@/lib/hooks/useRate';
 import { WalletTableSkeleton } from '@/components/skeletons/WalletTableSkeleton';
+import {
+  tableActionsCellCompactClass,
+  tableActionsHeadCompactClass,
+} from '@/components/ui/table-actions-column';
 import { Spinner } from '@/components/ui/spinner';
 import { usePaginatedWallets } from '@/lib/queries/useWallets';
 import { TransakWidget } from '@/components/wallets/TransakWidget';
@@ -266,7 +270,7 @@ export default function WalletsPage() {
                   <th className="p-4 text-left text-sm font-medium text-muted-foreground">
                     Balance, {network === 'Mainnet' ? 'USDCx' : 'tUSDM'}
                   </th>
-                  <th className="w-20 p-4 pr-8"></th>
+                  <th className={tableActionsHeadCompactClass}></th>
                 </tr>
               </thead>
               <tbody>
@@ -379,7 +383,7 @@ export default function WalletsPage() {
                             )}
                           </div>
                         </td>
-                        <td className="p-4 pr-8">
+                        <td className={tableActionsCellCompactClass}>
                           <div className="flex justify-end">
                             {/* Every action here (fund, top up, transfer, swap) is an
                                 admin-only endpoint, so the whole menu is admin-gated. */}

--- a/frontend/src/pages/webhooks.tsx
+++ b/frontend/src/pages/webhooks.tsx
@@ -15,6 +15,7 @@ import { RefreshButton } from '@/components/RefreshButton';
 import { SearchInput } from '@/components/ui/search-input';
 import { Tabs } from '@/components/ui/tabs';
 import { WebhookDialog } from '@/components/webhooks/WebhookDialog';
+import { HorizontalScrollArea } from '@/components/ui/horizontal-scroll-area';
 import {
   tableActionsCellWideClass,
   tableActionsHeadWideClass,
@@ -263,7 +264,7 @@ export default function WebhooksPage() {
     }
 
     return (
-      <div className="rounded-lg border overflow-x-auto">
+      <HorizontalScrollArea className="rounded-lg border">
         <table className="w-full min-w-[1080px]">
           <thead className="bg-muted/30 dark:bg-muted/15">
             <tr className="border-b">
@@ -294,10 +295,7 @@ export default function WebhooksPage() {
               <th scope="col" className="p-4 text-left text-sm font-medium text-muted-foreground">
                 Updated
               </th>
-              <th
-                scope="col"
-                className={`${tableActionsHeadWideClass} text-sm font-medium text-muted-foreground`}
-              >
+              <th scope="col" className={tableActionsHeadWideClass}>
                 Actions
               </th>
             </tr>
@@ -380,7 +378,7 @@ export default function WebhooksPage() {
             })}
           </tbody>
         </table>
-      </div>
+      </HorizontalScrollArea>
     );
   };
 

--- a/frontend/src/pages/webhooks.tsx
+++ b/frontend/src/pages/webhooks.tsx
@@ -15,6 +15,10 @@ import { RefreshButton } from '@/components/RefreshButton';
 import { SearchInput } from '@/components/ui/search-input';
 import { Tabs } from '@/components/ui/tabs';
 import { WebhookDialog } from '@/components/webhooks/WebhookDialog';
+import {
+  tableActionsCellWideClass,
+  tableActionsHeadWideClass,
+} from '@/components/ui/table-actions-column';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { useWebhooks } from '@/lib/hooks/useWebhooks';
 import { shortenAddress } from '@/lib/utils';
@@ -292,7 +296,7 @@ export default function WebhooksPage() {
               </th>
               <th
                 scope="col"
-                className="p-4 pr-6 text-right text-sm font-medium text-muted-foreground"
+                className={`${tableActionsHeadWideClass} text-sm font-medium text-muted-foreground`}
               >
                 Actions
               </th>
@@ -340,7 +344,7 @@ export default function WebhooksPage() {
                   <td className="p-4 text-sm text-muted-foreground">
                     {formatWebhookDate(webhook.updatedAt)}
                   </td>
-                  <td className="p-4 pr-6">
+                  <td className={tableActionsCellWideClass}>
                     <div className="flex justify-end gap-2">
                       <Button
                         type="button"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -97,6 +97,36 @@
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
     --accent-brand: 174 60% 51%;
+    --table-actions-row-hover-fill: color-mix(
+      in srgb,
+      hsl(var(--muted)) 50%,
+      hsl(var(--background)) 50%
+    );
+    --table-actions-row-hover-fade: color-mix(
+      in srgb,
+      var(--table-actions-row-hover-fill) 85%,
+      transparent 15%
+    );
+    --table-actions-low-balance-hover-fill: color-mix(
+      in srgb,
+      rgb(245 158 11) 10%,
+      hsl(var(--background))
+    );
+    --table-actions-low-balance-hover-fade: color-mix(
+      in srgb,
+      var(--table-actions-low-balance-hover-fill) 85%,
+      transparent 15%
+    );
+    --table-actions-destructive-row-fill: color-mix(
+      in srgb,
+      hsl(var(--destructive)) 10%,
+      hsl(var(--background)) 90%
+    );
+    --table-actions-destructive-row-fade: color-mix(
+      in srgb,
+      var(--table-actions-destructive-row-fill) 85%,
+      transparent 15%
+    );
   }
 
   .dark {
@@ -120,6 +150,36 @@
     --input: 0 0% 18%;
     --ring: 0 0% 83.1%;
     --accent-brand: 174 60% 55%;
+    --table-actions-row-hover-fill: color-mix(
+      in srgb,
+      hsl(var(--muted)) 50%,
+      hsl(var(--background)) 50%
+    );
+    --table-actions-row-hover-fade: color-mix(
+      in srgb,
+      var(--table-actions-row-hover-fill) 85%,
+      transparent 15%
+    );
+    --table-actions-low-balance-hover-fill: color-mix(
+      in srgb,
+      rgb(245 158 11) 10%,
+      hsl(var(--background))
+    );
+    --table-actions-low-balance-hover-fade: color-mix(
+      in srgb,
+      var(--table-actions-low-balance-hover-fill) 85%,
+      transparent 15%
+    );
+    --table-actions-destructive-row-fill: color-mix(
+      in srgb,
+      hsl(var(--destructive)) 10%,
+      hsl(var(--background)) 90%
+    );
+    --table-actions-destructive-row-fade: color-mix(
+      in srgb,
+      var(--table-actions-destructive-row-fill) 85%,
+      transparent 15%
+    );
   }
 }
 


### PR DESCRIPTION
## **Purpose of this Pull Request**

[ ] Documentation update  
[X] Bug fix  
[ ] New feature  
[ ] Other:

## **Overview of Changes**

Pin trailing action columns on admin list tables so row controls stay visible while scrolling horizontally. Applies to AI Agents, Inbox Agents, Wallets, Payment Sources, Transactions, and Webhooks.

## **Screenshot**

<img width="1024" height="872" alt="image" src="https://github.com/user-attachments/assets/575d0c10-2f77-4faa-88ac-950420084a04" />

## **Issue Addressed**

https://linear.app/masumi/issue/MAS-485

## **Checklist**

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

Scroll wide tables horizontally and confirm action buttons stay pinned on the right edge.