### PR TITLE
fix(frontend): sanitize test payment curl examples and response status

### DIFF
--- a/frontend/src/components/testing/CurlResponseViewer.tsx
+++ b/frontend/src/components/testing/CurlResponseViewer.tsx
@@ -9,9 +9,22 @@ interface CurlResponseViewerProps {
   curlCommand?: string;
   response?: object | null;
   error?: string | null;
+  responseStatus?: number | null;
 }
 
-export function CurlResponseViewer({ curlCommand, response, error }: CurlResponseViewerProps) {
+function formatResponseStatusBadge(status: number): string {
+  if (status >= 200 && status < 300) {
+    return `${status} OK`;
+  }
+  return String(status);
+}
+
+export function CurlResponseViewer({
+  curlCommand,
+  response,
+  error,
+  responseStatus,
+}: CurlResponseViewerProps) {
   const [curlExpanded, setCurlExpanded] = useState(false);
 
   const hasCurl = curlCommand && curlCommand.length > 0;
@@ -68,13 +81,13 @@ export function CurlResponseViewer({ curlCommand, response, error }: CurlRespons
               <span className="text-xs font-medium text-muted-foreground">Response</span>
               {hasError ? (
                 <Badge variant="destructive" className="text-[10px] px-1.5 py-0">
-                  Error
+                  {responseStatus != null ? formatResponseStatusBadge(responseStatus) : 'Error'}
                 </Badge>
-              ) : (
+              ) : responseStatus != null ? (
                 <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                  200 OK
+                  {formatResponseStatusBadge(responseStatus)}
                 </Badge>
-              )}
+              ) : null}
             </div>
             {hasResponse && !hasError && <CopyButton value={JSON.stringify(response, null, 2)} />}
           </div>

--- a/frontend/src/components/testing/FullCycleDialog.tsx
+++ b/frontend/src/components/testing/FullCycleDialog.tsx
@@ -21,6 +21,7 @@ import {
   generatePaymentCurl,
   generatePurchaseCurl,
   extractErrorMessage,
+  getClientResponseStatus,
 } from './utils';
 import {
   PaymentFormFields,
@@ -40,7 +41,7 @@ interface FullCycleDialogProps {
 }
 
 export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
-  const { apiClient, network, apiKey, selectedPaymentSource } = useAppContext();
+  const { apiClient, network, selectedPaymentSource } = useAppContext();
   const resync = useResync();
   const {
     agents,
@@ -64,6 +65,8 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
 
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [purchaseError, setPurchaseError] = useState<string | null>(null);
+  const [paymentResponseStatus, setPaymentResponseStatus] = useState<number | null>(null);
+  const [purchaseResponseStatus, setPurchaseResponseStatus] = useState<number | null>(null);
 
   const {
     register,
@@ -104,6 +107,8 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
       setPurchaseResponse(null);
       setPaymentError(null);
       setPurchaseError(null);
+      setPaymentResponseStatus(null);
+      setPurchaseResponseStatus(null);
       setPaymentCurl('');
       setPurchaseCurl('');
     }
@@ -152,7 +157,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         };
 
         const baseUrl = process.env.NEXT_PUBLIC_PAYMENT_API_BASE_URL || '';
-        const curl = generatePurchaseCurl(baseUrl, apiKey || '', requestBody);
+        const curl = generatePurchaseCurl(baseUrl, requestBody);
         setPurchaseCurl(curl);
 
         const result = await postPurchase({
@@ -161,8 +166,11 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         });
 
         if (result.error) {
+          setPurchaseResponseStatus(getClientResponseStatus(result) ?? null);
           throw new Error(extractErrorMessage(result.error, 'Purchase creation failed'));
         }
+
+        setPurchaseResponseStatus(getClientResponseStatus(result) ?? 200);
 
         if (result.data?.data) {
           setPurchaseResponse(result.data.data);
@@ -181,7 +189,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         setIsLoadingPurchase(false);
       }
     },
-    [apiClient, apiKey, network, paidAgents, resync],
+    [apiClient, network, paidAgents, resync],
   );
 
   const onSubmitPayment = useCallback(
@@ -243,7 +251,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         };
 
         const baseUrl = process.env.NEXT_PUBLIC_PAYMENT_API_BASE_URL || '';
