### PR TITLE
fix(hydra): harden host setup and exchange transport

### DIFF
--- a/docs/hydra-host-deploy-droplet.md
+++ b/docs/hydra-host-deploy-droplet.md
@@ -120,7 +120,7 @@ docker create --name hydra-host \
   -v /srv/hydra/blockfrost.txt:/run/secrets/blockfrost.txt:ro \
   -e HYDRA_HOST_PUBLIC_HOST=hydra1.example.com \
   -e HYDRA_HOST_PUBLIC_EXCHANGE_URL=https://hydra-exchange.example.com:8444/exchange \
-  -e HYDRA_HOST_EXCHANGE_TRUST_PROXY=true \
+  -e HYDRA_HOST_EXCHANGE_TRUST_PROXY=false \
   -e HYDRA_HOST_NETWORK=preprod \
   -e HYDRA_HOST_ADMIN_TOKEN="$HYDRA_HOST_ADMIN_TOKEN" \
   -e HYDRA_HOST_USER_TOKEN="$HYDRA_HOST_USER_TOKEN" \
@@ -314,8 +314,11 @@ response. The payment service puts that exact URL in signed invites. It no
 longer derives the public Exchange Plane address from the private Control Plane
 address.
 
-Set `HYDRA_HOST_EXCHANGE_TRUST_PROXY=true` only when the cloud firewall permits
-the Exchange Plane load balancer to reach backend port `8444`. DigitalOcean adds
+Keep `HYDRA_HOST_EXCHANGE_TRUST_PROXY=false` during initial setup.
+Before enabling it, configure the load balancer and restrict backend port `8444`
+to that load balancer in the cloud firewall. Confirm that direct access is blocked.
+Then set `HYDRA_HOST_EXCHANGE_TRUST_PROXY=true` in the container configuration.
+DigitalOcean adds
 the client address to `X-Forwarded-For`. The Host uses the last address when it
 is a valid IP. It ignores this header when the setting is false.
 

--- a/docs/hydra-host-deploy-droplet.md
+++ b/docs/hydra-host-deploy-droplet.md
@@ -119,6 +119,8 @@ docker create --name hydra-host \
   -v /mnt/hydra_data:/data \
   -v /srv/hydra/blockfrost.txt:/run/secrets/blockfrost.txt:ro \
   -e HYDRA_HOST_PUBLIC_HOST=hydra1.example.com \
+  -e HYDRA_HOST_PUBLIC_EXCHANGE_URL=https://hydra-exchange.example.com:8444/exchange \
+  -e HYDRA_HOST_EXCHANGE_TRUST_PROXY=true \
   -e HYDRA_HOST_NETWORK=preprod \
   -e HYDRA_HOST_ADMIN_TOKEN="$HYDRA_HOST_ADMIN_TOKEN" \
   -e HYDRA_HOST_USER_TOKEN="$HYDRA_HOST_USER_TOKEN" \
@@ -203,8 +205,8 @@ that head actually peers with.
 
 | Port        | Plane                                          | Exposed                                                                                                                            |
 | ----------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `8443`      | Control. Your payment service talks to this.   | Yes, bearer-token gated. Restrict by source.                                                                                       |
-| `8444`      | Exchange. Where counterparties redeem invites. | Yes. See below.                                                                                                                    |
+| `8443`      | Control. Your payment service talks to this.   | Through the restricted Control Plane load balancer.                                                                                |
+| `8444`      | Exchange. Where counterparties redeem invites. | Through the public TLS Exchange Plane load balancer.                                                                               |
 | `5001-5032` | Peer. One per head, etcd raft.                 | Yes, per-head source allow-list.                                                                                                   |
 | `4001-4032` | `hydra-node` API                               | **Never.** Unauthenticated, can close a head. Pinned to loopback in code.                                                          |
 | `6001-6032` | Prometheus                                     | **Never.** `hydra-node` has no `--monitoring-host`, so it cannot be bound to loopback. Keep `HYDRA_HOST_MONITORING_ENABLED=false`. |
@@ -214,14 +216,15 @@ loopback only. It never crosses the network.
 
 ### DigitalOcean cloud firewall
 
-| Type    | Protocol | Ports     | Sources                                                                   |
-| ------- | -------- | --------- | ------------------------------------------------------------------------- |
-| Inbound | TCP      | 8443      | Your load balancer, or your payment service's address. Never `0.0.0.0/0`. |
-| Inbound | TCP      | 8444      | `0.0.0.0/0`                                                               |
-| Inbound | TCP      | 5001-5032 | Counterparty addresses only                                               |
-| Inbound | TCP      | 22        | Your own administrative range                                             |
+| Type    | Protocol | Ports     | Sources                                          |
+| ------- | -------- | --------- | ------------------------------------------------ |
+| Inbound | TCP      | 8443      | Control Plane load balancer. Never `0.0.0.0/0`.  |
+| Inbound | TCP      | 8444      | Exchange Plane load balancer. Never `0.0.0.0/0`. |
+| Inbound | TCP      | 5001-5032 | Counterparty addresses only                      |
+| Inbound | TCP      | 22        | Your own administrative range                    |
 
-The exchange plane on 8444 is open on purpose. It is unauthenticated by design,
+The Exchange Plane load balancer on 8444 is open on purpose. The droplet port
+accepts traffic only from that load balancer. The plane is unauthenticated by design,
 because the invite nonce is the credential: redemption requires a nonce this Host
 issued, unspent and unexpired. Bodies are capped at 64KB, concurrency at 16, and
 requests at 120 per minute. Nothing on that plane can provision, delete,
@@ -296,8 +299,34 @@ including `/etc/nftables.d/hydra-peer.nft` from `/etc/nftables.conf` and enablin
 ## 5. TLS and the load balancer
 
 The container serves plain HTTP and honours `X-Forwarded-Proto` for logging
