### PR TITLE
Mas 516 admin key stored unencrypted in browser

### DIFF
--- a/frontend/src/components/api-keys/ApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/ApiKeyDialog.tsx
@@ -11,6 +11,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { capabilitiesFromApiKeyStatus, DEFAULT_CAPABILITIES } from '@/lib/permissions';
 import { MASUMI_API_KEY_DOCS_URL } from '@/lib/masumi-links';
+import { encryptForStorage } from '@/lib/secure-storage';
 
 interface ApiError {
   message: string;
@@ -48,8 +49,8 @@ export function ApiKeyDialog() {
 
       setCapabilities(nextCapabilities);
 
-      const hexKey = Buffer.from(key).toString('hex');
-      localStorage.setItem('payment_api_key', hexKey);
+      const encryptedKey = await encryptForStorage(key);
+      localStorage.setItem('payment_api_key', encryptedKey);
 
       const sourcesResponse = await getPaymentSource({
         client: apiClient,

--- a/frontend/src/lib/secure-storage.ts
+++ b/frontend/src/lib/secure-storage.ts
@@ -1,4 +1,3 @@
-
 const DB_NAME = 'masumi-secure-storage';
 const STORE_NAME = 'keys';
 const KEY_ID = 'api-key-encryption-key';
@@ -98,7 +97,6 @@ export async function encryptForStorage(plaintext: string): Promise<string> {
   const key = await getOrCreateKey();
   return encryptWithKey(key, plaintext);
 }
-
 
 export async function decryptFromStorage(stored: string): Promise<string | null> {
   try {

--- a/frontend/src/lib/secure-storage.ts
+++ b/frontend/src/lib/secure-storage.ts
@@ -1,0 +1,110 @@
+
+const DB_NAME = 'masumi-secure-storage';
+const STORE_NAME = 'keys';
+const KEY_ID = 'api-key-encryption-key';
+const IV_LENGTH_BYTES = 12;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function loadStoredKey(): Promise<CryptoKey | null> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const request = tx.objectStore(STORE_NAME).get(KEY_ID);
+    request.onsuccess = () => resolve((request.result as CryptoKey | undefined) ?? null);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function saveKey(key: CryptoKey): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(key, KEY_ID);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+let keyPromise: Promise<CryptoKey> | null = null;
+
+// Non-extractable: the raw key material never exists as a string or byte
+// array script can read back out, only as an opaque CryptoKey handle.
+function getOrCreateKey(): Promise<CryptoKey> {
+  if (keyPromise == null) {
+    keyPromise = (async () => {
+      const existing = await loadStoredKey();
+      if (existing) return existing;
+      const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, [
+        'encrypt',
+        'decrypt',
+      ]);
+      await saveKey(key);
+      return key;
+    })();
+  }
+  return keyPromise;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export async function encryptWithKey(key: CryptoKey, plaintext: string): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+  return toBase64(combined);
+}
+
+export async function decryptWithKey(key: CryptoKey, stored: string): Promise<string | null> {
+  try {
+    const combined = fromBase64(stored);
+    if (combined.length <= IV_LENGTH_BYTES) return null;
+    const iv = combined.slice(0, IV_LENGTH_BYTES);
+    const ciphertext = combined.slice(IV_LENGTH_BYTES);
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    return new TextDecoder().decode(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+export async function encryptForStorage(plaintext: string): Promise<string> {
+  const key = await getOrCreateKey();
+  return encryptWithKey(key, plaintext);
+}
+
+
+export async function decryptFromStorage(stored: string): Promise<string | null> {
+  try {
+    const key = await getOrCreateKey();
+    return await decryptWithKey(key, stored);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -24,6 +24,7 @@ import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtende
 import { useX402NetworksForSession } from '@/lib/hooks/useX402';
 import { chainsForEnv } from '@/lib/x402-rail';
 import { capabilitiesFromApiKeyStatus, isAdminOnlyPath, isPayOnlyPath } from '@/lib/permissions';
+import { decryptFromStorage } from '@/lib/secure-storage';
 import { hasLegacyOnlyPaymentSources, isV2PaymentSource } from '@/lib/payment-source-type';
 import { MASUMI_DOCUMENTATION_URL } from '@/lib/masumi-links';
 import {
@@ -323,14 +324,20 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
         return;
       }
 
-      const hexedKey = localStorage.getItem('payment_api_key');
-      if (!hexedKey) {
+      const storedEncryptedKey = localStorage.getItem('payment_api_key');
+      if (!storedEncryptedKey) {
         setIsHealthy(true);
         setAuthorized(false);
         return;
       }
 
-      const storedApiKey = Buffer.from(hexedKey, 'hex').toString('utf-8');
+      const storedApiKey = await decryptFromStorage(storedEncryptedKey);
+      if (!storedApiKey) {
+        localStorage.removeItem('payment_api_key');
+        setIsHealthy(true);
+        setAuthorized(false);
+        return;
+      }
       apiClient.setConfig({
         headers: {
           token: storedApiKey,
@@ -349,7 +356,7 @@ function ThemedApp({ Component, pageProps, router }: AppProps) {
       // Re-read the stored key: signOut() clears it without changing this
       // effect's deps, and authorizing from the stale value would sign the
       // user straight back in.
-      if (cancelled || localStorage.getItem('payment_api_key') !== hexedKey) return;
+      if (cancelled || localStorage.getItem('payment_api_key') !== storedEncryptedKey) return;
 
       if (!apiKeyStatus) {
         setIsHealthy(true);


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

 Bug fix  


## **Overview of Changes**
Admin Key Stored Unencrypted in Browser
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-516/admin-key-stored-unencrypted-in-browser
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