-        const curl = generatePaymentCurl(baseUrl, apiKey || '', requestBody);
+        const curl = generatePaymentCurl(baseUrl, requestBody);
         setPaymentCurl(curl);
 
         const result = await postPayment({
@@ -252,8 +260,11 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         });
 
         if (result.error) {
+          setPaymentResponseStatus(getClientResponseStatus(result) ?? null);
           throw new Error(extractErrorMessage(result.error, 'Payment creation failed'));
         }
+
+        setPaymentResponseStatus(getClientResponseStatus(result) ?? 200);
 
         if (result.data?.data) {
           const payment = result.data.data;
@@ -273,7 +284,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
         setIsLoadingPayment(false);
       }
     },
-    [apiClient, apiKey, network, paidAgents, createPurchaseAutomatically, resync],
+    [apiClient, network, paidAgents, createPurchaseAutomatically, resync],
   );
 
   const handleClose = () => {
@@ -284,6 +295,8 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
     setPurchaseResponse(null);
     setPaymentError(null);
     setPurchaseError(null);
+    setPaymentResponseStatus(null);
+    setPurchaseResponseStatus(null);
     setPaymentCurl('');
     setPurchaseCurl('');
     onClose();
@@ -393,6 +406,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
                   curlCommand={paymentCurl}
                   response={paymentResponse}
                   error={paymentError}
+                  responseStatus={paymentResponseStatus}
                 />
               </div>
 
@@ -415,6 +429,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
                     curlCommand={purchaseCurl}
                     response={purchaseResponse}
                     error={purchaseError}
+                    responseStatus={purchaseResponseStatus}
                   />
                 </div>
               )}

--- a/frontend/src/components/testing/FullCycleDialog.tsx
+++ b/frontend/src/components/testing/FullCycleDialog.tsx
@@ -119,6 +119,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
       try {
         setIsLoadingPurchase(true);
         setPurchaseError(null);
+        setPurchaseResponseStatus(null);
         setStep(2);
 
         // Always pass amounts — backend validates Fixed matches, Dynamic requires them
@@ -197,6 +198,7 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
       try {
         setIsLoadingPayment(true);
         setPaymentError(null);
+        setPaymentResponseStatus(null);
 
         const times = calculateDefaultTimes();
         const selectedAgent = paidAgents.find((option) => option.optionId === data.paymentOptionId);

--- a/frontend/src/components/testing/MockPaymentDialog.tsx
+++ b/frontend/src/components/testing/MockPaymentDialog.tsx
@@ -15,6 +15,7 @@ import {
   calculateDefaultTimes,
   generatePaymentCurl,
   extractErrorMessage,
+  getClientResponseStatus,
 } from './utils';
 import {
   PaymentFormFields,
@@ -31,7 +32,7 @@ interface MockPaymentDialogProps {
 }
 
 export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
-  const { apiClient, network, apiKey, selectedPaymentSource } = useAppContext();
+  const { apiClient, network, selectedPaymentSource } = useAppContext();
   const resync = useResync();
   const {
     agents,
@@ -44,6 +45,7 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [curlCommand, setCurlCommand] = useState<string>('');
   const [response, setResponse] = useState<PostPaymentResponse['data'] | null>(null);
+  const [responseStatus, setResponseStatus] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const {
@@ -81,6 +83,7 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
       setValue('paymentOptionId', '');
       setValue('identifierFromPurchaser', generateRandomHex(16));
       setResponse(null);
+      setResponseStatus(null);
       setError(null);
       setCurlCommand('');
     }
@@ -141,7 +144,7 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
         };
 
         const baseUrl = process.env.NEXT_PUBLIC_PAYMENT_API_BASE_URL || '';
-        const curl = generatePaymentCurl(baseUrl, apiKey || '', requestBody);
+        const curl = generatePaymentCurl(baseUrl, requestBody);
         setCurlCommand(curl);
 
         const result = await postPayment({
@@ -150,8 +153,11 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
         });
 
         if (result.error) {
+          setResponseStatus(getClientResponseStatus(result) ?? null);
           throw new Error(extractErrorMessage(result.error, 'Payment creation failed'));
         }
+
+        setResponseStatus(getClientResponseStatus(result) ?? 200);
 
         if (result.data?.data) {
           setResponse(result.data.data);
@@ -170,13 +176,14 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
         setIsLoading(false);
       }
     },
-    [apiClient, apiKey, network, paidAgents, resync],
+    [apiClient, network, paidAgents, resync],
   );
 
   const handleClose = () => {
     reset();
     resetInputData(false);
     setResponse(null);
+    setResponseStatus(null);
     setError(null);
     setCurlCommand('');
     onClose();
@@ -233,7 +240,12 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
         </div>
 
         <div className="shrink-0">
-          <CurlResponseViewer curlCommand={curlCommand} response={response} error={error} />
+          <CurlResponseViewer
+            curlCommand={curlCommand}
+            response={response}
+            error={error}
+            responseStatus={responseStatus}
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/components/testing/MockPaymentDialog.tsx
+++ b/frontend/src/components/testing/MockPaymentDialog.tsx
@@ -94,6 +94,7 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
       try {
         setIsLoading(true);
         setError(null);
+        setResponseStatus(null);
 
         const times = calculateDefaultTimes();
         const selectedAgent = paidAgents.find((option) => option.optionId === data.paymentOptionId);

--- a/frontend/src/components/testing/MockPurchaseDialog.tsx
+++ b/frontend/src/components/testing/MockPurchaseDialog.tsx
@@ -26,7 +26,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Spinner } from '@/components/ui/spinner';
 import { CurlResponseViewer } from './CurlResponseViewer';
-import { generatePurchaseCurl, decodeBlockchainIdentifier, extractErrorMessage } from './utils';
+import { generatePurchaseCurl, decodeBlockchainIdentifier, extractErrorMessage, getClientResponseStatus } from './utils';
 import { Search, ClipboardPaste, Wallet } from 'lucide-react';
 import { WalletDetailsDialog, WalletWithBalance } from '@/components/wallets/WalletDetailsDialog';
 import { useWallets } from '@/lib/queries/useWallets';
@@ -163,7 +163,7 @@ function tryExtractPaymentFields(json: string): ExtractedPaymentFields | null {
 }
 
 export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
-  const { apiClient, network, apiKey, selectedPaymentSource } = useAppContext();
+  const { apiClient, network, selectedPaymentSource } = useAppContext();
   const resync = useResync();
   // Both deferred until the dialog is open. `useAllAgents` walks every
   // inclusive-cursor page before it publishes anything, so running it on a
@@ -193,6 +193,7 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
   const [pasteError, setPasteError] = useState<string | null>(null);
   const [curlCommand, setCurlCommand] = useState<string>('');
   const [response, setResponse] = useState<PostPurchaseResponse['data'] | null>(null);
+  const [responseStatus, setResponseStatus] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedBuyerWalletId, setSelectedBuyerWalletId] = useState<string>('');
   const [selectedWalletForDetails, setSelectedWalletForDetails] =
@@ -435,7 +436,7 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
         };
 
         const baseUrl = process.env.NEXT_PUBLIC_PAYMENT_API_BASE_URL || '';