-only. The token, not the transport, is what authenticates. Terminate TLS outside:
-a managed load balancer in front of `8443`.
+only. Terminate TLS outside the container for both HTTP planes.
+
+Use two regional load balancers because their public access rules differ:
+
+| Load balancer  | Public rule  | Backend rule | Access                                   |
+| -------------- | ------------ | ------------ | ---------------------------------------- |
+| Control Plane  | HTTPS `443`  | HTTP `8443`  | Allow only the payment service addresses |
+| Exchange Plane | HTTPS `8444` | HTTP `8444`  | Public                                   |
+
+Set `HYDRA_HOST_PUBLIC_EXCHANGE_URL` to the Exchange Plane URL, including
+`/exchange`. The Host reports this URL through its authenticated capabilities
+response. The payment service puts that exact URL in signed invites. It no
+longer derives the public Exchange Plane address from the private Control Plane
+address.
+
+Set `HYDRA_HOST_EXCHANGE_TRUST_PROXY=true` only when the cloud firewall permits
+the Exchange Plane load balancer to reach backend port `8444`. DigitalOcean adds
+the client address to `X-Forwarded-For`. The Host uses the last address when it
+is a valid IP. It ignores this header when the setting is false.
+
+VERIFIED on 2026-09-04: DigitalOcean regional load balancers support several
+port and protocol rules, and HTTP forwarding adds `X-Forwarded-For`. See the
+[forwarding-rule reference](https://docs.digitalocean.com/reference/doctl/reference/compute/load-balancer/add-forwarding-rules/)
+and [load-balancer feature reference](https://docs.digitalocean.com/products/networking/load-balancers/details/features/).
+
+Do not put both planes behind one public load balancer. A load balancer firewall
+applies to the load balancer, not to one forwarding rule. Making its Exchange
+Plane rule public would also make the Control Plane listener public.
 
 Keeping ACME state out of the image means the container has exactly one thing
 needing durable storage.

--- a/docs/hydra-host-deploy-droplet.md
+++ b/docs/hydra-host-deploy-droplet.md
@@ -350,8 +350,22 @@ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8443/v1/capabilities
 # 401 means healthy
 ```
 
-Point a load-balancer health check at `8443` with the same expectation, or at TCP
-connect if your load balancer cannot assert a status code.
+Configure a separate TCP health check on each load balancer:
+
+| Load balancer  | Health protocol | Backend port |
+| -------------- | --------------- | ------------ |
+| Control Plane  | TCP             | `8443`       |
+| Exchange Plane | TCP             | `8444`       |
+
+These ports match the forwarding rules and firewall sources above. The Exchange
+Plane load balancer cannot probe `8443` through those firewall rules.
+TCP checks confirm that a listener accepts connections. They do not test
+authentication, TLS, or head readiness. Keep the local `401` probe as a manual check.
+
+VERIFIED on 2026-09-05: DigitalOcean HTTP health checks accept status codes
+`200` through `399`, so the `401` probe cannot serve as an HTTP health check.
+TCP health checks require a successful TCP handshake. See the
+[health-check reference](https://docs.digitalocean.com/products/networking/load-balancers/how-to/manage/#health-checks).
 
 ## 7. One Host per volume
 

--- a/docs/hydra-host-native-mode.md
+++ b/docs/hydra-host-native-mode.md
@@ -62,6 +62,8 @@ Two arm64 cases, and they are not the same problem:
 ### 1. Fetch `hydra-node`
 
 ```bash
+(
+set -e
 HYDRA_VERSION=2.3.0
 HYDRA_SHA256=a9074d0b69cc7104ccad672c942da7c0c695b4dbdff5002fd503904fe24ad528
 curl --proto '=https' --tlsv1.2 -fsSL -o hydra.zip \
@@ -70,6 +72,7 @@ printf '%s  %s\n' "$HYDRA_SHA256" hydra.zip | shasum -a 256 -c -
 unzip -j hydra.zip -d .bin
 chmod +x .bin/hydra-node
 .bin/hydra-node --version
+)
 ```
 
 The checksum above is the SHA-256 digest reported by the official Hydra 2.3.0

--- a/docs/hydra-host-native-mode.md
+++ b/docs/hydra-host-native-mode.md
@@ -63,12 +63,18 @@ Two arm64 cases, and they are not the same problem:
 
 ```bash
 HYDRA_VERSION=2.3.0
-curl -fsSL -o hydra.zip \
+HYDRA_SHA256=a9074d0b69cc7104ccad672c942da7c0c695b4dbdff5002fd503904fe24ad528
+curl --proto '=https' --tlsv1.2 -fsSL -o hydra.zip \
   "https://github.com/cardano-scaling/hydra/releases/download/${HYDRA_VERSION}/hydra-aarch64-darwin-${HYDRA_VERSION}.zip"
+printf '%s  %s\n' "$HYDRA_SHA256" hydra.zip | shasum -a 256 -c -
 unzip -j hydra.zip -d .bin
 chmod +x .bin/hydra-node
 .bin/hydra-node --version
 ```
+
+The checksum above is the SHA-256 digest reported by the official Hydra 2.3.0
+release API on 2026-09-04. Review and replace both the version and digest
+together when upgrading.
 
 Both sides of a head must run the same version, so pin it rather than tracking
 latest.
@@ -77,6 +83,7 @@ latest.
 
 ```bash
 HYDRA_HOST_PUBLIC_HOST=hydra.example.com \
+HYDRA_HOST_PUBLIC_EXCHANGE_URL=http://127.0.0.1:8444/exchange \
 HYDRA_HOST_NETWORK=preprod \
 HYDRA_HOST_ADMIN_TOKEN="$(openssl rand -hex 32)" \
 HYDRA_HOST_USER_TOKEN="$(openssl rand -hex 32)" \
@@ -87,6 +94,9 @@ HYDRA_HOST_LEDGER_PARAMS_FILE="$PWD/packages/hydra-host/params/preprod.json" \
 HYDRA_HOST_USE_SYSTEM_ETCD=false \
 pnpm exec tsx packages/hydra-host/src/index.ts
 ```
+
+The loopback Exchange Plane URL is for a local native run. A reachable Host
+must use its public HTTPS Exchange Plane URL.
 
 Four of those differ from the container and are worth understanding:
 

--- a/docs/hydra-operations.md
+++ b/docs/hydra-operations.md
@@ -65,6 +65,7 @@ block-storage volume, the systemd unit, the firewall, and backups end to end.
 cd packages/hydra-host
 HYDRA_HOST_IMAGE=hydra-host:local \
 HYDRA_HOST_PUBLIC_HOST=hydra.example.com \
+HYDRA_HOST_PUBLIC_EXCHANGE_URL=http://127.0.0.1:8444/exchange \
 HYDRA_HOST_NETWORK=preprod \
 HYDRA_HOST_ADMIN_TOKEN="$(openssl rand -hex 32)" \
 HYDRA_HOST_USER_TOKEN="$(openssl rand -hex 32)" \
@@ -100,6 +101,11 @@ a head. `HYDRA_HOST_PUBLIC_HOST` is a bare hostname or IP with no scheme, port
 or path; the Host refuses to start otherwise, because that value becomes each
 node's advertise identity and must not change for a head's lifetime.
 
+`HYDRA_HOST_PUBLIC_EXCHANGE_URL` is the full URL that signed invites give to
+counterparties. It must end in `/exchange`. It must use HTTPS unless it points
+to loopback. Set `HYDRA_HOST_EXCHANGE_TRUST_PROXY=true` only when a trusted
+HTTP proxy is the only network path to port `8444`.
+
 The ports are the security boundary. Five ranges exist and only three may leave
 the machine:
 
@@ -113,6 +119,9 @@ the machine:
 
 The API range is additionally bound to `127.0.0.1` inside the container, so it
 stays shut even if someone switches to host networking.
+
+The base Compose file also binds the Control Plane and Exchange Plane to
+`127.0.0.1`. Public access requires an explicit deployment configuration.
 
 **The peer plane cannot authenticate its callers**, which is why the base
 compose file does not publish it. It still has to be reachable, because a head

--- a/hydra-l2-flow/hydra-native.sh
+++ b/hydra-l2-flow/hydra-native.sh
@@ -51,6 +51,10 @@ DEMO="${DEMO:-${HYDRA_DEMO_DIR:-$( \
   done )}}"
 
 HYDRA_VERSION="${HYDRA_VERSION:-2.3.0}"
+HYDRA_RELEASE_SHA256="${HYDRA_RELEASE_SHA256:-}"
+if [ -z "$HYDRA_RELEASE_SHA256" ] && [ "$HYDRA_VERSION" = '2.3.0' ]; then
+  HYDRA_RELEASE_SHA256='a9074d0b69cc7104ccad672c942da7c0c695b4dbdff5002fd503904fe24ad528'
+fi
 # Only used for the HYDRA_BIN_TAG path below (testing an unreleased commit):
 # hydra-node CI publishes those as workflow artifacts, not release assets.
 HYDRA_BIN_RUN_ID="${HYDRA_BIN_RUN_ID:-27418396480}"
@@ -115,9 +119,15 @@ ensure_bin(){
   else
     # Tagged releases from 2.3.0 onward publish aarch64-darwin binaries as a
     # release zip (2.2.0 and earlier had no release assets at all).
+    [ -n "$HYDRA_RELEASE_SHA256" ] || {
+      c_red "HYDRA_RELEASE_SHA256 is required for Hydra ${HYDRA_VERSION}"
+      exit 1
+    }
     c_blu "Downloading native hydra-aarch64-darwin-${HYDRA_VERSION}.zip (release asset, ~176 MiB)…"
     gh release download "$HYDRA_VERSION" --repo cardano-scaling/hydra \
       --pattern "hydra-aarch64-darwin-${HYDRA_VERSION}.zip" --dir "$tmp" || { c_red "download failed"; exit 1; }
+    printf '%s  %s\n' "$HYDRA_RELEASE_SHA256" "$tmp/hydra-aarch64-darwin-${HYDRA_VERSION}.zip" \
+      | shasum -a 256 -c - || { c_red "checksum verification failed"; exit 1; }
     (cd "$tmp" && unzip -oq "hydra-aarch64-darwin-${HYDRA_VERSION}.zip") || { c_red "unzip failed"; exit 1; }
   fi
   [ -f "$tmp/hydra-node" ] || { c_red "artifact missing hydra-node"; exit 1; }

--- a/hydra-l2-flow/run-payment-node-demo.sh
+++ b/hydra-l2-flow/run-payment-node-demo.sh
@@ -9,6 +9,5 @@ cd "$REPO"
 [ -f .env.hydra-demo ] || { echo "missing .env.hydra-demo"; exit 1; }
 set -a; # shellcheck disable=SC1091
 source .env.hydra-demo; set +a
-echo "payment node → DB $DATABASE_URL"
 echo "hydra local $HYDRA_NODE_URL  remote $HYDRA_REMOTE_NODE_URL"
 exec pnpm dev

--- a/packages/hydra-host/docker-compose.yml
+++ b/packages/hydra-host/docker-compose.yml
@@ -4,7 +4,7 @@
 # production run the image under whatever you already operate, carrying over the
 # volume, the stop grace period and the healthcheck below.
 #
-# The port mapping is the security boundary. The secure default binds only the
+# The port mapping is the security boundary. The base file binds the
 # authenticated control plane and single-purpose exchange plane to loopback:
 #
 #   8443        control plane      published, bearer-token gated
@@ -34,11 +34,11 @@ services:
     restart: unless-stopped
 
     ports:
-      - '8443:8443'
+      - '127.0.0.1:8443:8443'
       # The exchange plane. A counterparty redeems an invite by posting to this
       # port on the issuer's Host, so a Host that does not publish it can issue
       # invites nobody can accept.
-      - '8444:8444'
+      - '127.0.0.1:8444:8444'
       # The peer plane is deliberately NOT published here. Every head needs its
       # own port and a head whose port is unpublished cannot reach its peer, so
       # publishing it is required — but it is unauthenticated etcd raft, and the
@@ -54,6 +54,10 @@ services:
       # becomes each node's advertise identity, so it must be resolvable from
       # outside and must not change for a head's lifetime.
       HYDRA_HOST_PUBLIC_HOST: ${HYDRA_HOST_PUBLIC_HOST:?set to this host's public name}
+      # Local default only. Production must set the TLS URL exposed by its
+      # dedicated Exchange Plane load balancer.
+      HYDRA_HOST_PUBLIC_EXCHANGE_URL: ${HYDRA_HOST_PUBLIC_EXCHANGE_URL:-http://127.0.0.1:8444/exchange}
+      HYDRA_HOST_EXCHANGE_TRUST_PROXY: ${HYDRA_HOST_EXCHANGE_TRUST_PROXY:-false}
       HYDRA_HOST_NETWORK: ${HYDRA_HOST_NETWORK:-preprod}
 
       # Two tiers, both at least 32 characters. Admin covers fleet operations;

--- a/packages/hydra-host/src/api/exchange-server.spec.ts
+++ b/packages/hydra-host/src/api/exchange-server.spec.ts
@@ -4,7 +4,7 @@ import type { Server } from 'node:http';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { createExchangePlane, OVERFLOW_SOURCE, rateLimitKey } from './exchange-server.js';
+import { createExchangePlane, exchangeRequestSource, OVERFLOW_SOURCE, rateLimitKey } from './exchange-server.js';
 import { ExchangeStore } from '../registry/exchange-store.js';
 
 // The keys are the real shape a `.vk` envelope carries — `5820` and 32 bytes —
@@ -26,6 +26,21 @@ let dataDir: string;
 let onRedeemed: jest.Mock<(nonce: string, hostNodeId: string) => Promise<void>>;
 
 const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+describe('Exchange Plane request source', () => {
+	it('ignores forwarded addresses unless the proxy is trusted', () => {
+		expect(exchangeRequestSource('10.0.0.2', '198.51.100.4', false)).toBe('10.0.0.2');
+	});
+
+	it('uses the address appended by the trusted proxy', () => {
+		expect(exchangeRequestSource('10.0.0.2', '203.0.113.9, 198.51.100.4', true)).toBe('198.51.100.4');
+		expect(exchangeRequestSource('10.0.0.2', '2001:db8::7', true)).toBe('2001:db8::7');
+	});
+
+	it('falls back to the socket address for a malformed forwarded address', () => {
+		expect(exchangeRequestSource('10.0.0.2', 'attacker-controlled', true)).toBe('10.0.0.2');
+	});
+});
 
 /** Poll until the value is set, for work the handler does after answering. */
 async function eventually<T>(read: () => Promise<T | null>, timeoutMs = 2_000): Promise<T | null> {

--- a/packages/hydra-host/src/api/exchange-server.ts
+++ b/packages/hydra-host/src/api/exchange-server.ts
@@ -19,6 +19,7 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { isIP } from 'node:net';
 import type { ExchangeStore } from '../registry/exchange-store.js';
 import { isExchangeMaterial, isExchangeSignature } from '../registry/exchange-types.js';
 import type { SupervisorLogger } from '../supervisor/supervisor.js';
@@ -77,6 +78,20 @@ export function rateLimitKey(remote: string, tracked: ReadonlySet<string> | Map<
 	return tracked.has(remote) || tracked.size < cap ? remote : OVERFLOW_SOURCE;
 }
 
+export function exchangeRequestSource(
+	remote: string | undefined,
+	forwarded: string | string[] | undefined,
+	trustProxy: boolean,
+): string {
+	const socketAddress = remote ?? 'unknown';
+	if (!trustProxy || forwarded === undefined) {
+		return socketAddress;
+	}
+	const parts = (Array.isArray(forwarded) ? forwarded.join(',') : forwarded).split(',');
+	const candidate = parts[parts.length - 1]?.trim();
+	return candidate !== undefined && isIP(candidate) !== 0 ? candidate : socketAddress;
+}
+
 export type ExchangeDeps = {
 	store: ExchangeStore;
 	logger: SupervisorLogger;
@@ -88,6 +103,8 @@ export type ExchangeDeps = {
 	 * counterparty who can do nothing about it.
 	 */
 	onRedeemed: (nonce: string, hostNodeId: string) => Promise<void>;
+	/** Read X-Forwarded-For only when a trusted HTTP proxy is the sole caller. */
+	trustProxy?: boolean;
 	/** Test/deployment tuning. Defaults protect a small single-host process. */
 	limits?: { maxInFlight?: number; requestsPerMinute?: number; maxTrackedSources?: number };
 };
@@ -174,7 +191,11 @@ export function createExchangePlane(deps: ExchangeDeps): Server {
 			requestsInWindow.clear();
 			failuresInWindow.clear();
 		}
-		const remote = request.socket.remoteAddress ?? 'unknown';
+		const remote = exchangeRequestSource(
+			request.socket.remoteAddress,
+			request.headers['x-forwarded-for'],
+			deps.trustProxy === true,
+		);
 		const source = rateLimitKey(remote, requestsInWindow, maxTrackedSources);
 		const seen = (requestsInWindow.get(source) ?? 0) + 1;
 		requestsInWindow.set(source, seen);

--- a/packages/hydra-host/src/api/proxy.spec.ts
+++ b/packages/hydra-host/src/api/proxy.spec.ts
@@ -20,6 +20,7 @@ const env: EnvSource = {
 	get: (key) =>
 		({
 			HYDRA_HOST_PUBLIC_HOST: 'hydra1.example.com',
+			HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'https://exchange.hydra1.example.com:8444/exchange',
 			HYDRA_HOST_ADMIN_TOKEN: ADMIN,
 			HYDRA_HOST_USER_TOKEN: USER,
 			HYDRA_HOST_PEER_PORT_COUNT: '4',

--- a/packages/hydra-host/src/api/server.spec.ts
+++ b/packages/hydra-host/src/api/server.spec.ts
@@ -25,6 +25,7 @@ const env: EnvSource = {
 	get: (key) =>
 		({
 			HYDRA_HOST_PUBLIC_HOST: 'hydra1.example.com',
+			HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'https://exchange.hydra1.example.com:8444/exchange',
 			HYDRA_HOST_ADMIN_TOKEN: ADMIN,
 			HYDRA_HOST_USER_TOKEN: USER,
 			HYDRA_HOST_PEER_PORT_COUNT: '4',
@@ -100,6 +101,15 @@ describe('control plane auth', () => {
 
 	it('accepts an admin route with the admin token', async () => {
 		expect((await call('GET', '/v1/nodes', { token: ADMIN })).status).toBe(200);
+	});
+
+	it('reports the configured public Exchange Plane URL to an admin', async () => {
+		const response = await call('GET', '/v1/capabilities', { token: ADMIN });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			exchangeUrl: 'https://exchange.hydra1.example.com:8444/exchange',
+		});
 	});
 
 	it('404s an unknown path without revealing whether a token would help', async () => {

--- a/packages/hydra-host/src/api/server.ts
+++ b/packages/hydra-host/src/api/server.ts
@@ -329,6 +329,7 @@ export function createControlPlane(deps: ServerDeps): Server {
 					ledgerProtocolParametersFile: config.ledgerProtocolParametersFile,
 					network: config.network,
 					exchangePort: config.exchangePort,
+					exchangeUrl: config.publicExchangeUrl,
 					slots: () => ({ used: ports.used, capacity: config.ports.capacity }),
 				});
 				send(response, 200, capabilities);

--- a/packages/hydra-host/src/capabilities.ts
+++ b/packages/hydra-host/src/capabilities.ts
@@ -41,6 +41,8 @@ export type Capabilities = {
 	 * counterparty as a 404 for a nonce that was never theirs.
 	 */
 	exchangePort: number;
+	/** Public URL reported verbatim from validated Host configuration. */
+	exchangeUrl: string;
 };
 
 export type CapabilitiesDeps = {
@@ -48,6 +50,7 @@ export type CapabilitiesDeps = {
 	ledgerProtocolParametersFile: string;
 	network: string;
 	exchangePort: number;
+	exchangeUrl: string;
 	slots: () => { used: number; capacity: number };
 	exec?: (file: string, args: string[]) => Promise<{ stdout: string }>;
 };
@@ -100,6 +103,7 @@ export async function readCapabilities(deps: CapabilitiesDeps): Promise<Capabili
 		ledgerParamsHash,
 		network: deps.network,
 		exchangePort: deps.exchangePort,
+		exchangeUrl: deps.exchangeUrl,
 		nodeSlots: deps.slots(),
 	};
 }

--- a/packages/hydra-host/src/config.spec.ts
+++ b/packages/hydra-host/src/config.spec.ts
@@ -8,6 +8,7 @@ function env(overrides: Record<string, string> = {}): EnvSource {
 	const values = new Map<string, string>(
 		Object.entries({
 			HYDRA_HOST_PUBLIC_HOST: 'hydra1.example.com',
+			HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'https://exchange.hydra1.example.com:8444/exchange',
 			HYDRA_HOST_ADMIN_TOKEN: TOKEN_A,
 			HYDRA_HOST_USER_TOKEN: TOKEN_B,
 			...overrides,
@@ -30,6 +31,41 @@ describe('loadHostConfig', () => {
 		expect(() => loadHostConfig({ get: (k) => (k === 'HYDRA_HOST_PUBLIC_HOST' ? undefined : values.get(k)) })).toThrow(
 			/HYDRA_HOST_PUBLIC_HOST is required/,
 		);
+	});
+
+	it('requires a secure public Exchange Plane URL', () => {
+		const values = env();
+		expect(() =>
+			loadHostConfig({ get: (key) => (key === 'HYDRA_HOST_PUBLIC_EXCHANGE_URL' ? undefined : values.get(key)) }),
+		).toThrow(/HYDRA_HOST_PUBLIC_EXCHANGE_URL is required/);
+		expect(() =>
+			loadHostConfig(env({ HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'http://exchange.example.com:8444/exchange' })),
+		).toThrow(/must use HTTPS/);
+		expect(loadHostConfig(env()).publicExchangeUrl).toBe('https://exchange.hydra1.example.com:8444/exchange');
+	});
+
+	it('allows plaintext Exchange Plane URLs only on loopback', () => {
+		expect(
+			loadHostConfig(env({ HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'http://127.0.0.1:8444/exchange' })).publicExchangeUrl,
+		).toBe('http://127.0.0.1:8444/exchange');
+		expect(
+			loadHostConfig(env({ HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'http://[::1]:8444/exchange' })).publicExchangeUrl,
+		).toBe('http://[::1]:8444/exchange');
+	});
+
+	it('rejects public Exchange Plane URLs with credentials or a wrong path', () => {
+		for (const bad of [
+			'https://user:pass@exchange.example.com:8444/exchange',
+			'https://exchange.example.com:8444/',
+			'https://exchange.example.com:8444/exchange?token=secret',
+		]) {
+			expect(() => loadHostConfig(env({ HYDRA_HOST_PUBLIC_EXCHANGE_URL: bad }))).toThrow(ConfigError);
+		}
+	});
+
+	it('trusts proxy client headers only after an explicit opt-in', () => {
+		expect(loadHostConfig(env()).exchangeTrustProxy).toBe(false);
+		expect(loadHostConfig(env({ HYDRA_HOST_EXCHANGE_TRUST_PROXY: 'true' })).exchangeTrustProxy).toBe(true);
 	});
 
 	// The advertise string must be a bare host:port; a scheme or path here would

--- a/packages/hydra-host/src/config.ts
+++ b/packages/hydra-host/src/config.ts
@@ -14,6 +14,10 @@ export type HostConfig = {
 	dataDir: string;
 	hydraNodeBin: string;
 	listenPort: number;
+	/** Public, TLS-backed URL that counterparties use to redeem invites. */
+	publicExchangeUrl: string;
+	/** Trust the last X-Forwarded-For value from the Exchange Plane proxy. */
+	exchangeTrustProxy: boolean;
 	/**
 	 * Port for the counterparty-facing Exchange Plane.
 	 *
@@ -130,6 +134,27 @@ function integer(env: EnvSource, key: string, fallback: number): number {
 
 const HOSTNAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 
+function publicExchangeUrl(env: EnvSource): string {
+	const raw = required(env, 'HYDRA_HOST_PUBLIC_EXCHANGE_URL');
+	let parsed: URL;
+	try {
+		parsed = new URL(raw);
+	} catch {
+		throw new ConfigError('HYDRA_HOST_PUBLIC_EXCHANGE_URL must be an absolute URL');
+	}
+	if (parsed.username.length > 0 || parsed.password.length > 0 || parsed.search.length > 0 || parsed.hash.length > 0) {
+		throw new ConfigError('HYDRA_HOST_PUBLIC_EXCHANGE_URL must not contain credentials, a query, or a fragment');
+	}
+	if (parsed.pathname.replace(/\/+$/, '') !== '/exchange') {
+		throw new ConfigError('HYDRA_HOST_PUBLIC_EXCHANGE_URL must end with /exchange');
+	}
+	const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]';
+	if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLoopback)) {
+		throw new ConfigError('HYDRA_HOST_PUBLIC_EXCHANGE_URL must use HTTPS unless it points to loopback');
+	}
+	return parsed.toString().replace(/\/+$/, '');
+}
+
 export function loadHostConfig(env: EnvSource = processEnv): HostConfig {
 	const publicHost = required(env, 'HYDRA_HOST_PUBLIC_HOST');
 	if (!HOSTNAME_PATTERN.test(publicHost)) {
@@ -187,6 +212,8 @@ export function loadHostConfig(env: EnvSource = processEnv): HostConfig {
 		hydraNodeBin: optional(env, 'HYDRA_NODE_BIN', '/usr/local/bin/hydra-node'),
 		listenPort: tcpPort(env, 'HYDRA_HOST_PORT', 8443),
 		exchangePort: tcpPort(env, 'HYDRA_HOST_EXCHANGE_PORT', 8444),
+		publicExchangeUrl: publicExchangeUrl(env),
+		exchangeTrustProxy: optional(env, 'HYDRA_HOST_EXCHANGE_TRUST_PROXY', 'false') === 'true',
 		publicHost,
 		network,
 		blockfrostProjectFile: optional(env, 'BLOCKFROST_PROJECT_FILE', '/run/secrets/blockfrost.txt'),

--- a/packages/hydra-host/src/index.ts
+++ b/packages/hydra-host/src/index.ts
@@ -190,6 +190,7 @@ async function main(): Promise<void> {
 	const exchangePlane = createExchangePlane({
 		store: exchange,
 		logger,
+		trustProxy: config.exchangeTrustProxy,
 		onRedeemed: async (nonce, hostNodeId) => {
 			const invite = (await exchange.listInvites()).find((candidate) => candidate.nonce === nonce);
 			if (invite?.redeemer == null) {

--- a/packages/hydra-host/src/supervisor/supervisor.spec.ts
+++ b/packages/hydra-host/src/supervisor/supervisor.spec.ts
@@ -32,6 +32,7 @@ const env: EnvSource = {
 	get: (key) =>
 		({
 			HYDRA_HOST_PUBLIC_HOST: 'hydra1.example.com',
+			HYDRA_HOST_PUBLIC_EXCHANGE_URL: 'https://exchange.hydra1.example.com:8444/exchange',
 			HYDRA_HOST_ADMIN_TOKEN: 'a'.repeat(40),
 			HYDRA_HOST_USER_TOKEN: 'u'.repeat(40),
 			HYDRA_HOST_PEER_PORT_COUNT: '4',

--- a/scripts/hydra-e2e/env.mts
+++ b/scripts/hydra-e2e/env.mts
@@ -150,6 +150,7 @@ export function hostEnv(spec: HostSpec): NodeJS.ProcessEnv {
 		HYDRA_HOST_PORT: String(spec.controlPort),
 		HYDRA_HOST_EXCHANGE_PORT: String(spec.exchangePort),
 		HYDRA_HOST_PUBLIC_HOST: PUBLIC_HOST,
+		HYDRA_HOST_PUBLIC_EXCHANGE_URL: `http://127.0.0.1:${spec.exchangePort}/exchange`,
 		HYDRA_HOST_NETWORK: 'preprod',
 		HYDRA_HOST_ADMIN_TOKEN: spec.adminToken,
 		HYDRA_HOST_USER_TOKEN: spec.userToken,

--- a/src/services/hydra-host/client.spec.ts
+++ b/src/services/hydra-host/client.spec.ts
@@ -24,6 +24,7 @@ describe('Hydra Host transport security', () => {
 				JSON.stringify({
 					hydraVersion: '0.20.0',
 					network: 'Preprod',
+					exchangeUrl: 'https://exchange.example.com:8444/exchange',
 					nodeSlots: { used: 0, capacity: 2 },
 				}),
 				{ status: 200, headers: { 'Content-Type': 'application/json' } },
@@ -33,7 +34,28 @@ describe('Hydra Host transport security', () => {
 
 		await expect(
 			fetchHostCapabilities('http://10.0.0.8:4000', 'admin-token', { allowInsecureHttp: true }),
-		).resolves.toMatchObject({ hydraVersion: '0.20.0' });
+		).resolves.toMatchObject({
+			hydraVersion: '0.20.0',
+			exchangeUrl: 'https://exchange.example.com:8444/exchange',
+		});
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects an insecure public Exchange Plane URL reported by the Host', async () => {
+		global.fetch = jest.fn<() => Promise<Response>>().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					hydraVersion: '0.20.0',
+					network: 'Preprod',
+					exchangeUrl: 'http://exchange.example.com:8444/exchange',
+					nodeSlots: { used: 0, capacity: 2 },
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		) as unknown as typeof fetch;
+
+		await expect(
+			fetchHostCapabilities('https://hydra.example.com', 'admin-token', { allowInsecureHttp: false }),
+		).resolves.toMatchObject({ exchangeUrl: null });
 	});
 });

