### PR TITLE
fix(startup-migrations): retry conflicts in agent-identifier backfill

### DIFF
--- a/src/utils/startup-migrations/backfill-transaction-agent-identifiers/index.ts
+++ b/src/utils/startup-migrations/backfill-transaction-agent-identifiers/index.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@masumi/payment-core/db';
 import { decodeBlockchainIdentifier } from '@masumi/payment-core/blockchain-identifier';
 import { logger } from '@masumi/payment-core/logger';
+import { withSerializableSlotRetry } from '@masumi/payment-core/serializable-semaphore';
 
 const BATCH = 250;
 
@@ -64,17 +65,21 @@ export async function backfillTransactionAgentIdentifiers(): Promise<void> {
 		});
 		if (chunk.length === 0) break;
 
-		await prisma.$transaction(
-			async (tx) => {
-				for (const row of chunk) {
-					const agentIdentifier = safeDecodeAgentIdentifier(row, 'paymentRequest');
-					await tx.paymentRequest.update({
-						where: { id: row.id },
-						data: { agentIdentifier, agentIdentifierSyncedAt: syncedAt },
-					});
-				}
-			},
-			{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+		await withSerializableSlotRetry(
+			() =>
+				prisma.$transaction(
+					async (tx) => {
+						for (const row of chunk) {
+							const agentIdentifier = safeDecodeAgentIdentifier(row, 'paymentRequest');
+							await tx.paymentRequest.update({
+								where: { id: row.id },
+								data: { agentIdentifier, agentIdentifierSyncedAt: syncedAt },
+							});
+						}
+					},
+					{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+				),
+			{ label: 'backfill-agent-identifier-payment-request' },
 		);
 		paymentsDone += chunk.length;
 	}
@@ -88,17 +93,21 @@ export async function backfillTransactionAgentIdentifiers(): Promise<void> {
 		});
 		if (chunk.length === 0) break;
 
-		await prisma.$transaction(
-			async (tx) => {
-				for (const row of chunk) {
-					const agentIdentifier = safeDecodeAgentIdentifier(row, 'purchaseRequest');
-					await tx.purchaseRequest.update({
-						where: { id: row.id },
-						data: { agentIdentifier, agentIdentifierSyncedAt: syncedAt },
-					});
-				}
-			},
-			{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+		await withSerializableSlotRetry(
+			() =>
+				prisma.$transaction(
+					async (tx) => {
+						for (const row of chunk) {
+							const agentIdentifier = safeDecodeAgentIdentifier(row, 'purchaseRequest');
+							await tx.purchaseRequest.update({
+								where: { id: row.id },
+								data: { agentIdentifier, agentIdentifierSyncedAt: syncedAt },
+							});
+						}
+					},
+					{ isolationLevel: 'Serializable', timeout: 30_000, maxWait: 30_000 },
+				),
+			{ label: 'backfill-agent-identifier-purchase-request' },
 		);
 		purchasesDone += chunk.length;
 	}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

Bug fix  


## **Overview of Changes**
Server Startup Deadlock with Concurrent Instances
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-509/server-startup-deadlock-with-concurrent-instances
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
