### PR TITLE
fix(frontend): confirm before recovery phrase downloads

### DIFF
--- a/frontend/src/components/setup/screens/SeedPhrasesScreen.tsx
+++ b/frontend/src/components/setup/screens/SeedPhrasesScreen.tsx
@@ -20,6 +20,8 @@ import {
 import { cn, shortenAddress } from '@/lib/utils';
 import { useWalletGeneration } from '@/lib/hooks/useWalletGeneration';
 import { copyToClipboard, type SetupWallet } from '@/components/setup/setup-helpers';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION } from '@/lib/wallet-recovery-download';
 
 export function SeedPhrasesScreen({
   onNext,
@@ -37,6 +39,21 @@ export function SeedPhrasesScreen({
   // may want to reveal one and not the other.
   const [showBuyingMnemonic, setShowBuyingMnemonic] = useState(false);
   const [showSellingMnemonic, setShowSellingMnemonic] = useState(false);
+  const [pendingDownload, setPendingDownload] = useState<'buying' | 'selling' | null>(null);
+
+  const performSeedDownload = () => {
+    const wallet = pendingDownload === 'buying' ? buyingWallet : sellingWallet;
+    if (!wallet) return;
+    const blob = new Blob([wallet.mnemonic], { type: 'text/plain' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download =
+      pendingDownload === 'buying' ? 'buying-wallet-seed.txt' : 'selling-wallet-seed.txt';
+    a.click();
+    window.URL.revokeObjectURL(url);
+    setPendingDownload(null);
+  };
 
   return (
     <div className="space-y-6 w-full max-w-2xl">
@@ -178,25 +195,7 @@ export function SeedPhrasesScreen({
                         variant="outline"
                         size="sm"
                         className="gap-1.5 flex-1"
-                        onClick={() => {
-                          // Explicit consent before writing a plaintext
-                          // seed phrase to disk — the file persists with
-                          // no encryption and survives until the user
-                          // shreds it.
-                          const ok = window.confirm(
-                            'This downloads your seed phrase as an unencrypted .txt file. Anyone with access to the file can spend your funds. Continue?',
-                          );
-                          if (!ok) return;
-                          const blob = new Blob([buyingWallet.mnemonic], {
-                            type: 'text/plain',
-                          });
-                          const url = window.URL.createObjectURL(blob);
-                          const a = document.createElement('a');
-                          a.href = url;
-                          a.download = 'buying-wallet-seed.txt';
-                          a.click();
-                          window.URL.revokeObjectURL(url);
-                        }}
+                        onClick={() => setPendingDownload('buying')}
                       >
                         <Download className="h-3.5 w-3.5" /> Download
                       </Button>
@@ -309,24 +308,7 @@ export function SeedPhrasesScreen({
                         variant="outline"
                         size="sm"
                         className="gap-1.5 flex-1"
-                        onClick={() => {
-                          // Explicit consent before writing a plaintext
-                          // seed phrase to disk — see buying-wallet block
-                          // for full rationale.
-                          const ok = window.confirm(
-                            'This downloads your seed phrase as an unencrypted .txt file. Anyone with access to the file can spend your funds. Continue?',
-                          );
-                          if (!ok) return;
-                          const blob = new Blob([sellingWallet.mnemonic], {
-                            type: 'text/plain',
-                          });
-                          const url = window.URL.createObjectURL(blob);
-                          const a = document.createElement('a');
-                          a.href = url;
-                          a.download = 'selling-wallet-seed.txt';
-                          a.click();
-                          window.URL.revokeObjectURL(url);
-                        }}
+                        onClick={() => setPendingDownload('selling')}
                       >
                         <Download className="h-3.5 w-3.5" /> Download
                       </Button>
@@ -393,6 +375,15 @@ export function SeedPhrasesScreen({
           </div>
         </CardContent>
       </Card>
+
+      <ConfirmDialog
+        open={pendingDownload != null}
+        onClose={() => setPendingDownload(null)}
+        title="Download recovery phrase file?"
+        description={RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION}
+        onConfirm={performSeedDownload}
+        confirmLabel="Download"
+      />
     </div>
   );
 }

--- a/frontend/src/components/wallets/AddWalletDialog.tsx
+++ b/frontend/src/components/wallets/AddWalletDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { Eye, EyeOff } from 'lucide-react';
+import { Download, Eye, EyeOff } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { patchPaymentSourceExtended, postWallet } from '@/lib/api/generated';
@@ -48,6 +48,8 @@ import {
   sortPaymentSourcesByPreference,
 } from '@/lib/payment-source-type';
 import { invalidateTransactionReportFacets } from '@/lib/queries/transaction-report-cache';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION } from '@/lib/wallet-recovery-download';
 
 interface AddWalletDialogProps {
   open: boolean;
@@ -83,11 +85,14 @@ export function AddWalletDialog({ open, onClose, onSuccess, defaultType }: AddWa
   const [paymentSourceId, setPaymentSourceId] = useState<string | null>(null);
   const { apiClient, network, selectedPaymentSourceId } = useAppContext();
 
+  const [confirmMnemonicDownloadOpen, setConfirmMnemonicDownloadOpen] = useState(false);
+
   const {
     register,
     handleSubmit,
     setValue,
     reset,
+    watch,
     formState: { errors },
   } = useForm<WalletFormValues>({
     resolver: zodResolver(walletSchema),
@@ -129,6 +134,7 @@ export function AddWalletDialog({ open, onClose, onSuccess, defaultType }: AddWa
       setError('');
       setIsPreparing(false);
       setPaymentSourceId(null);
+      setConfirmMnemonicDownloadOpen(false);
     }
   }, [defaultPaymentSource?.id, open, reset, defaultType]);
 
@@ -265,156 +271,196 @@ export function AddWalletDialog({ open, onClose, onSuccess, defaultType }: AddWa
   };
 
   const walletTypeLabel = getWalletTypeLabel(type).toLowerCase();
+  const mnemonic = watch('mnemonic').trim();
+
+  const performMnemonicDownload = () => {
+    if (!mnemonic) return;
+    const blob = new Blob([mnemonic], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${walletTypeLabel.replace(/\s+/g, '-')}-wallet-seed.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setConfirmMnemonicDownloadOpen(false);
+  };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent size="lg">
-        <DialogHeader>
-          <DialogTitle>Add wallet</DialogTitle>
-          <DialogDescription>
-            Create a {walletTypeLabel} wallet for {network}. The required setup changes with the
-            wallet&apos;s role.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onClose}>
+        <DialogContent size="lg" isPushedBack={confirmMnemonicDownloadOpen}>
+          <DialogHeader>
+            <DialogTitle>Add wallet</DialogTitle>
+            <DialogDescription>
+              Create a {walletTypeLabel} wallet for {network}. The required setup changes with the
+              wallet&apos;s role.
+            </DialogDescription>
+          </DialogHeader>
 
-        <WalletTypeSelector value={type} onChange={setType} disabled={isLoading} />
+          <WalletTypeSelector value={type} onChange={setType} disabled={isLoading} />
 
-        <div className="space-y-2">
-          <label className="text-sm font-medium">Payment source</label>
-          <Select
-            value={paymentSourceId ?? ''}
-            onValueChange={setPaymentSourceId}
-            disabled={isLoading || sortedPaymentSources.length === 0}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select payment source" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                {sortedPaymentSources.map((paymentSource) => (
-                  <SelectItem key={paymentSource.id} value={paymentSource.id}>
-                    <div className="flex min-w-0 items-center gap-2">
-                      <PaymentSourceTypeBadge
-                        paymentSourceType={paymentSource.paymentSourceType}
-                        showDefault
-                      />
-                      <span className="truncate">
-                        {shortenAddress(paymentSource.smartContractAddress, 8)}
-                      </span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            {selectedPaymentSource
-              ? `This wallet belongs to ${getPaymentSourceTypeLabel(selectedPaymentSource.paymentSourceType)} on ${network}.`
-              : 'Create a payment source before adding wallets.'}
-          </p>
-        </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Payment source</label>
+            <Select
+              value={paymentSourceId ?? ''}
+              onValueChange={setPaymentSourceId}
+              disabled={isLoading || sortedPaymentSources.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select payment source" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {sortedPaymentSources.map((paymentSource) => (
+                    <SelectItem key={paymentSource.id} value={paymentSource.id}>
+                      <div className="flex min-w-0 items-center gap-2">
+                        <PaymentSourceTypeBadge
+                          paymentSourceType={paymentSource.paymentSourceType}
+                          showDefault
+                        />
+                        <span className="truncate">
+                          {shortenAddress(paymentSource.smartContractAddress, 8)}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {selectedPaymentSource
+                ? `This wallet belongs to ${getPaymentSourceTypeLabel(selectedPaymentSource.paymentSourceType)} on ${network}.`
+                : 'Create a payment source before adding wallets.'}
+            </p>
+          </div>
 
-        {error && (
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
-        )}
+          {error && (
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
+          )}
 
-        {type === 'Funding' ? (
-          <FundWalletSetupForm
-            onSubmit={handleCreateFundWallet}
-            isSubmitting={createFundWallet.isPending}
-            network={network}
-            onCancel={onClose}
-            showDescription={false}
-            submitLabel="Add funding wallet"
-          />
-        ) : (
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
+          {type === 'Funding' ? (
+            <FundWalletSetupForm
+              onSubmit={handleCreateFundWallet}
+              isSubmitting={createFundWallet.isPending}
+              network={network}
+              onCancel={onClose}
+              showDescription={false}
+              submitLabel="Add funding wallet"
+            />
+          ) : (
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium">
+                    Mnemonic Phrase <span className="text-destructive">*</span>
+                  </label>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleGenerateMnemonic}
+                    disabled={isGenerating}
+                    className="h-8"
+                  >
+                    {isGenerating ? <Spinner size={16} /> : 'Generate'}
+                  </Button>
+                </div>
+                <div className="relative">
+                  <Textarea
+                    {...register('mnemonic')}
+                    placeholder="Enter your mnemonic phrase"
+                    required
+                    className="min-h-[100px] font-mono pr-10"
+                    spellCheck={false}
+                    autoComplete="off"
+                    style={
+                      showMnemonic
+                        ? undefined
+                        : ({
+                            WebkitTextSecurity: 'disc',
+                            textSecurity: 'disc',
+                          } as React.CSSProperties)
+                    }
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowMnemonic((v) => !v)}
+                    className="absolute right-2 top-2 text-muted-foreground hover:text-foreground"
+                    aria-label={showMnemonic ? 'Hide mnemonic' : 'Show mnemonic'}
+                    tabIndex={-1}
+                  >
+                    {showMnemonic ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                {errors.mnemonic && (
+                  <p className="text-xs text-destructive mt-1">{errors.mnemonic.message}</p>
+                )}
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    disabled={!mnemonic || isLoading}
+                    onClick={() => setConfirmMnemonicDownloadOpen(true)}
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    Download seed phrase
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-2">
                 <label className="text-sm font-medium">
-                  Mnemonic Phrase <span className="text-destructive">*</span>
+                  Note <span className="text-destructive">*</span>
                 </label>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleGenerateMnemonic}
-                  disabled={isGenerating}
-                  className="h-8"
-                >
-                  {isGenerating ? <Spinner size={16} /> : 'Generate'}
+                <Input
+                  {...register('note')}
+                  placeholder="Enter a note to identify this wallet"
+                  required
+                />
+                {errors.note && (
+                  <p className="text-xs text-destructive mt-1">{errors.note.message}</p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  {type === 'Purchasing' ? 'Refund' : 'Revenue'} Collection Address{' '}
+                </label>
+                <Input
+                  {...register('collectionAddress')}
+                  placeholder={`Enter the address where ${type === 'Purchasing' ? 'refunds' : 'revenue'} will be sent`}
+                />
+                {errors.collectionAddress && (
+                  <p className="text-xs text-destructive mt-1">
+                    {errors.collectionAddress.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={onClose} disabled={isLoading}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isLoading}>
+                  {isLoading ? 'Adding...' : 'Add Wallet'}
                 </Button>
               </div>
-              <div className="relative">
-                <Textarea
-                  {...register('mnemonic')}
-                  placeholder="Enter your mnemonic phrase"
-                  required
-                  className="min-h-[100px] font-mono pr-10"
-                  spellCheck={false}
-                  autoComplete="off"
-                  style={
-                    showMnemonic
-                      ? undefined
-                      : ({
-                          WebkitTextSecurity: 'disc',
-                          textSecurity: 'disc',
-                        } as React.CSSProperties)
-                  }
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowMnemonic((v) => !v)}
-                  className="absolute right-2 top-2 text-muted-foreground hover:text-foreground"
-                  aria-label={showMnemonic ? 'Hide mnemonic' : 'Show mnemonic'}
-                  tabIndex={-1}
-                >
-                  {showMnemonic ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </div>
-              {errors.mnemonic && (
-                <p className="text-xs text-destructive mt-1">{errors.mnemonic.message}</p>
-              )}
-            </div>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
 
-            <div className="space-y-2">
-              <label className="text-sm font-medium">
-                Note <span className="text-destructive">*</span>
-              </label>
-              <Input
-                {...register('note')}
-                placeholder="Enter a note to identify this wallet"
-                required
-              />
-              {errors.note && (
-                <p className="text-xs text-destructive mt-1">{errors.note.message}</p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium">
-                {type === 'Purchasing' ? 'Refund' : 'Revenue'} Collection Address{' '}
-              </label>
-              <Input
-                {...register('collectionAddress')}
-                placeholder={`Enter the address where ${type === 'Purchasing' ? 'refunds' : 'revenue'} will be sent`}
-              />
-              {errors.collectionAddress && (
-                <p className="text-xs text-destructive mt-1">{errors.collectionAddress.message}</p>
-              )}
-            </div>
-
-            <div className="flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={onClose} disabled={isLoading}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={isLoading}>
-                {isLoading ? 'Adding...' : 'Add Wallet'}
-              </Button>
-            </div>
-          </form>
-        )}
-      </DialogContent>
-    </Dialog>
+      <ConfirmDialog
+        open={confirmMnemonicDownloadOpen}
+        onClose={() => setConfirmMnemonicDownloadOpen(false)}
+        elevatedChildStack
+        title="Download recovery phrase file?"
+        description={RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION}
+        onConfirm={performMnemonicDownload}
+        confirmLabel="Download"
+      />
+    </>
   );
 }

--- a/frontend/src/components/wallets/WalletDetailsDialog.tsx
+++ b/frontend/src/components/wallets/WalletDetailsDialog.tsx
@@ -475,7 +475,10 @@ export function WalletDetailsDialog({
           size="md"
           variant={isChild ? 'slide-from-right' : 'default'}
           isPushedBack={
-            !!selectedWalletForTopup || !!selectedWalletForSwap || !!rules.pendingDeleteRule
+            !!selectedWalletForTopup ||
+            !!selectedWalletForSwap ||
+            !!rules.pendingDeleteRule ||
+            confirmMnemonicDownloadOpen
           }
           hideOverlay={isChild}
           onBack={isChild ? handleDialogClose : undefined}
@@ -668,6 +671,7 @@ export function WalletDetailsDialog({
       <ConfirmDialog
         open={confirmMnemonicDownloadOpen}
         onClose={() => setConfirmMnemonicDownloadOpen(false)}
+        elevatedChildStack={!elevatedChildStack}
         elevatedGrandchildStack={elevatedChildStack}
         title="Download recovery phrase file?"
         description={RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION}

--- a/frontend/src/components/wallets/WalletDetailsDialog.tsx
+++ b/frontend/src/components/wallets/WalletDetailsDialog.tsx
@@ -57,6 +57,7 @@ import { WalletExportSection } from '@/components/wallets/sections/WalletExportS
 import { CollectionAddressSection } from '@/components/wallets/sections/CollectionAddressSection';
 import { FundTransfersSection } from '@/components/wallets/sections/FundTransfersSection';
 import { useCollectionAddressEditor } from '@/components/wallets/useCollectionAddressEditor';
+import { RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION } from '@/lib/wallet-recovery-download';
 
 // Re-exported for the many call sites that import these types from this module.
 export type { TokenBalance, WalletWithBalance } from '@/components/wallets/wallet-details-utils';
@@ -93,6 +94,7 @@ export function WalletDetailsDialog({
   );
   const [exportedMnemonic, setExportedMnemonic] = useState<string | null>(null);
   const [isExporting, setIsExporting] = useState(false);
+  const [confirmMnemonicDownloadOpen, setConfirmMnemonicDownloadOpen] = useState(false);
   const [swapTransactions, setSwapTransactions] = useState<SwapTx[]>([]);
   const [swapTxLoading, setSwapTxLoading] = useState(false);
   const [swapTxCursor, setSwapTxCursor] = useState<string | undefined>(undefined);
@@ -400,7 +402,7 @@ export function WalletDetailsDialog({
     }
   };
 
-  const handleDownload = () => {
+  const performMnemonicDownload = () => {
     if (!wallet || !exportedMnemonic) return;
     const data = {
       walletAddress: wallet.walletAddress,
@@ -417,6 +419,7 @@ export function WalletDetailsDialog({
     a.download = `wallet-export-${wallet.walletAddress}.json`;
     a.click();
     URL.revokeObjectURL(url);
+    setConfirmMnemonicDownloadOpen(false);
   };
 
   const handleDialogClose = useCallback(() => {
@@ -640,7 +643,7 @@ export function WalletDetailsDialog({
                 exportedMnemonic={exportedMnemonic}
                 onClose={() => setExportedMnemonic(null)}
                 onCopyMnemonic={handleCopyMnemonic}
-                onDownload={handleDownload}
+                onDownload={() => setConfirmMnemonicDownloadOpen(true)}
               />
             )}
 
@@ -661,6 +664,16 @@ export function WalletDetailsDialog({
           </div>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={confirmMnemonicDownloadOpen}
+        onClose={() => setConfirmMnemonicDownloadOpen(false)}
+        elevatedGrandchildStack={elevatedChildStack}
+        title="Download recovery phrase file?"
+        description={RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION}
+        onConfirm={performMnemonicDownload}
+        confirmLabel="Download"
+      />
 
       <ConfirmDialog
         open={!!rules.pendingDeleteRule}

--- a/frontend/src/lib/wallet-recovery-download.ts
+++ b/frontend/src/lib/wallet-recovery-download.ts
@@ -1,0 +1,3 @@
+/** Shared copy for recovery-phrase download confirmation dialogs. */
+export const RECOVERY_PHRASE_DOWNLOAD_CONFIRM_DESCRIPTION =
+  'This downloads your recovery phrase as an unencrypted file. Anyone with access to the file can spend from this wallet. Continue only if you will store it securely.';


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[] Bug fix  
[X] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**

- Require ConfirmDialog before downloading recovery phrases in Wallet Details export (was instant download on dev)
- Replace window.confirm with ConfirmDialog on Setup seed phrase screen for consistent UX
- Add Download seed phrase to Add Wallet dialog (after Generate) with the same confirm flow
- Share one warning message via wallet-recovery-download.ts across all three flows
- Fix nested modal stacking (isPushedBack + elevatedChildStack) so confirms render above parent dialogs

<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
