### PR TITLE
fix(frontend): self-host monaco so schema validator loads under CSP

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -20,6 +20,8 @@
 # production
 /build
 
+/public/monaco
+
 # misc
 .DS_Store
 *.pem

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,6 +1,7 @@
 node_modules/
 .next/
 dist/
+public/monaco/
 src/lib/api/generated/
 **/*.gen.ts
 openapi-docs.json

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -13,7 +13,9 @@ const localRulesPlugin = {
 const eslintConfig = defineConfig([
   ...nextVitals,
   prettierConfig,
-  globalIgnores(['.next/**', 'dist/**', 'node_modules/**']),
+  // 'public/monaco' is Monaco's prebuilt bundle staged by scripts/copy-monaco.mjs.
+  // Generated, gitignored, minified vendor code — linting it takes minutes.
+  globalIgnores(['.next/**', 'dist/**', 'node_modules/**', 'public/monaco/**']),
   {
     ignores: ['**/*.gen.ts', 'src/lib/api/generated/**'],
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "preinstall": "node -e \"if (!(process.env.npm_config_user_agent||'').startsWith('pnpm')) { console.error('\\nThis project uses pnpm. Use: pnpm install\\n'); process.exit(1); }\"",
     "dev": "next dev",
+    "prebuild": "node scripts/copy-monaco.mjs",
     "build": "next build",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
@@ -20,6 +21,7 @@
     "@hey-api/openapi-ts": "0.98.2",
     "@hookform/resolvers": "5.4.0",
     "@meshsdk/core": "1.9.0-beta.96",
+    "@monaco-editor/loader": "1.7.0",
     "@radix-ui/react-checkbox": "1.3.4",
     "@radix-ui/react-collapsible": "1.1.13",
     "@radix-ui/react-dialog": "1.1.16",
@@ -41,6 +43,7 @@
     "lucide-react": "0.562.0",
     "lz-string": "1.5.0",
     "masumi-schema-validator-component": "1.2.0",
+    "monaco-editor": "0.55.1",
     "next": "^16.2.12",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/frontend/scripts/copy-monaco.mjs
+++ b/frontend/scripts/copy-monaco.mjs
@@ -1,0 +1,25 @@
+// Copies Monaco's prebuilt AMD bundle into public/ so the admin UI serves it from
+// its own origin. @monaco-editor/loader otherwise pulls it from jsdelivr, which
+// the node's CSP (script-src 'self') blocks — the editor then hangs on "Loading..."
+// forever because @monaco-editor/react swallows the rejection into a console.error.
+//
+// Runs as `prebuild`, so `next build` (and the Docker frontend stage) always ships
+// assets matching the installed monaco-editor version. See InputSchemaValidator.tsx
+// for the matching loader.config() path.
+import { cpSync, existsSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = resolve(frontendRoot, 'node_modules/monaco-editor/min/vs');
+const target = resolve(frontendRoot, 'public/monaco/vs');
+
+if (!existsSync(source)) {
+  console.error(`[copy-monaco] monaco-editor assets not found at ${source}`);
+  console.error('[copy-monaco] run `pnpm install` before building the frontend');
+  process.exit(1);
+}
+
+rmSync(target, { recursive: true, force: true });
+cpSync(source, target, { recursive: true });
+console.log(`[copy-monaco] copied ${source} -> ${target}`);

--- a/frontend/src/components/developers/InputSchemaValidator.tsx
+++ b/frontend/src/components/developers/InputSchemaValidator.tsx
@@ -1,4 +1,6 @@
+import loader from '@monaco-editor/loader';
 import dynamic from 'next/dynamic';
+loader.config({ paths: { vs: '/admin/monaco/vs' } });
 
 const SchemaPlayground = dynamic(
   () => import('masumi-schema-validator-component').then((mod) => mod.SchemaPlayground),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@meshsdk/core':
         specifier: 1.9.0-beta.96
         version: 1.9.0-beta.96(@bufbuild/protobuf@1.10.1)(@harmoniclabs/bytestring@1.0.0)(@harmoniclabs/crypto@0.2.5)(rxjs@7.8.2)
+      '@monaco-editor/loader':
+        specifier: 1.7.0
+        version: 1.7.0
       '@radix-ui/react-checkbox':
         specifier: 1.3.4
         version: 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -381,6 +384,9 @@ importers:
       masumi-schema-validator-component:
         specifier: 1.2.0
         version: 1.2.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+      monaco-editor:
+        specifier: 0.55.1
+        version: 0.55.1
       next:
         specifier: ^16.2.12
         version: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,6 +118,7 @@ export async function startApp() {
 							frameAncestors: ["'none'"],
 							imgSrc: ["'self'", 'data:'],
 							objectSrc: ["'none'"],
+							workerSrc: ["'self'", 'blob:'],
 							// 'wasm-unsafe-eval' lets the bundled Mesh SDK (Cardano serialization) compile
 							// its WebAssembly. It permits WASM only, not arbitrary JS eval.
 							scriptSrc: ["'self'", "'unsafe-inline'", "'wasm-unsafe-eval'"],


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

 Bug fix  


## **Overview of Changes**
Monaco Editor Fails to Load Due to CSP Blocking jsDelivr
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-591/monaco-editor-fails-to-load-due-to-csp-blocking-jsdelivr
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
