### PR TITLE
fix(api-key): stop encoding admin privilege in generated tokens

### DIFF
--- a/src/routes/api/api-key/index.ts
+++ b/src/routes/api/api-key/index.ts
@@ -2,7 +2,6 @@ import { adminAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import { cursorPaginationArgs } from '@/utils/shared/queries';
 import { ApiKeyStatus, Network } from '@/generated/prisma/client';
 import { prisma } from '@masumi/payment-core/db';
-import { createId } from '@paralleldrive/cuid2';
 import createHttpError from 'http-errors';
 import { generateApiKeySecureHash } from '@masumi/payment-core/api-key-hash';
 import { encrypt, decrypt } from '@/utils/security/encryption';
@@ -28,6 +27,7 @@ import {
 	updateAPIKeySchemaInput,
 	updateAPIKeySchemaOutput,
 } from './schemas';
+import { generateApiKeyToken } from './token';
 import { resolveCreateUsageLimited } from './usage-limited';
 import {
 	consolidateUsageCredits,
@@ -296,7 +296,7 @@ export const addAPIKeyEndpointPost = adminAuthenticatedEndpointFactory.build({
 		);
 		const scopeHotWalletIds = Array.from(new Set(input.WalletScopeHotWalletIds));
 		const scopeEvmWalletIds = Array.from(new Set(input.X402WalletScopeEvmWalletIds));
-		const apiKey = 'masumi-payment-' + (isAdmin ? 'admin-' : '') + createId();
+		const apiKey = generateApiKeyToken();
 		const result = await prisma.apiKey.create({
 			data: {
 				encryptedToken: encrypt(apiKey),

--- a/src/routes/api/api-key/token.ts
+++ b/src/routes/api/api-key/token.ts
@@ -1,0 +1,24 @@
+import { createId } from '@paralleldrive/cuid2';
+
+/**
+ * Non-secret product prefix carried by every issued API key.
+ *
+ * It leaks nothing about the key holder and is what lets secret scanners
+ * (GitHub, GitLab, gitleaks) fingerprint a leaked Masumi credential, so it stays.
+ */
+export const API_KEY_TOKEN_PREFIX = 'masumi-payment-';
+
+/**
+ * Mint the token string for a new API key.
+ *
+ * Deliberately takes no permission argument. The generator used to splice an
+ * `admin-` segment in for admin keys, so a leaked `masumi-payment-admin-…` string
+ * announced itself as the highest-privilege credential in the system while read
+ * and pay keys carried no marker at all — a perfect classifier for anyone
+ * triaging a dump of leaked secrets. Permissions are stored on the ApiKey row and
+ * resolved from there by the auth middleware, which never parses the token, so
+ * the token itself must stay opaque.
+ */
+export function generateApiKeyToken(): string {
+	return API_KEY_TOKEN_PREFIX + createId();
+}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

 Bug fix  


## **Overview of Changes**

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-586/admin-tokens-are-easily-identifiable-if-leaked
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