-        const curl = generatePurchaseCurl(baseUrl, apiKey || '', requestBody);
+        const curl = generatePurchaseCurl(baseUrl, requestBody);
         setCurlCommand(curl);
 
         const result = await postPurchase({
@@ -444,8 +445,11 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
         });
 
         if (result.error) {
+          setResponseStatus(getClientResponseStatus(result) ?? null);
           throw new Error(extractErrorMessage(result.error, 'Purchase creation failed'));
         }
+
+        setResponseStatus(getClientResponseStatus(result) ?? 200);
 
         if (result.data?.data) {
           setResponse(result.data.data);
@@ -467,7 +471,6 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
     [
       resync,
       apiClient,
-      apiKey,
       network,
       extractedAmounts,
       paymentForceLayer,
@@ -488,6 +491,7 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
     setSupportedPaymentSourceIndex(null);
     setBuyerForceLayer('Auto');
     setResponse(null);
+    setResponseStatus(null);
     setError(null);
     setCurlCommand('');
     onClose();
@@ -830,7 +834,12 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
           </div>
 
           <div className="shrink-0">
-            <CurlResponseViewer curlCommand={curlCommand} response={response} error={error} />
+            <CurlResponseViewer
+              curlCommand={curlCommand}
+              response={response}
+              error={error}
+              responseStatus={responseStatus}
+            />
           </div>
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/testing/MockPurchaseDialog.tsx
+++ b/frontend/src/components/testing/MockPurchaseDialog.tsx
@@ -417,6 +417,7 @@ export function MockPurchaseDialog({ open, onClose }: MockPurchaseDialogProps) {
       try {
         setIsLoading(true);
         setError(null);
+        setResponseStatus(null);
 
         const requestBody = {
           blockchainIdentifier: data.blockchainIdentifier,

--- a/frontend/src/components/testing/MockPurchaseDialog.tsx
+++ b/frontend/src/components/testing/MockPurchaseDialog.tsx
@@ -26,7 +26,12 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Spinner } from '@/components/ui/spinner';
 import { CurlResponseViewer } from './CurlResponseViewer';
-import { generatePurchaseCurl, decodeBlockchainIdentifier, extractErrorMessage, getClientResponseStatus } from './utils';
+import {
+  generatePurchaseCurl,
+  decodeBlockchainIdentifier,
+  extractErrorMessage,
+  getClientResponseStatus,
+} from './utils';
 import { Search, ClipboardPaste, Wallet } from 'lucide-react';
 import { WalletDetailsDialog, WalletWithBalance } from '@/components/wallets/WalletDetailsDialog';
 import { useWallets } from '@/lib/queries/useWallets';

--- a/frontend/src/components/testing/utils.ts
+++ b/frontend/src/components/testing/utils.ts
@@ -114,10 +114,16 @@ function buildCurlEndpointUrl(baseUrl: string, resource: 'payment' | 'purchase')
 /** HTTP status from a generated-client result (success or axios error). */
 export function getClientResponseStatus(result: unknown): number | undefined {
   if (!isObject(result)) return undefined;
+
+  // Success: hey-api spreads AxiosResponse onto the result.
+  const topLevelStatus = getOwnValue(result, 'status');
+  if (typeof topLevelStatus === 'number') return topLevelStatus;
+
+  // Error: axios error shape stores status on nested response.
   const response = getOwnValue(result, 'response');
   if (!isObject(response)) return undefined;
-  const status = getOwnValue(response, 'status');
-  return typeof status === 'number' ? status : undefined;
+  const nestedStatus = getOwnValue(response, 'status');
+  return typeof nestedStatus === 'number' ? nestedStatus : undefined;
 }
 
 // Escape a value for embedding inside single quotes in a POSIX shell command:

--- a/frontend/src/components/testing/utils.ts
+++ b/frontend/src/components/testing/utils.ts
@@ -88,7 +88,9 @@ export function calculateDefaultTimes() {
   return { payByTime, submitResultTime, unlockTime, externalDisputeUnlockTime };
 }
 
-// Get proper base URL for curl examples shown in the UI.
+const CURL_API_V1_SUFFIX = '/api/v1';
+
+// Root URL for curl examples shown in the UI (may already include /api/v1).
 function resolveCurlBaseUrl(baseUrl: string): string {
   if (baseUrl && baseUrl.startsWith('http')) {
     return baseUrl;
@@ -98,6 +100,15 @@ function resolveCurlBaseUrl(baseUrl: string): string {
     return configured;
   }
   return CURL_BASE_URL_PLACEHOLDER;
+}
+
+function buildCurlEndpointUrl(baseUrl: string, resource: 'payment' | 'purchase'): string {
+  const root = resolveCurlBaseUrl(baseUrl).replace(/\/+$/, '');
+  const resourcePath = `/${resource}/`;
+  if (root.endsWith(CURL_API_V1_SUFFIX)) {
+    return `${root}${resourcePath}`;
+  }
+  return `${root}${CURL_API_V1_SUFFIX}${resourcePath}`;
 }
 
 /** HTTP status from a generated-client result (success or axios error). */
@@ -117,16 +128,16 @@ function escapeShellSingleQuotes(value: string): string {
 
 // Generate curl command for payment (display/copy only; never embeds a live API key).
 export function generatePaymentCurl(baseUrl: string, body: object): string {
-  const url = resolveCurlBaseUrl(baseUrl);
-  return `curl -X POST "${url}/api/v1/payment/" \\
+  const url = buildCurlEndpointUrl(baseUrl, 'payment');
+  return `curl -X POST "${url}" \\
   -H "Content-Type: application/json" \\
   -H "token: ${CURL_API_KEY_PLACEHOLDER}" \\
   -d '${escapeShellSingleQuotes(JSON.stringify(body, null, 2))}'`;
 }
 
 export function generatePurchaseCurl(baseUrl: string, body: object): string {
-  const url = resolveCurlBaseUrl(baseUrl);
-  return `curl -X POST "${url}/api/v1/purchase/" \\
+  const url = buildCurlEndpointUrl(baseUrl, 'purchase');
+  return `curl -X POST "${url}" \\
   -H "Content-Type: application/json" \\
   -H "token: ${CURL_API_KEY_PLACEHOLDER}" \\
   -d '${escapeShellSingleQuotes(JSON.stringify(body, null, 2))}'`;

--- a/frontend/src/components/testing/utils.ts
+++ b/frontend/src/components/testing/utils.ts
@@ -2,6 +2,9 @@ import LZString from 'lz-string';
 import stringify from 'canonical-json';
 import { getOwnPlainObject, getOwnString, getOwnValue, isObject } from '@/lib/object-properties';
 
+export const CURL_API_KEY_PLACEHOLDER = '<your-api-key>';
+const CURL_BASE_URL_PLACEHOLDER = '<payment-api-base-url>';
+
 type CanonicalJsonPrimitive = string | number | boolean | null;
 export type CanonicalJsonValue =
   | CanonicalJsonPrimitive
@@ -85,13 +88,25 @@ export function calculateDefaultTimes() {
   return { payByTime, submitResultTime, unlockTime, externalDisputeUnlockTime };
 }
 
-// Get proper base URL with fallback
-function getBaseUrl(baseUrl: string): string {
-  // Check if baseUrl is valid (not empty and starts with http)
+// Get proper base URL for curl examples shown in the UI.
+function resolveCurlBaseUrl(baseUrl: string): string {
   if (baseUrl && baseUrl.startsWith('http')) {
     return baseUrl;
   }
-  return 'http://localhost:3001';
+  const configured = process.env.NEXT_PUBLIC_PAYMENT_API_BASE_URL;
+  if (configured && configured.startsWith('http')) {
+    return configured;
+  }
+  return CURL_BASE_URL_PLACEHOLDER;
+}
+
+/** HTTP status from a generated-client result (success or axios error). */
+export function getClientResponseStatus(result: unknown): number | undefined {
+  if (!isObject(result)) return undefined;
+  const response = getOwnValue(result, 'response');
+  if (!isObject(response)) return undefined;
+  const status = getOwnValue(response, 'status');
+  return typeof status === 'number' ? status : undefined;
 }
 
 // Escape a value for embedding inside single quotes in a POSIX shell command:
@@ -100,21 +115,20 @@ function escapeShellSingleQuotes(value: string): string {
   return value.replace(/'/g, "'\\''");
 }
 
-// Generate curl command for payment
-// Note: Payment API accepts dates as ISO strings
-export function generatePaymentCurl(baseUrl: string, apiKey: string, body: object): string {
-  const url = getBaseUrl(baseUrl);
+// Generate curl command for payment (display/copy only; never embeds a live API key).
+export function generatePaymentCurl(baseUrl: string, body: object): string {
+  const url = resolveCurlBaseUrl(baseUrl);
   return `curl -X POST "${url}/api/v1/payment/" \\
   -H "Content-Type: application/json" \\
-  -H "token: ${apiKey}" \\
+  -H "token: ${CURL_API_KEY_PLACEHOLDER}" \\
   -d '${escapeShellSingleQuotes(JSON.stringify(body, null, 2))}'`;
 }
 
-export function generatePurchaseCurl(baseUrl: string, apiKey: string, body: object): string {
-  const url = getBaseUrl(baseUrl);
+export function generatePurchaseCurl(baseUrl: string, body: object): string {
+  const url = resolveCurlBaseUrl(baseUrl);
   return `curl -X POST "${url}/api/v1/purchase/" \\
   -H "Content-Type: application/json" \\
-  -H "token: ${apiKey}" \\
+  -H "token: ${CURL_API_KEY_PLACEHOLDER}" \\
   -d '${escapeShellSingleQuotes(JSON.stringify(body, null, 2))}'`;
 }
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
- Curl snippets use `<your-api-key>` instead of the live session token.
- Curl base URL uses the configured API URL, not a hardcoded `localhost:3001` fallback.
- Fixed duplicate `/api/v1` when the env base already includes `/api/v1`.
- Response viewer shows the actual HTTP status instead of always `200 OK`.
- Error responses display the real status code in the badge.
- `getClientResponseStatus()` reads status from generated-client results.
- Mock Payment, Purchase, and Full Cycle dialogs pass status into the response viewer.
- Removed live API key from curl generation call sites.
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
