### PR TITLE
fix(frontend): gate test payment tools to Preprod only

### DIFF
--- a/frontend/src/lib/testing/test-payment-tools.ts
+++ b/frontend/src/lib/testing/test-payment-tools.ts
@@ -1,0 +1,9 @@
+import type { NetworkType } from '@/lib/contexts/AppContext';
+
+/**
+ * Developers > Testing and transaction test shortcuts create real on-chain
+ * escrows. Restrict to Preprod so Mainnet operators cannot trigger them by mistake.
+ */
+export function canUseTestPaymentTools(network: NetworkType): boolean {
+  return network === 'Preprod';
+}

--- a/frontend/src/pages/developers.tsx
+++ b/frontend/src/pages/developers.tsx
@@ -12,7 +12,18 @@ import { MockPaymentDialog, MockPurchaseDialog, FullCycleDialog } from '@/compon
 import { InputSchemaValidator } from '@/components/developers/InputSchemaValidator';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { canUseTestPaymentTools } from '@/lib/testing/test-payment-tools';
+import { cn } from '@/lib/utils';
 import { AlertTriangle } from 'lucide-react';
+
+function testToolCardClassName(allowed: boolean) {
+  return cn(
+    'group border rounded-lg p-6 text-left transition-all duration-200',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+    allowed
+      ? 'animate-fade-in-up opacity-0 hover:shadow-md hover:border-primary/30 active:scale-[0.98] cursor-pointer'
+      : 'cursor-not-allowed opacity-45 bg-muted/30 border-muted/70 saturate-50 hover:shadow-none',
+  );
+}
 
 export const getStaticProps: GetStaticProps = async () => {
   return {
@@ -103,8 +114,9 @@ export default function Developers() {
                     type="button"
                     onClick={() => testPaymentsAllowed && setPaymentDialogOpen(true)}
                     disabled={!testPaymentsAllowed}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
-                    style={{ animationDelay: '0ms' }}
+                    aria-disabled={!testPaymentsAllowed}
+                    className={testToolCardClassName(testPaymentsAllowed)}
+                    style={testPaymentsAllowed ? { animationDelay: '0ms' } : undefined}
                   >
                     <div className="flex items-center gap-3 mb-3">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted group-hover:bg-primary/10 transition-colors duration-200">
@@ -121,8 +133,9 @@ export default function Developers() {
                     type="button"
                     onClick={() => testPaymentsAllowed && setPurchaseDialogOpen(true)}
                     disabled={!testPaymentsAllowed}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
-                    style={{ animationDelay: '75ms' }}
+                    aria-disabled={!testPaymentsAllowed}
+                    className={testToolCardClassName(testPaymentsAllowed)}
+                    style={testPaymentsAllowed ? { animationDelay: '75ms' } : undefined}
                   >
                     <div className="flex items-center gap-3 mb-3">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted group-hover:bg-primary/10 transition-colors duration-200">
@@ -139,8 +152,9 @@ export default function Developers() {
                     type="button"
                     onClick={() => testPaymentsAllowed && setFullCycleDialogOpen(true)}
                     disabled={!testPaymentsAllowed}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
-                    style={{ animationDelay: '150ms' }}
+                    aria-disabled={!testPaymentsAllowed}
+                    className={testToolCardClassName(testPaymentsAllowed)}
+                    style={testPaymentsAllowed ? { animationDelay: '150ms' } : undefined}
                   >
                     <div className="flex items-center gap-3 mb-3">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-muted group-hover:bg-primary/10 transition-colors duration-200">

--- a/frontend/src/pages/developers.tsx
+++ b/frontend/src/pages/developers.tsx
@@ -11,6 +11,8 @@ import { GetStaticProps } from 'next';
 import { MockPaymentDialog, MockPurchaseDialog, FullCycleDialog } from '@/components/testing';
 import { InputSchemaValidator } from '@/components/developers/InputSchemaValidator';
 import { useAppContext } from '@/lib/contexts/AppContext';
+import { canUseTestPaymentTools } from '@/lib/testing/test-payment-tools';
+import { AlertTriangle } from 'lucide-react';
 
 export const getStaticProps: GetStaticProps = async () => {
   return {
@@ -26,7 +28,8 @@ const PAY_ONLY_TABS = ['Testing'];
 const TABS = [{ name: 'Testing' }, { name: 'Schema Validator' }, { name: 'OpenAPI' }];
 
 export default function Developers() {
-  const { capabilities } = useAppContext();
+  const { capabilities, network } = useAppContext();
+  const testPaymentsAllowed = capabilities.canPay && canUseTestPaymentTools(network);
   const tabs = capabilities.canPay ? TABS : TABS.filter((tab) => !PAY_ONLY_TABS.includes(tab.name));
   const [activeTab, setActiveTab] = useState(tabs[0].name);
   const [isIframeLoaded, setIsIframeLoaded] = useState(false);
@@ -86,11 +89,21 @@ export default function Developers() {
 
             {activeTab === 'Testing' && capabilities.canPay && (
               <div className="space-y-6 animate-fade-in-up opacity-0">
+                {!testPaymentsAllowed && (
+                  <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <p>
+                      Test payment tools are only available on Preprod. Switch the network selector
+                      to Preprod to create test payments or purchases.
+                    </p>
+                  </div>
+                )}
                 <div className="grid gap-4 md:grid-cols-3">
                   <button
                     type="button"
-                    onClick={() => setPaymentDialogOpen(true)}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0"
+                    onClick={() => testPaymentsAllowed && setPaymentDialogOpen(true)}
+                    disabled={!testPaymentsAllowed}
+                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
                     style={{ animationDelay: '0ms' }}
                   >
                     <div className="flex items-center gap-3 mb-3">
@@ -106,8 +119,9 @@ export default function Developers() {
 
                   <button
                     type="button"
-                    onClick={() => setPurchaseDialogOpen(true)}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0"
+                    onClick={() => testPaymentsAllowed && setPurchaseDialogOpen(true)}
+                    disabled={!testPaymentsAllowed}
+                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
                     style={{ animationDelay: '75ms' }}
                   >
                     <div className="flex items-center gap-3 mb-3">
@@ -123,8 +137,9 @@ export default function Developers() {
 
                   <button
                     type="button"
-                    onClick={() => setFullCycleDialogOpen(true)}
-                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0"
+                    onClick={() => testPaymentsAllowed && setFullCycleDialogOpen(true)}
+                    disabled={!testPaymentsAllowed}
+                    className="group border rounded-lg p-6 text-left transition-all duration-200 hover:shadow-md hover:border-primary/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] animate-fade-in-up opacity-0 disabled:opacity-50 disabled:pointer-events-none disabled:hover:shadow-none"
                     style={{ animationDelay: '150ms' }}
                   >
                     <div className="flex items-center gap-3 mb-3">
@@ -179,17 +194,17 @@ export default function Developers() {
       </MainLayout>
 
       <MockPaymentDialog
-        open={capabilities.canPay && isPaymentDialogOpen}
+        open={testPaymentsAllowed && isPaymentDialogOpen}
         onClose={() => setPaymentDialogOpen(false)}
       />
 
       <MockPurchaseDialog
-        open={capabilities.canPay && isPurchaseDialogOpen}
+        open={testPaymentsAllowed && isPurchaseDialogOpen}
         onClose={() => setPurchaseDialogOpen(false)}
       />
 
       <FullCycleDialog
-        open={capabilities.canPay && isFullCycleDialogOpen}
+        open={testPaymentsAllowed && isFullCycleDialogOpen}
         onClose={() => setFullCycleDialogOpen(false)}
       />
     </>

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -41,6 +41,7 @@ import { buildTransactionReportViewDefaults } from '@/components/transactions/do
 import { useBulkClearTransactionErrors } from '@/lib/hooks/useBulkClearTransactionErrors';
 import { toast } from 'react-toastify';
 import { useResync } from '@/lib/hooks/useResync';
+import { canUseTestPaymentTools } from '@/lib/testing/test-payment-tools';
 
 type Transaction = ReturnType<typeof useTransactions>['transactions'][number];
 
@@ -66,6 +67,7 @@ const getHydraHeadId = (transaction: Transaction) =>
 
 export default function Transactions() {
   const { apiClient, selectedPaymentSourceId, network, capabilities } = useAppContext();
+  const testPaymentsAllowed = capabilities.canPay && canUseTestPaymentTools(network);
   const resync = useResync();
 
   const [activeTab, setActiveTab] = useState('All');
@@ -397,7 +399,7 @@ export default function Transactions() {
               {/* Developers > Testing creates real payments/purchases via
                   pay-authenticated endpoints, and the tab is hidden for
                   read-only keys, so this shortcut would dead-end. */}
-              {capabilities.canPay && (
+              {testPaymentsAllowed && (
                 <Link href="/developers">
                   <Button className="flex items-center gap-2 btn-hover-lift">
                     <FlaskConical className="h-4 w-4" />
@@ -540,7 +542,7 @@ export default function Transactions() {
                             : 'Transactions will appear here once payments are made.'
                         }
                         action={
-                          !searchQuery && capabilities.canPay ? (
+                          !searchQuery && testPaymentsAllowed ? (
                             <Link
                               href="/developers"
                               className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
- Test Payment / Test Purchase / Full Cycle dialogs only open on Preprod. 
- Transactions "Test transaction" button hidden on Mainnet. 
- Transactions empty-state "Create a test transaction" link hidden on Mainnet. 
- Gated cards skip fade-in animation so disabled styling actually shows. Gated cards use reduced opacity, muted background, desaturated look, and cursor-not-allowed.
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
