### PR TITLE
fix(purchases): retry a funds-lock rejected for an already-spent input

### DIFF
--- a/packages/payment-core/src/submit-error-classifier.spec.ts
+++ b/packages/payment-core/src/submit-error-classifier.spec.ts
@@ -1,4 +1,4 @@
-import { isDefinitiveNodeRejection } from './submit-error-classifier';
+import { isDefinitiveNodeRejection, isStaleInputRejection } from './submit-error-classifier';
 
 describe('isDefinitiveNodeRejection', () => {
 	describe('definitive ledger rejections', () => {
@@ -66,5 +66,52 @@ describe('isDefinitiveNodeRejection', () => {
 			circular.cause = circular;
 			expect(isDefinitiveNodeRejection(circular)).toBe(false);
 		});
+	});
+});
+
+describe('isStaleInputRejection', () => {
+	// Verbatim from CI run 33430764978: a V1 funds-lock batch built from a UTxO
+	// snapshot that still held an input the wallet's previous batch had spent.
+	const staleInputRejection = {
+		status: 400,
+		data: {
+			error: 'Bad Request',
+			message:
+				'{"contents":{"contents":{"contents":{"era":"ShelleyBasedEraConway","error":' +
+				'["ConwayUtxowFailure (UtxoFailure (BadInputsUTxO (NonEmptySet (fromList [TxIn ' +
+				'(TxId {unTxId = SafeHash \\"0eb26fbeb06008dc13f02ad6deec36d8b8c57f224029c4384121988725571074\\"}) ' +
+				'(TxIx {unTxIx = 3})]))))","ConwayUtxowFailure (UtxoFailure (ValueNotConservedUTxO ...))"],' +
+				'"kind":"ShelleyTxValidationError"}}}}',
+			status_code: 400,
+		},
+	};
+
+	it('detects the already-spent-input rejection in the Mesh/Blockfrost shape', () => {
+		expect(isStaleInputRejection(staleInputRejection)).toBe(true);
+	});
+
+	it('still reports that rejection as definitive, so reverting stays safe', () => {
+		expect(isDefinitiveNodeRejection(staleInputRejection)).toBe(true);
+	});
+
+	it('does not match the other definitive rejections, which repeat on a rebuild', () => {
+		for (const pattern of [
+			'OutsideValidityIntervalUTxO',
+			'InsufficientCollateral',
+			'FeeTooSmall',
+			'ScriptWitnessNotValidatingUTXOW',
+			'MissingScriptWitnessesUTXOW',
+			'MissingVKeyWitnessesUTXOW',
+			'ValidationTagMismatch',
+			'PlutusFailure',
+		]) {
+			expect(isStaleInputRejection(new Error(`node rejected: ${pattern}`))).toBe(false);
+		}
+	});
+
+	it('returns false for transport failures and non-error values', () => {
+		expect(isStaleInputRejection(new Error('ECONNRESET'))).toBe(false);
+		expect(isStaleInputRejection(null)).toBe(false);
+		expect(isStaleInputRejection({})).toBe(false);
 	});
 });

