### PR TITLE
fix(frontend): disclose read-only API key default credits

### DIFF
--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { convertDecimalToBaseUnits, isValidDecimalAmount } from '@/lib/convertDecimalToBaseUnits';
 import type { ApiKey, PostApiKeyData } from '@/lib/api/generated';
 import { walletScopeProblem } from '@/components/api-keys/wallet-scope.helpers';
+import { MASUMI_API_KEY_PERMISSIONS_DOCS_URL } from '@/lib/masumi-links';
 
 interface AddApiKeyDialogProps {
   open: boolean;
@@ -566,7 +567,16 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                   <p className="text-xs text-muted-foreground">
                     Read-only keys are always usage-limited. They receive a default allowance of
                     1000 ADA for read operations. This limit is applied automatically and cannot be
-                    changed here.
+                    changed here.{' '}
+                    <a
+                      href={MASUMI_API_KEY_PERMISSIONS_DOCS_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline underline-offset-4 hover:text-primary/80"
+                    >
+                      Learn more about API key permissions
+                    </a>
+                    .
                   </p>
                 </div>
               )}

--- a/frontend/src/components/api-keys/AddApiKeyDialog.tsx
+++ b/frontend/src/components/api-keys/AddApiKeyDialog.tsx
@@ -290,7 +290,7 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
 
   const onSubmit = async (data: ApiKeyFormValues) => {
     const isReadOnly = !data.canPay && !data.canAdmin;
-    const defaultCredits = [
+    const readOnlyDefaultCredits = [
       {
         unit: 'lovelace',
         amount: '1000000000', // 1000 ADA
@@ -321,7 +321,7 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
             ? undefined
             : data.evmChains,
         UsageCredits: isReadOnly
-          ? defaultCredits
+          ? readOnlyDefaultCredits
           : data.usageLimited
             ? [
                 ...(data.credits.lovelace
@@ -560,6 +560,16 @@ export function AddApiKeyDialog({ open, onClose, onSuccess }: AddApiKeyDialogPro
                   <p className="text-xs text-muted-foreground">Admin keys are not usage limited</p>
                 )}
               </div>
+
+              {isReadOnly && (
+                <div className="rounded-md border border-muted bg-muted/20 p-3">
+                  <p className="text-xs text-muted-foreground">
+                    Read-only keys are always usage-limited. They receive a default allowance of
+                    1000 ADA for read operations. This limit is applied automatically and cannot be
+                    changed here.
+                  </p>
+                </div>
+              )}
 
               {usageLimited && !isReadOnly && (
                 <>

--- a/frontend/src/lib/masumi-links.ts
+++ b/frontend/src/lib/masumi-links.ts
@@ -5,4 +5,5 @@ export const MASUMI_SUPPORT_URL = 'https://www.masumi.network/contact';
 export const MASUMI_API_KEY_DOCS_URL =
   'https://www.masumi.network/dev/masumi/documentation/technical-documentation/environment-variables';
 /** Permission flags and presets (Read-only, Read and Pay, Admin). */
-export const MASUMI_API_KEY_PERMISSIONS_DOCS_URL = 'https://docs.masumi.network/api-reference';
+export const MASUMI_API_KEY_PERMISSIONS_DOCS_URL =
+  'https://www.masumi.network/dev/masumi/api-reference/payment-service/post-api-key';

--- a/frontend/src/lib/masumi-links.ts
+++ b/frontend/src/lib/masumi-links.ts
@@ -4,3 +4,5 @@ export const MASUMI_PRESS_URL = 'https://www.masumi.network/press';
 export const MASUMI_SUPPORT_URL = 'https://www.masumi.network/contact';
 export const MASUMI_API_KEY_DOCS_URL =
   'https://www.masumi.network/dev/masumi/documentation/technical-documentation/environment-variables';
+/** Permission flags and presets (Read-only, Read and Pay, Admin). */
+export const MASUMI_API_KEY_PERMISSIONS_DOCS_URL = 'https://docs.masumi.network/api-reference';


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
<img width="562" height="785" alt="image" src="https://github.com/user-attachments/assets/3d230148-abbb-44f2-a5a1-66fb411e12e2" />

- Show a notice when Read-only is selected that a default 1000 ADA usage allowance is applied.
- Rename `defaultCredits` to `readOnlyDefaultCredits` (behavior unchanged).
- Add a permissions docs link via `MASUMI_API_KEY_PERMISSIONS_DOCS_URL` in `masumi-links.ts`.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
