### PR TITLE
ci(e2e): run one preprod suite at a time, repository-wide

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,12 +4,24 @@ on:
   pull_request:
     branches: [dev]
 
-# Cancel an in-flight run when a newer commit lands on the same PR. E2E uses
-# real preprod wallets; stacking runs causes UTxO contention and burns CI
-# minutes on stale commits.
+# One e2e run at a time, repository-wide. Every run drives the SAME preprod
+# wallets, which are seeded from repository secrets and shared by every branch,
+# so two runs spend from one purchasing wallet at once. On 2026-08-31 that was
+# visible in every failure: the runs at 18:32 (three at once) and 19:28 (two at
+# once) failed, the second one on
+# `BadInputsUTxO` for an input the other run had just spent, while every run
+# that had the wallets to itself passed. The pair at 21:07 and 21:09 failed
+# differently and for the same reason: the first run's locks took the wallet
+# below the funding floor the second one checked.
+#
+# `cancel-in-progress: false` on purpose. Killing an e2e job mid-flow strands
+# whatever it has already locked in the escrow contract, which is real preprod
+# ADA that no later run gets back. A superseded commit therefore finishes its
+# run and the newer one waits. GitHub keeps only ONE pending run per group, so
+# a third push supersedes the queued run rather than piling up.
 concurrency:
-  group: e2e-${{ github.ref }}
-  cancel-in-progress: true
+  group: e2e-preprod-wallets
+  cancel-in-progress: false
 
 jobs:
   e2e:


### PR DESCRIPTION
## The pattern

Every e2e run drives the same preprod wallets. They are seeded from repository secrets, so every branch shares one purchasing wallet and one selling wallet. The concurrency group was keyed on `github.ref`, which only serialises a single pull request against itself.

Every e2e failure on 2026-08-31 overlapped another run. Every run that had the wallets to itself passed.

| Window | Runs | Outcome |
| --- | --- | --- |
| 15:16, 15:53, 16:09, 20:37 | one at a time | all passed |
| 17:46 + 17:50 | two at once | one failed |
| 18:32 | three at once | two failed |
| 19:28 | two at once | both failed, one on `BadInputsUTxO` for an input the other run had just spent |
| 21:07 + 21:09 | two at once | both failed, the second because the first run's locks took the wallet below its funding floor |

So the "stale UTxO snapshot" in #812 was usually not Blockfrost lag at all. It was a second CI run spending the same wallet. That fix stays worth having, because it also covers the genuine lag case, but it treats the symptom.

## The change

One fixed group name, so runs queue instead of overlapping.

`cancel-in-progress` stays `false`. Killing an e2e job mid-flow strands whatever it has already locked in the escrow contract, and that is real preprod ADA no later run gets back. A superseded commit finishes its run and the newer one waits. GitHub keeps only one pending run per group, so a third push replaces the queued run rather than piling up.

The cost is queue time: e2e is 20 to 25 minutes, and with several open pull requests the wait adds up. The alternative is what the table above shows.

## Two things this does not fix

- **The wallet needs funding.** The V1 purchasing wallet `addr_test1qqdjz283kl65xwqdp8nzpzwspwmyfck8050y5fgyxuuf8f4angzu6l6zj43var73ex5gz20w06wm6d5sgdlkdn83jq6qjc72pc` held 11.38 ADA at 21:09, below the 22 ADA the preflight asks for three concurrent locks, and below the 12 ADA a single lock needs. Until it is topped up from the faucet, every run fails in `globalSetup`, including this pull request's own.
- **The suite does not recover what it locks.** The flows end at authorize-refund, not at withdrawal, so each run leaves ADA in the escrow contract for the collection job to sweep afterwards. That is why the balance trends down across runs. Making teardown wait for collection is a separate change.