### PR TITLE
fix(earnings): prevent crash in income/spending endpoints

### DIFF
--- a/src/routes/api/payments/income/index.ts
+++ b/src/routes/api/payments/income/index.ts
@@ -6,6 +6,8 @@ import { readAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import {
 	parseDateRange,
 	filterByAgentIdentifier,
+	fetchAndProcessInBatches,
+	EARNINGS_QUERY_BATCH_SIZE,
 	Fund,
 	addToAllFundsMaps,
 	mapDailyFundsOutput,
@@ -17,6 +19,11 @@ import { ez } from 'express-zod-api';
 import spacetime from 'spacetime';
 import { buildWalletScopeFilter } from '@/utils/shared/wallet-scope';
 import { resolvePaymentPaymentSourceTypeFilter } from '../queries';
+import { createEarningsRateLimitMiddleware, earningsConcurrencyMiddleware } from '@/utils/earnings-request-control';
+
+const paymentIncomeEndpointFactory = readAuthenticatedEndpointFactory
+	.addMiddleware(createEarningsRateLimitMiddleware())
+	.addMiddleware(earningsConcurrencyMiddleware);
 
 export const postPaymentIncomeSchemaInput = z.object({
 	agentIdentifier: z
@@ -146,7 +153,7 @@ function getMonthNumberLocal(date: Date, timeZone: string): string {
 	return sp.format('{YYYY}-{MM}');
 }
 
-export const getPaymentIncome = readAuthenticatedEndpointFactory.build({
+export const getPaymentIncome = paymentIncomeEndpointFactory.build({
 	method: 'post',
 	input: postPaymentIncomeSchemaInput,
 	output: postPaymentIncomeSchemaOutput,
@@ -157,38 +164,31 @@ export const getPaymentIncome = readAuthenticatedEndpointFactory.build({
 
 			const { periodStart, periodEnd } = parseDateRange(input.startDate, input.endDate);
 
-			const allPayments = await prisma.paymentRequest.findMany({
-				where: {
-					payByTime: {
-						gte: periodStart.getTime(),
-						lte: periodEnd.getTime(),
-					},
-					onChainState: { not: null },
-					PaymentSource: {
-						network: input.network,
-						paymentSourceType: resolvePaymentPaymentSourceTypeFilter(input),
-						deletedAt: null,
-					},
-					...buildWalletScopeFilter(ctx.walletScopeIds),
-				},
-				orderBy: [
-					{
-						payByTime: 'asc',
-					},
-					{
-						id: 'asc',
-					},
-				],
-				include: {
-					RequestedFunds: true,
-					WithdrawnForBuyer: true,
-					WithdrawnForSeller: true,
-					PaymentSource: true,
-				},
-			});
+			// Denormalized column mirroring decodeBlockchainIdentifier(...).agentIdentifier
+			// (see PaymentRequest.agentIdentifier in schema.prisma). Pre-filtering on it
+			// lets the DB exclude confirmed non-matches; rows not yet backfilled
+			// (agentIdentifierSyncedAt: null) are still fetched so the JS-side
+			// filterByAgentIdentifier below can decode them as a fallback.
+			const agentIdentifierFilter = input.agentIdentifier
+				? { OR: [{ agentIdentifier: input.agentIdentifier }, { agentIdentifierSyncedAt: null }] }
+				: {};
 
-			const allPaymentsFiltered = filterByAgentIdentifier(allPayments, input.agentIdentifier);
+			const where = {
+				payByTime: {
+					gte: periodStart.getTime(),
+					lte: periodEnd.getTime(),
+				},
+				onChainState: { not: null },
+				PaymentSource: {
+					network: input.network,
+					paymentSourceType: resolvePaymentPaymentSourceTypeFilter(input),
+					deletedAt: null,
+				},
+				...buildWalletScopeFilter(ctx.walletScopeIds),
+				...agentIdentifierFilter,
+			};
 
+			let totalTransactions = 0;
 			const totalRefundedMap: Fund = {
 				units: new Map<string, bigint>(),
 				blockchainFees: 0n,
@@ -210,72 +210,96 @@ export const getPaymentIncome = readAuthenticatedEndpointFactory.build({
 			const monthlyIncomeMap = new Map<string, Fund>();
 			const monthlyPendingMap = new Map<string, Fund>();
 
-			for (const payment of allPaymentsFiltered) {
-				//get the day number in the local time zone of the user
-				const dayDateLocal = getDayNumberLocal(new Date(Number(payment.payByTime)), input.timeZone ?? 'Etc/UTC');
-				const monthDateLocal = getMonthNumberLocal(new Date(Number(payment.payByTime)), input.timeZone ?? 'Etc/UTC');
+			await fetchAndProcessInBatches(
+				(cursorId) =>
+					prisma.paymentRequest.findMany({
+						where,
+						orderBy: [{ payByTime: 'asc' }, { id: 'asc' }],
+						include: {
+							RequestedFunds: true,
+							WithdrawnForBuyer: true,
+							WithdrawnForSeller: true,
+							PaymentSource: true,
+						},
+						take: EARNINGS_QUERY_BATCH_SIZE,
+						...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
+					}),
+				EARNINGS_QUERY_BATCH_SIZE,
+				(batch) => {
+					const filteredBatch = filterByAgentIdentifier(batch, input.agentIdentifier);
+					totalTransactions += filteredBatch.length;
 
-				if (payment.onChainState === OnChainState.Withdrawn) {
-					addToAllFundsMaps(
-						totalIncomeMap,
-						dayIncomeMap,
-						monthlyIncomeMap,
-						dayDateLocal,
-						monthDateLocal,
-						payment.RequestedFunds,
-						payment.totalSellerCardanoFees,
-					);
-				} else if (payment.onChainState === OnChainState.RefundWithdrawn) {
-					addToAllFundsMaps(
-						totalRefundedMap,
-						dayRefundedMap,
-						monthlyRefundedMap,
-						dayDateLocal,
-						monthDateLocal,
-						payment.RequestedFunds,
-						payment.totalSellerCardanoFees,
-					);
-				} else if (payment.onChainState === OnChainState.DisputedWithdrawn) {
-					if (payment.WithdrawnForSeller.length > 0) {
-						addToAllFundsMaps(
-							totalIncomeMap,
-							dayIncomeMap,
-							monthlyIncomeMap,
-							dayDateLocal,
-							monthDateLocal,
-							payment.WithdrawnForSeller,
-							payment.totalSellerCardanoFees,
+					for (const payment of filteredBatch) {
+						//get the day number in the local time zone of the user
+						const dayDateLocal = getDayNumberLocal(new Date(Number(payment.payByTime)), input.timeZone ?? 'Etc/UTC');
+						const monthDateLocal = getMonthNumberLocal(
+							new Date(Number(payment.payByTime)),
+							input.timeZone ?? 'Etc/UTC',
 						);
+
+						if (payment.onChainState === OnChainState.Withdrawn) {
+							addToAllFundsMaps(
+								totalIncomeMap,
+								dayIncomeMap,
+								monthlyIncomeMap,
+								dayDateLocal,
+								monthDateLocal,
+								payment.RequestedFunds,
+								payment.totalSellerCardanoFees,
+							);
+						} else if (payment.onChainState === OnChainState.RefundWithdrawn) {
+							addToAllFundsMaps(
+								totalRefundedMap,
+								dayRefundedMap,
+								monthlyRefundedMap,
+								dayDateLocal,
+								monthDateLocal,
+								payment.RequestedFunds,
+								payment.totalSellerCardanoFees,
+							);
+						} else if (payment.onChainState === OnChainState.DisputedWithdrawn) {
+							if (payment.WithdrawnForSeller.length > 0) {
+								addToAllFundsMaps(
+									totalIncomeMap,
+									dayIncomeMap,
+									monthlyIncomeMap,
+									dayDateLocal,
+									monthDateLocal,
+									payment.WithdrawnForSeller,
+									payment.totalSellerCardanoFees,
+								);
+							}
+							if (payment.WithdrawnForBuyer.length > 0) {
+								addToAllFundsMaps(
+									totalRefundedMap,
+									dayRefundedMap,
+									monthlyRefundedMap,
+									dayDateLocal,
+									monthDateLocal,
+									payment.WithdrawnForBuyer,
+									payment.WithdrawnForSeller.length === 0 ? payment.totalSellerCardanoFees : 0n,
+								);
+							}
+						} else if (payment.onChainState !== OnChainState.FundsOrDatumInvalid) {
+							addToAllFundsMaps(
+								totalPendingMap,
+								dayPendingMap,
+								monthlyPendingMap,
+								dayDateLocal,
+								monthDateLocal,
+								payment.RequestedFunds,
+								payment.totalSellerCardanoFees,
+							);
+						}
 					}
-					if (payment.WithdrawnForBuyer.length > 0) {
-						addToAllFundsMaps(
-							totalRefundedMap,
-							dayRefundedMap,
-							monthlyRefundedMap,
-							dayDateLocal,
-							monthDateLocal,
-							payment.WithdrawnForBuyer,
-							payment.WithdrawnForSeller.length === 0 ? payment.totalSellerCardanoFees : 0n,
-						);
-					}
-				} else if (payment.onChainState !== OnChainState.FundsOrDatumInvalid) {
-					addToAllFundsMaps(
-						totalPendingMap,
-						dayPendingMap,
-						monthlyPendingMap,
-						dayDateLocal,
-						monthDateLocal,
-						payment.RequestedFunds,
-						payment.totalSellerCardanoFees,
-					);
-				}
-			}
+				},
+			);
 
 			return {
 				agentIdentifier: input.agentIdentifier,
 				periodStart,
 				periodEnd,
-				totalTransactions: allPaymentsFiltered.length,
+				totalTransactions,
 				TotalIncome: mapTotalFundsOutput(totalIncomeMap),
 				TotalRefunded: mapTotalFundsOutput(totalRefundedMap),
 				TotalPending: mapTotalFundsOutput(totalPendingMap),

--- a/src/routes/api/purchases/spending/index.ts
+++ b/src/routes/api/purchases/spending/index.ts
@@ -6,6 +6,8 @@ import { readAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import {
 	parseDateRange,
 	filterByAgentIdentifier,
+	fetchAndProcessInBatches,
+	EARNINGS_QUERY_BATCH_SIZE,
 	Fund,
 	addToAllFundsMaps,
 	mapDailyFundsOutput,
@@ -17,6 +19,11 @@ import { ez } from 'express-zod-api';
 import spacetime from 'spacetime';
 import { buildWalletScopeFilter } from '@/utils/shared/wallet-scope';
 import { resolvePurchasePaymentSourceTypeFilter } from '../queries';
+import { createEarningsRateLimitMiddleware, earningsConcurrencyMiddleware } from '@/utils/earnings-request-control';
+
+const purchaseSpendingEndpointFactory = readAuthenticatedEndpointFactory
+	.addMiddleware(createEarningsRateLimitMiddleware())
+	.addMiddleware(earningsConcurrencyMiddleware);
 
 export const postPurchaseSpendingSchemaInput = z.object({
 	agentIdentifier: z
@@ -146,7 +153,7 @@ function getMonthNumberLocal(date: Date, timeZone: string): string {
 	return sp.format('{YYYY}-{MM}');
 }
 
-export const postPurchaseSpending = readAuthenticatedEndpointFactory.build({
+export const postPurchaseSpending = purchaseSpendingEndpointFactory.build({
 	method: 'post',
 	input: postPurchaseSpendingSchemaInput,
 	output: postPurchaseSpendingSchemaOutput,
@@ -157,38 +164,31 @@ export const postPurchaseSpending = readAuthenticatedEndpointFactory.build({
 
 			const { periodStart, periodEnd } = parseDateRange(input.startDate, input.endDate);
 
-			const allPurchases = await prisma.purchaseRequest.findMany({
-				where: {
-					payByTime: {
-						gte: periodStart.getTime(),
-						lte: periodEnd.getTime(),
-					},
-					onChainState: { not: null },
-					PaymentSource: {
-						network: input.network,
-						paymentSourceType: resolvePurchasePaymentSourceTypeFilter(input),
-						deletedAt: null,
-					},
-					...buildWalletScopeFilter(ctx.walletScopeIds),
-				},
-				orderBy: [
-					{
-						payByTime: 'asc',
-					},
-					{
-						id: 'asc',
-					},
-				],
-				include: {
-					PaidFunds: true,
-					WithdrawnForBuyer: true,
-					WithdrawnForSeller: true,
-					PaymentSource: true,
-				},
-			});
+			// Denormalized column mirroring decodeBlockchainIdentifier(...).agentIdentifier
+			// (see PurchaseRequest.agentIdentifier in schema.prisma). Pre-filtering on it
+			// lets the DB exclude confirmed non-matches; rows not yet backfilled
+			// (agentIdentifierSyncedAt: null) are still fetched so the JS-side
+			// filterByAgentIdentifier below can decode them as a fallback.
+			const agentIdentifierFilter = input.agentIdentifier
+				? { OR: [{ agentIdentifier: input.agentIdentifier }, { agentIdentifierSyncedAt: null }] }
+				: {};
 
-			const allPurchasesFiltered = filterByAgentIdentifier(allPurchases, input.agentIdentifier);
+			const where = {
+				payByTime: {
+					gte: periodStart.getTime(),
+					lte: periodEnd.getTime(),
+				},
+				onChainState: { not: null },
+				PaymentSource: {
+					network: input.network,
+					paymentSourceType: resolvePurchasePaymentSourceTypeFilter(input),
+					deletedAt: null,
+				},
+				...buildWalletScopeFilter(ctx.walletScopeIds),
+				...agentIdentifierFilter,
+			};
 
+			let totalTransactions = 0;
 			const totalRefundedMap: Fund = {
 				units: new Map<string, bigint>(),
 				blockchainFees: 0n,
@@ -210,76 +210,100 @@ export const postPurchaseSpending = readAuthenticatedEndpointFactory.build({
 			const monthlySpendMap = new Map<string, Fund>();
 			const monthlyPendingMap = new Map<string, Fund>();
 
-			for (const purchase of allPurchasesFiltered) {
-				//get the day number in the local time zone of the user
-				const dayDateLocal = getDayNumberLocal(new Date(Number(purchase.payByTime)), input.timeZone ?? 'Etc/UTC');
-				const monthDateLocal = getMonthNumberLocal(new Date(Number(purchase.payByTime)), input.timeZone ?? 'Etc/UTC');
+			await fetchAndProcessInBatches(
+				(cursorId) =>
+					prisma.purchaseRequest.findMany({
+						where,
+						orderBy: [{ payByTime: 'asc' }, { id: 'asc' }],
+						include: {
+							PaidFunds: true,
+							WithdrawnForBuyer: true,
+							WithdrawnForSeller: true,
+							PaymentSource: true,
+						},
+						take: EARNINGS_QUERY_BATCH_SIZE,
+						...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
+					}),
+				EARNINGS_QUERY_BATCH_SIZE,
+				(batch) => {
+					const filteredBatch = filterByAgentIdentifier(batch, input.agentIdentifier);
+					totalTransactions += filteredBatch.length;
 
-				if (purchase.onChainState === OnChainState.Withdrawn) {
-					addToAllFundsMaps(
-						totalSpendMap,
-						daySpendMap,
-						monthlySpendMap,
-						dayDateLocal,
-						monthDateLocal,
-						purchase.PaidFunds,
-						purchase.totalBuyerCardanoFees,
-					);
-				} else if (purchase.onChainState === OnChainState.RefundWithdrawn) {
-					addToAllFundsMaps(
-						totalRefundedMap,
-						dayRefundedMap,
-						monthlyRefundedMap,
-						dayDateLocal,
-						monthDateLocal,
-						purchase.PaidFunds,
-						purchase.totalBuyerCardanoFees,
-					);
-				} else if (purchase.onChainState === OnChainState.DisputedWithdrawn) {
-					if (purchase.WithdrawnForBuyer.length > 0) {
-						addToAllFundsMaps(
-							totalRefundedMap,
-							dayRefundedMap,
-							monthlyRefundedMap,
-							dayDateLocal,
-							monthDateLocal,
-							purchase.WithdrawnForBuyer,
-							purchase.totalBuyerCardanoFees,
+					for (const purchase of filteredBatch) {
+						//get the day number in the local time zone of the user
+						const dayDateLocal = getDayNumberLocal(new Date(Number(purchase.payByTime)), input.timeZone ?? 'Etc/UTC');
+						const monthDateLocal = getMonthNumberLocal(
+							new Date(Number(purchase.payByTime)),
+							input.timeZone ?? 'Etc/UTC',
 						);
+
+						if (purchase.onChainState === OnChainState.Withdrawn) {
+							addToAllFundsMaps(
+								totalSpendMap,
+								daySpendMap,
+								monthlySpendMap,
+								dayDateLocal,
+								monthDateLocal,
+								purchase.PaidFunds,
+								purchase.totalBuyerCardanoFees,
+							);
+						} else if (purchase.onChainState === OnChainState.RefundWithdrawn) {
+							addToAllFundsMaps(
+								totalRefundedMap,
+								dayRefundedMap,
+								monthlyRefundedMap,
+								dayDateLocal,
+								monthDateLocal,
+								purchase.PaidFunds,
+								purchase.totalBuyerCardanoFees,
+							);
+						} else if (purchase.onChainState === OnChainState.DisputedWithdrawn) {
+							if (purchase.WithdrawnForBuyer.length > 0) {
+								addToAllFundsMaps(
+									totalRefundedMap,
+									dayRefundedMap,
+									monthlyRefundedMap,
+									dayDateLocal,
+									monthDateLocal,
+									purchase.WithdrawnForBuyer,
+									purchase.totalBuyerCardanoFees,
+								);
+							}
+							if (purchase.WithdrawnForSeller.length > 0) {
+								addToAllFundsMaps(
+									totalSpendMap,
+									daySpendMap,
+									monthlySpendMap,
+									dayDateLocal,
+									monthDateLocal,
+									purchase.WithdrawnForSeller,
+									purchase.WithdrawnForBuyer.length === 0 ? purchase.totalBuyerCardanoFees : 0n,
+								);
+							}
+						} else if (purchase.onChainState !== OnChainState.FundsOrDatumInvalid) {
+							// Mirror the income endpoint: purchases whose funds-lock timed out
+							// (tx-sync marks them FundsOrDatumInvalid; the money never left the
+							// buyer wallet) must NOT be counted as pending spend, or they inflate
+							// TotalPending/DailyPending/MonthlyPending forever.
+							addToAllFundsMaps(
+								totalPendingMap,
+								dayPendingMap,
+								monthlyPendingMap,
+								dayDateLocal,
+								monthDateLocal,
+								purchase.PaidFunds,
+								purchase.totalBuyerCardanoFees,
+							);
+						}
 					}
-					if (purchase.WithdrawnForSeller.length > 0) {
-						addToAllFundsMaps(
-							totalSpendMap,
-							daySpendMap,
-							monthlySpendMap,
-							dayDateLocal,
-							monthDateLocal,
-							purchase.WithdrawnForSeller,
-							purchase.WithdrawnForBuyer.length === 0 ? purchase.totalBuyerCardanoFees : 0n,
-						);
-					}
-				} else if (purchase.onChainState !== OnChainState.FundsOrDatumInvalid) {
-					// Mirror the income endpoint: purchases whose funds-lock timed out
-					// (tx-sync marks them FundsOrDatumInvalid; the money never left the
-					// buyer wallet) must NOT be counted as pending spend, or they inflate
-					// TotalPending/DailyPending/MonthlyPending forever.
-					addToAllFundsMaps(
-						totalPendingMap,
-						dayPendingMap,
-						monthlyPendingMap,
-						dayDateLocal,
-						monthDateLocal,
-						purchase.PaidFunds,
-						purchase.totalBuyerCardanoFees,
-					);
-				}
-			}
+				},
+			);
 
 			return {
 				agentIdentifier: input.agentIdentifier,
 				periodStart,
 				periodEnd,
-				totalTransactions: allPurchasesFiltered.length,
+				totalTransactions,
 				TotalSpend: mapTotalFundsOutput(totalSpendMap),
 				TotalRefunded: mapTotalFundsOutput(totalRefundedMap),
 				TotalPending: mapTotalFundsOutput(totalPendingMap),

--- a/src/utils/earnings-helpers.spec.ts
+++ b/src/utils/earnings-helpers.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fetchAndProcessInBatches } from './earnings-helpers';
+
+describe('fetchAndProcessInBatches', () => {
+	it('pages through full batches and stops at a short final page', async () => {
+		const pages = [[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }, { id: 'd' }], [{ id: 'e' }]];
+		const fetchBatch = jest.fn(async () => pages.shift() ?? []);
+		const processed: Array<{ id: string }[]> = [];
+
+		await fetchAndProcessInBatches(fetchBatch, 2, (batch) => {
+			processed.push(batch);
+		});
+
+		expect(processed).toEqual([[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }, { id: 'd' }], [{ id: 'e' }]]);
+		expect(fetchBatch).toHaveBeenCalledTimes(3);
+	});
+
+	it('passes the last row id of the previous page as the next cursor', async () => {
+		const pages = [[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }]];
+		const fetchBatch = jest.fn(async (_cursorId?: string) => pages.shift() ?? []);
+
+		await fetchAndProcessInBatches(fetchBatch, 2, () => {});
+
+		expect(fetchBatch).toHaveBeenNthCalledWith(1, undefined);
+		expect(fetchBatch).toHaveBeenNthCalledWith(2, 'b');
+	});
+
+	it('stops immediately and never calls processBatch when the first page is empty', async () => {
+		const fetchBatch = jest.fn(async () => []);
+		const processBatch = jest.fn();
+
+		await fetchAndProcessInBatches(fetchBatch, 2, processBatch);
+
+		expect(fetchBatch).toHaveBeenCalledTimes(1);
+		expect(processBatch).not.toHaveBeenCalled();
+	});
+
+	it('does not fetch again once a full-size page turns out to be the last one', async () => {
+		// A page exactly equal to batchSize looks like there might be more, so the
+		// loop must fetch once more to confirm — but an empty follow-up page must
+		// stop it there rather than looping forever.
+		const pages = [[{ id: 'a' }, { id: 'b' }], []];
+		const fetchBatch = jest.fn(async () => pages.shift() ?? []);
+		const processBatch = jest.fn();
+
+		await fetchAndProcessInBatches(fetchBatch, 2, processBatch);
+
+		expect(fetchBatch).toHaveBeenCalledTimes(2);
+		expect(processBatch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/earnings-helpers.ts
+++ b/src/utils/earnings-helpers.ts
@@ -21,6 +21,33 @@ export function parseDateRange(
 	return { periodStart, periodEnd };
 }
 
+/** Page size for the income/spending aggregation queries below. */
+export const EARNINGS_QUERY_BATCH_SIZE = 1000;
+
+/**
+ * Fetches rows via cursor pagination and hands each page to `processBatch`
+ * instead of returning the whole result set. Callers with an unbounded
+ * date range (the income/spending default) could otherwise pull an entire
+ * table's history into memory in one `findMany`; this bounds peak memory to
+ * one page regardless of total row count. Requires `orderBy` to end in a
+ * unique tiebreaker (these callers already sort by `id` last) so the cursor
+ * position is stable across pages.
+ */
+export async function fetchAndProcessInBatches<T extends { id: string }>(
+	fetchBatch: (cursorId: string | undefined) => Promise<T[]>,
+	batchSize: number,
+	processBatch: (rows: T[]) => void,
+): Promise<void> {
+	let cursorId: string | undefined;
+	for (;;) {
+		const batch = await fetchBatch(cursorId);
+		if (batch.length === 0) break;
+		processBatch(batch);
+		if (batch.length < batchSize) break;
+		cursorId = batch[batch.length - 1].id;
+	}
+}
+
 export function filterByAgentIdentifier<T extends { blockchainIdentifier: string }>(
 	transactions: T[],
 	agentIdentifier: string | null,

--- a/src/utils/earnings-request-control.ts
+++ b/src/utils/earnings-request-control.ts
@@ -1,0 +1,19 @@
+import { createAuthenticatedRateLimitMiddleware } from '@/utils/middleware/rate-limit';
+import { createConcurrencyLimitMiddleware } from '@/utils/middleware/concurrency-limit';
+
+/**
+ * /payment/income and /purchase/spending both run unbounded, full-history
+ * aggregation queries (see earnings-helpers.ts) against the same DB/heap. One
+ * shared instance caps their COMBINED concurrency so hammering either
+ * endpoint (or both at once) can't multiply into a heap-exhaustion crash.
+ */
+export const earningsConcurrencyMiddleware = createConcurrencyLimitMiddleware({
+	limit: 4,
+	timeoutMs: 5 * 60_000,
+});
+
+export const createEarningsRateLimitMiddleware = () =>
+	createAuthenticatedRateLimitMiddleware({
+		maxRequests: 30,
+		windowMs: 60_000,
+	});

--- a/src/utils/middleware/concurrency-limit/index.spec.ts
+++ b/src/utils/middleware/concurrency-limit/index.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+import { testMiddleware } from 'express-zod-api';
+import { Network } from '@/generated/prisma/client';
+import type { AuthContext } from '@masumi/payment-core/auth-middleware';
+import { createConcurrencyLimitMiddleware } from './index';
+
+const makeAuthContext = (overrides: Partial<AuthContext> = {}): AuthContext => ({
+	id: 'api-key-default',
+	canRead: true,
+	canPay: true,
+	canAdmin: false,
+	networkLimit: [Network.Mainnet, Network.Preprod],
+	caip2NetworkLimit: ['cardano:mainnet', 'cardano:preprod'],
+	usageLimited: false,
+	walletScopeIds: null,
+	x402WalletScopeIds: null,
+	...overrides,
+});
+
+describe('createConcurrencyLimitMiddleware', () => {
+	it('caps combined concurrency across different API keys and rejects with 503', async () => {
+		const middleware = createConcurrencyLimitMiddleware({ limit: 2, timeoutMs: 60_000 });
+
+		const active = await Promise.all([
+			testMiddleware({
+				middleware,
+				ctx: makeAuthContext({ id: 'api-key-a' }),
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			}),
+			testMiddleware({
+				middleware,
+				ctx: makeAuthContext({ id: 'api-key-b' }),
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			}),
+		]);
+		expect(active.map(({ responseMock }) => responseMock.statusCode)).toEqual([200, 200]);
+
+		const blocked = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext({ id: 'api-key-c' }),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(blocked.responseMock.statusCode).toBe(503);
+		expect(blocked.responseMock.getHeader('retry-after')).toBe('1');
+
+		for (const { responseMock } of active) responseMock.emit('finish');
+	});
+
+	it('releases a slot when the response finishes, admitting the next request', async () => {
+		const middleware = createConcurrencyLimitMiddleware({ limit: 1, timeoutMs: 60_000 });
+
+		const first = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext(),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(first.responseMock.statusCode).toBe(200);
+
+		const blocked = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext(),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(blocked.responseMock.statusCode).toBe(503);
+
+		first.responseMock.emit('finish');
+
+		const admitted = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext(),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(admitted.responseMock.statusCode).toBe(200);
+		admitted.responseMock.emit('finish');
+	});
+
+	it('releases a slot when the response closes early', async () => {
+		const middleware = createConcurrencyLimitMiddleware({ limit: 1, timeoutMs: 60_000 });
+
+		const first = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext(),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		first.responseMock.emit('close');
+
+		const admitted = await testMiddleware({
+			middleware,
+			ctx: makeAuthContext(),
+			requestProps: { method: 'POST', body: {} },
+			responseOptions: { eventEmitter: EventEmitter },
+		});
+		expect(admitted.responseMock.statusCode).toBe(200);
+		admitted.responseMock.emit('finish');
+	});
+
+	it('expires a slot that never finishes or closes, so a hung handler cannot leak it forever', async () => {
+		jest.useFakeTimers();
+		try {
+			const middleware = createConcurrencyLimitMiddleware({ limit: 1, timeoutMs: 60_000 });
+
+			const stalled = await testMiddleware({
+				middleware,
+				ctx: makeAuthContext(),
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			expect(stalled.responseMock.statusCode).toBe(200);
+
+			await jest.advanceTimersByTimeAsync(60_000);
+
+			const admitted = await testMiddleware({
+				middleware,
+				ctx: makeAuthContext(),
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			expect(admitted.responseMock.statusCode).toBe(200);
+			admitted.responseMock.emit('finish');
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it('destroys the response when the timeout fires, so a stuck connection is not held open forever', async () => {
+		jest.useFakeTimers();
+		try {
+			const middleware = createConcurrencyLimitMiddleware({ limit: 1, timeoutMs: 60_000 });
+
+			const stalled = await testMiddleware({
+				middleware,
+				ctx: makeAuthContext(),
+				requestProps: { method: 'POST', body: {} },
+				responseOptions: { eventEmitter: EventEmitter },
+			});
+			const destroySpy = jest.spyOn(stalled.responseMock, 'destroy');
+
+			await jest.advanceTimersByTimeAsync(60_000);
+
+			expect(destroySpy).toHaveBeenCalledTimes(1);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+});

--- a/src/utils/middleware/concurrency-limit/index.ts
+++ b/src/utils/middleware/concurrency-limit/index.ts
@@ -1,0 +1,66 @@
+import type { AuthContext } from '@masumi/payment-core/auth-middleware';
+import { Middleware } from 'express-zod-api';
+import createHttpError from 'http-errors';
+import { z } from '@masumi/payment-core/zod';
+
+const concurrencyLimitInputSchema = z.object({});
+
+type ConcurrencyLimitOptions = {
+	limit: number;
+	timeoutMs: number;
+};
+
+/**
+ * Caps how many requests built on ONE middleware instance can be in flight at
+ * once, rejecting the rest with 503 instead of letting them pile into memory.
+ * Share a single instance across every route that hits the same underlying
+ * resource (e.g. several endpoints that all run heavy, unbounded queries
+ * against the same DB/heap) so the cap bounds their combined concurrency
+ * rather than each route independently.
+ *
+ * Note: the `timeoutMs` safety net frees the accounting slot and destroys the
+ * response, but does not cancel whatever the handler is still doing server
+ * side (e.g. an in-flight DB query) — there is no cancellation signal wired
+ * into the handler here. It bounds how long one stuck request can hold a
+ * slot and stops the server waiting on a client that gave up; it does not by
+ * itself bound that request's own resource use past `timeoutMs`.
+ */
+export const createConcurrencyLimitMiddleware = ({ limit, timeoutMs }: ConcurrencyLimitOptions) => {
+	let active = 0;
+
+	return new Middleware<AuthContext, AuthContext, string, typeof concurrencyLimitInputSchema>({
+		input: concurrencyLimitInputSchema,
+		handler: async ({ ctx, response }) => {
+			if (active >= limit) {
+				response.setHeader('Retry-After', '1');
+				throw createHttpError(503, 'Server capacity reached. Retry later.');
+			}
+
+			active += 1;
+			let released = false;
+			const release = () => {
+				if (released) return;
+				released = true;
+				active -= 1;
+				clearTimeout(deadline);
+				response.off('finish', release);
+				response.off('close', release);
+			};
+			// Safety net: if the response never fires finish/close (a hung
+			// handler or query), don't leak the slot for the rest of the process.
+			// Destroying the response also stops the server holding that specific
+			// connection open forever for a client that gave up, and makes the
+			// eventual (still in-flight) write fail fast instead of succeeding
+			// against a socket nobody is reading from.
+			const deadline = setTimeout(() => {
+				response.destroy();
+				release();
+			}, timeoutMs);
+			deadline.unref();
+			response.once('finish', release);
+			response.once('close', release);
+
+			return ctx;
+		},
+	});
+};


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

Bug fix  

## **Overview of Changes**

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-508/sending-around-20-requests-at-the-same-time-to-paymentincome-or
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