--- a/src/services/hydra-host/client.ts
+++ b/src/services/hydra-host/client.ts
@@ -32,6 +32,8 @@ export type HostCapabilities = {
 	network: string;
 	/** Where this Host serves its Exchange Plane. Null on a Host that predates reporting it. */
 	exchangePort: number | null;
+	/** Public, TLS-backed Exchange Plane URL. */
+	exchangeUrl: string | null;
 	nodeSlots: { used: number; capacity: number };
 	probeError: string | null;
 };
@@ -134,6 +136,31 @@ function requireString(value: unknown, field: string): string {
 	return found;
 }
 
+function validatedPublicExchangeUrl(value: string | undefined): string | null {
+	if (value === undefined) {
+		return null;
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
+		return null;
+	}
+	const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]';
+	const hasAllowedTransport = parsed.protocol === 'https:' || (parsed.protocol === 'http:' && isLoopback);
+	if (
+		!hasAllowedTransport ||
+		parsed.username.length > 0 ||
+		parsed.password.length > 0 ||
+		parsed.search.length > 0 ||
+		parsed.hash.length > 0 ||
+		parsed.pathname.replace(/\/+$/, '') !== '/exchange'
+	) {
+		return null;
+	}
+	return value;
+}
+
 export async function fetchHostCapabilities(
 	baseUrl: string,
 	adminToken: string,
@@ -154,6 +181,7 @@ export async function fetchHostCapabilities(
 		network: getOwnString(body, 'network') ?? '',
 		exchangePort:
 			typeof getOwnValue(body, 'exchangePort') === 'number' ? (getOwnValue(body, 'exchangePort') as number) : null,
+		exchangeUrl: validatedPublicExchangeUrl(getOwnString(body, 'exchangeUrl')),
 		nodeSlots: {
 			used: typeof used === 'number' ? used : 0,
 			capacity: typeof capacity === 'number' ? capacity : 0,

--- a/src/services/hydra-host/placement.spec.ts
+++ b/src/services/hydra-host/placement.spec.ts
@@ -19,6 +19,7 @@ function capabilities(overrides: Partial<HostCapabilities> = {}): HostCapabiliti
 		ledgerParamsHash: 'sha256:abc',
 		network: 'preprod',
 		exchangePort: 8444,
+		exchangeUrl: 'https://exchange.hydra1.example.com:8444/exchange',
 		nodeSlots: { used: 1, capacity: 32 },
 		probeError: null,
 		...overrides,
@@ -111,6 +112,10 @@ describe('assertHostCompatible', () => {
 		expect(() => assertHostCompatible(capabilities({ scriptCatalogueHash: null }), expected)).toThrow(
 			/reports no script catalogue/,
 		);
+	});
+
+	it('refuses a Host that cannot publish a separate Exchange Plane URL', () => {
+		expect(() => assertHostCompatible(capabilities({ exchangeUrl: null }), expected)).toThrow(/public exchange URL/);
 	});
 
 	it('refuses a host reporting no ledger params at all', () => {

--- a/src/services/hydra-host/placement.ts
+++ b/src/services/hydra-host/placement.ts
@@ -92,6 +92,11 @@ export function assertHostCompatible(capabilities: HostCapabilities, expected: E
 			`the hydra host could not describe itself (${capabilities.probeError}); refusing to place a head on it`,
 		);
 	}
+	if (capabilities.exchangeUrl === null) {
+		throw new HostIncompatibleError(
+			'the hydra host reports no public exchange URL. Upgrade the Host before placing another head',
+		);
+	}
 
 	if (capabilities.network !== expected.network) {
 		throw new HostIncompatibleError(

--- a/src/services/hydra-invite/orchestrator.ts
+++ b/src/services/hydra-invite/orchestrator.ts
@@ -89,38 +89,19 @@ async function loadWallet(hotWalletId: string): Promise<WalletContext> {
 }
 
 /**
- * Where our own invites are redeemed.
+ * The Host's own public exchange URL, or a refusal.
  *
- * The host comes from the Host's control-plane URL — same deployment, so the
- * same machine — and the port from what that Host reported about itself when it
- * was connected. Never from a service-wide setting: an invite carries this URL
- * to a counterparty, and with two Hosts a single shared value can only be right
- * for one of them. The other's invites advertise the wrong exchange, the
- * redemption reaches a Host that never issued the nonce, and the counterparty is
- * told 404 for something they did nothing wrong with.
+ * The Control Plane may be private while the Exchange Plane is public, so the
+ * URL cannot be derived from the control URL without breaking that boundary.
  */
-export function exchangeUrlForHost(baseUrl: string, exchangePort: number): string {
-	const url = new URL(baseUrl);
-	url.port = String(exchangePort);
-	url.pathname = '/exchange';
-	url.search = '';
-	return url.toString().replace(/\/+$/, '');
-}
-
-/**
- * The Host's own exchange port, or a refusal.
- *
- * Refusing beats guessing: a wrong port is baked into a signed invite and only
- * fails at the counterparty, minutes later, as a 404 they cannot act on.
- */
-function requireExchangePort(node: { hostExchangePort: number | null; hostBaseUrl: string }): number {
-	if (node.hostExchangePort === null) {
+function requireExchangeUrl(node: { hostExchangeUrl: string | null; hostBaseUrl: string }): string {
+	if (node.hostExchangeUrl === null) {
 		throw createHttpError(
 			409,
-			`the hydra host at ${node.hostBaseUrl} has not reported its exchange port yet. Press Check on the node and try again`,
+			`the hydra host at ${node.hostBaseUrl} has not reported its public exchange URL. Upgrade the Host and press Check`,
 		);
 	}
-	return node.hostExchangePort;
+	return node.hostExchangeUrl;
 }
 
 export type MintedInvite = {
@@ -200,7 +181,7 @@ export async function mintHeadInvite(input: {
 	const expiresAt = new Date(Date.now() + (input.ttlMs ?? INVITE_TTL_MS));
 
 	const node = await reserveNodeForExchange(wallet.network, wallet.id, nonce, periods, input.autoFund !== false);
-	const exchangeUrl = exchangeUrlForHost(node.hostBaseUrl, requireExchangePort(node));
+	const exchangeUrl = requireExchangeUrl(node);
 
 	const payload: HydraHeadInvitePayloadInput = {
 		nonce,
@@ -407,9 +388,7 @@ export async function redeemHeadInvite(input: {
 	if (node.ledgerParamsHash !== payload.ledgerParamsHash) {
 		throw createHttpError(409, 'the selected local Hydra Host does not match the invite ledger protocol parameters');
 	}
-	// The port comes from the Host's own capabilities, never from the caller: a
-	// redeemer that guesses it points the exchange at whatever is listening.
-	const exchangeUrl = exchangeUrlForHost(node.hostBaseUrl, requireExchangePort(node));
+	const exchangeUrl = requireExchangeUrl(node);
 
 	const redemptionPayload = buildHydraRedemptionPayload({
 		nonce: payload.nonce,

--- a/src/services/hydra-invite/provisioning.spec.ts
+++ b/src/services/hydra-invite/provisioning.spec.ts
@@ -37,7 +37,11 @@ jest.unstable_mockModule('@/utils/security/encryption', () => ({
 jest.unstable_mockModule('@/services/hydra-host/client', () => ({
 	HydraHostRequestError: class extends Error {},
 	acknowledgeEscrowOnHost: mockAcknowledge,
-	fetchHostCapabilities: jest.fn(async () => ({ exchangePort: 4600, ledgerParamsHash: 'params-hash' })),
+	fetchHostCapabilities: jest.fn(async () => ({
+		exchangePort: 4600,
+		exchangeUrl: 'https://exchange.example.com:4600/exchange',
+		ledgerParamsHash: 'params-hash',
+	})),
 	hostNodeUrls: () => ({ nodeUrl: 'https://host/node', nodeHttpUrl: 'https://host/node/http' }),
 	provisionNodeOnHost: mockProvision,
 }));
@@ -92,10 +96,11 @@ beforeEach(() => {
 
 describe('reserveNodeForExchange', () => {
 	it('acknowledges escrow on the node it just recorded', async () => {
-		await reserveNodeForExchange(Network.Preprod, 'wallet-1', 'nonce-1', PERIODS);
+		const reserved = await reserveNodeForExchange(Network.Preprod, 'wallet-1', 'nonce-1', PERIODS);
 
 		expect(mockCreate).toHaveBeenCalled();
 		expect(mockAcknowledge).toHaveBeenCalledWith('https://host', 'admin-token', 'node-1', expect.anything());
+		expect(reserved.hostExchangeUrl).toBe('https://exchange.example.com:4600/exchange');
 	});
 
 	// The Host discloses key material exactly once, so a replayed provision

--- a/src/services/hydra-invite/provisioning.ts
+++ b/src/services/hydra-invite/provisioning.ts
@@ -156,8 +156,8 @@ export function assertContestationPeriodAllowed(network: Network, contestationPe
 export type ReservedNode = {
 	hostId: string;
 	hostBaseUrl: string;
-	/** Where this Host redeems invites. From the Host itself, never assumed. */
-	hostExchangePort: number | null;
+	/** Public redemption URL reported by this Host. */
+	hostExchangeUrl: string | null;
 	allowInsecureHttp: boolean;
 	adminToken: string;
 	nodeId: string;
@@ -321,9 +321,7 @@ export async function reserveNodeForExchange(
 	return {
 		hostId: host.id,
 		hostBaseUrl: host.baseUrl,
-		// Read from the capabilities probe above when the row had none, so the
-		// very first invite on a freshly connected Host is already correct.
-		hostExchangePort: host.exchangePort ?? capabilities.exchangePort,
+		hostExchangeUrl: capabilities.exchangeUrl,
 		allowInsecureHttp: host.allowInsecureHttp,
 		adminToken: host.adminToken,
 		nodeId: provisioned.nodeId,


### PR DESCRIPTION
## Summary

- VERIFIED: Tagged Hydra 2.3.0 macOS downloads now require the official SHA-256 digest before extraction.
- VERIFIED: Base Compose binds the Control Plane and Exchange Plane to 127.0.0.1.
- VERIFIED: Hydra Host now reports an explicit public Exchange Plane URL. The payment service validates and signs that exact URL.
- VERIFIED: Trusted proxy client addresses require explicit opt-in. The demo launcher no longer prints DATABASE_URL.

## Verification

- VERIFIED: pnpm run lint completed with zero warnings.
- VERIFIED: Backend and Hydra Host TypeScript checks completed with exit code 0.
- VERIFIED: Focused Jest suites passed 121 tests across 7 suites.
- VERIFIED: Bash syntax checks, Prettier checks, Compose expansion, and git diff checks passed.
- VERIFIED: The pre-push hook completed formatting, Prisma generation, lint, Swagger checks, frontend type generation, and backend plus frontend TypeScript checks.
- VERIFIED: One unrelated supervisor test times out after 5 seconds and leaves a child process open. The same test failed on an untouched origin/dev archive at packages/hydra-host/src/supervisor/supervisor.spec.ts:513.

## Deployment note

- VERIFIED: HYDRA_HOST_PUBLIC_EXCHANGE_URL is now required outside the base Compose default.
- VERIFIED: Production setup needs a TLS Exchange Plane endpoint. Set HYDRA_HOST_EXCHANGE_TRUST_PROXY=true only when the load balancer is the sole network path to backend port 8444.