--- a/packages/payment-core/src/submit-error-classifier.ts
+++ b/packages/payment-core/src/submit-error-classifier.ts
@@ -38,6 +38,26 @@ export function isDefinitiveNodeRejection(error: unknown): boolean {
 }
 
 /**
+ * A `BadInputsUTxO` rejection is definitive, but it is not a defect in the tx:
+ * it says the ledger no longer holds an input the build referenced. In practice
+ * that means another transaction from the same wallet already spent it and the
+ * UTxO snapshot the build used was stale — Blockfrost's UTxO index can lag its
+ * transaction index by tens of seconds, so a wallet that funds two batches in
+ * quick succession can build the second one from a pre-spend view.
+ *
+ * Nothing was broadcast, so reverting is safe, and a rebuild from a fresh
+ * snapshot succeeds on its own. Callers therefore requeue these requests
+ * instead of parking them in WaitingForManualAction for an operator.
+ *
+ * Deliberately narrow: only this one pattern. Every other definitive rejection
+ * (script failure, missing witness, fee too small) repeats on a rebuild, and
+ * requeuing those would spin every tick until the request's deadline.
+ */
+export function isStaleInputRejection(error: unknown): boolean {
+	return /BadInputsUTxO/.test(collectErrorText(error));
+}
+
+/**
  * Collect every plausible message string reachable from an error value. Handles
  * raw strings, `Error` instances (whose `message` is non-enumerable), and the
  * nested plain-object shape Mesh/Blockfrost throws. Cycle- and depth-guarded.

--- a/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v1/src/services/purchases/batch-payments/service.ts
@@ -19,7 +19,7 @@ import { generateWalletExtended } from '@/utils/generator/wallet-generator';
 import { SmartContractState } from '@masumi/payment-core/smart-contract-state';
 import { convertNetwork } from '@masumi/payment-core/network';
 import { interpretBlockchainError } from '@masumi/payment-core/blockchain-error-interpreter';
-import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-classifier';
+import { isDefinitiveNodeRejection, isStaleInputRejection } from '@masumi/payment-core/submit-error-classifier';
 import { isTransientPreSubmitError } from '@masumi/payment-core/pre-submit-error';
 import { Mutex, MutexInterface, tryAcquire } from 'async-mutex';
 import { CONSTANTS } from '@masumi/payment-core/config';
@@ -963,8 +963,14 @@ export async function batchLatestPaymentEntriesV1() {
 								// transient pre-submit cause (Blockfrost 5xx / transport drop during
 								// build) is not a real failure — requeue to FundsLockingRequested so
 								// the next tick re-batches instead of parking an operator ticket.
+								//
+								// A node rejection for an input the ledger no longer holds is the
+								// same kind of non-failure: the wallet funded an earlier batch and
+								// the UTxO snapshot this build used was stale. Nothing was
+								// broadcast, and the next tick rebuilds from a fresh snapshot.
 								const isRetryableTransient =
-									outcome.status === 'pre-submit-failed' && isTransientPreSubmitError(outcome.error);
+									(outcome.status === 'pre-submit-failed' && isTransientPreSubmitError(outcome.error)) ||
+									(outcome.status === 'submit-rejected' && isStaleInputRejection(outcome.error));
 								const errNote =
 									outcome.status === 'submit-rejected'
 										? 'Batching payments rejected by node: ' + interpretBlockchainError(outcome.error)

--- a/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
+++ b/packages/payment-source-v2/src/services/purchases/batch-payments/service.ts
@@ -31,7 +31,7 @@ import {
 	createTxWindow,
 } from '@/services/shared';
 import { createDatumFromBlockchainIdentifierV2 } from '@masumi/payment-source-v2';
-import { isDefinitiveNodeRejection } from '@masumi/payment-core/submit-error-classifier';
+import { isDefinitiveNodeRejection, isStaleInputRejection } from '@masumi/payment-core/submit-error-classifier';
 import { isTransientPreSubmitError } from '@masumi/payment-core/pre-submit-error';
 import { WALLET_SPLITTER_LOVELACE } from '../../../builders/batch-helpers';
 import { syncMeshCostModelsFromChainV2 } from '../../../utils/mesh-cost-model-sync';
@@ -1420,10 +1420,16 @@ export async function batchLatestPaymentEntriesV2() {
 								// failure — the tx was never broadcast and a later tick can succeed.
 								// Revert those to FundsLockingRequested so the scheduler re-batches
 								// them instead of parking a whole batch in WaitingForManualAction for
-								// an operator. Node rejections and non-transient build errors still go
-								// to manual action.
+								// an operator. Other node rejections and non-transient build errors
+								// still go to manual action.
+								//
+								// A node rejection for an input the ledger no longer holds is the
+								// same kind of non-failure: the wallet funded an earlier batch and
+								// the UTxO snapshot this build used was stale. Nothing was
+								// broadcast, and the next tick rebuilds from a fresh snapshot.
 								const isRetryableTransient =
-									outcome.status === 'pre-submit-failed' && isTransientPreSubmitError(outcome.error);
+									(outcome.status === 'pre-submit-failed' && isTransientPreSubmitError(outcome.error)) ||
+									(outcome.status === 'submit-rejected' && isStaleInputRejection(outcome.error));
 								const errNote =
 									outcome.status === 'submit-rejected'
 										? 'Batching payments rejected by node: ' + interpretBlockchainError(outcome.error)


### PR DESCRIPTION
## The failure

E2E on [#801](https://github.com/masumi-network/masumi-payment-service/pull/801) (run 33430764978) lost two V1 flows. Both purchases were parked in `WaitingForManualAction`:

```
ConwayUtxowFailure (UtxoFailure (BadInputsUTxO (NonEmptySet (fromList
[TxIn (TxId {unTxId = SafeHash "0eb26fbe...74"}) (TxIx {unTxIx = 3})]))))
ConwayUtxowFailure (UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ)
{supplied: Coin 8557671 ..., expected: Coin 28655389 ...}))
```

Server-log timeline for purchasing wallet `cmthmyw2o0009kp2bturlq8s3`:

| Time | Event |
| --- | --- |
| 19:38:50 | batch tx `84938d78…` submitted (1 request) |
| 19:40:07 | tx-sync confirms it and unlocks the wallet |
| 19:40:28 | next batch built (2 requests) |
| 19:40:34 | node rejects it: input `0eb26fbe…#3` is already spent |

The rejected build still saw an input the first transaction had spent 100 seconds earlier. Blockfrost's UTxO index lags its transaction index, so a wallet that funds two batches in quick succession can build the second one from a pre-spend view. The value mismatch is the same fact stated twice: 20 ADA and 1000 tUSDM short, which is exactly the missing input.

## The fix

`BadInputsUTxO` stays a definitive rejection. Nothing was broadcast, so reverting the rows and unlocking the wallet remains correct. What changes is what happens next: unlike a script failure, a missing witness or a fee that is too small, this one does not repeat. The next tick rebuilds from a fresh snapshot and succeeds.

So these requests requeue to `FundsLockingRequested`, exactly as a transient pre-submit failure already does, instead of demanding an operator for a chain-sync race. `isStaleInputRejection` is deliberately narrow: one pattern, nothing else, because requeuing a deterministic rejection would spin every tick until the request's deadline.

V1 and V2 batch-payments both take this path, so both get the change.

## Why it started now

The e2e flow files began running concurrently on [#808](https://github.com/masumi-network/masumi-payment-service/pull/808). Two funds-locks now land on one purchasing wallet about two minutes apart, where serial flows put a whole flow between them. The race is not new and is not test-only: any production wallet that funds two batches inside Blockfrost's UTxO lag can hit it, and today that costs an operator ticket.

## Verification

- `pnpm test`: 3568 passed, 2 skipped, 0 failed.
- 11 tests in `submit-error-classifier.spec.ts`, including the verbatim rejection payload from run 33430764978. Stubbing the new function to `return false` makes 1 fail, so the test does exercise the code.
- `pnpm exec tsc --noEmit`: exit 0. `pnpm run lint:backend`: clean.
- Not reproduced on chain. The race needs Blockfrost to lag, which I cannot force; the evidence is the run's own server log.

## Follow-ups

- Two V1 submit-results failed with `Maximum Input Count Exceeded` in run 33393794038, on rows already abandoned by `--bail`. Not explained yet, and not addressed here.
- Both batch-payments services are past the 750-line guideline (V1 1229, V2 1680). Extracting the outcome handler is worth doing, but not inside a fix for a payment path.