### PR TITLE
Mas 592 openapi documentation fails to render due to frame

### DIFF
--- a/frontend/src/pages/developers.tsx
+++ b/frontend/src/pages/developers.tsx
@@ -154,7 +154,7 @@ export default function Developers() {
                     Interactive API documentation powered by Swagger UI.
                   </p>
                   <Button variant="outline" size="sm" asChild>
-                    <a href="/docs" target="_blank" rel="noopener noreferrer">
+                    <a href="/docs/" target="_blank" rel="noopener noreferrer">
                       Open in new tab
                       <ExternalLink className="w-3.5 h-3.5 ml-1.5" />
                     </a>
@@ -166,7 +166,7 @@ export default function Developers() {
                   )}
                   <iframe
                     ref={iframeRef}
-                    src="/docs"
+                    src="/docs/"
                     className="w-full h-full"
                     title="OpenAPI Documentation"
                     onLoad={handleIframeLoad}

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { requestTiming } from '@/utils/middleware/request-timing';
 import { DEFAULTS } from '@masumi/payment-core/config';
 import { requestLogger } from '@/utils/middleware/request-logger';
 import { robotsNoindex, serveRobotsTxt } from '@/utils/middleware/robots-noindex';
+import { allowSameOriginFraming } from '@/utils/middleware/allow-same-origin-framing';
 import { generateApiKeySecureHash } from '@masumi/payment-core/api-key-hash';
 import { migrateApiKeyEncryption } from '@/utils/startup-migrations/api-key-encryption';
 import { migrateWebhookEncryption } from '@/utils/startup-migrations/webhook-encryption';
@@ -170,6 +171,7 @@ export async function startApp() {
 
 			app.use(
 				'/docs',
+				allowSameOriginFraming,
 				ui.serve,
 				ui.setup(JSON.parse(docsString) as JsonObject, {
 					explorer: false,

--- a/src/utils/middleware/allow-same-origin-framing/index.ts
+++ b/src/utils/middleware/allow-same-origin-framing/index.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+
+
+export const allowSameOriginFraming = (_req: Request, res: Response, next: NextFunction) => {
+	const contentSecurityPolicy = res.getHeader('Content-Security-Policy');
+	if (typeof contentSecurityPolicy === 'string') {
+		res.setHeader(
+			'Content-Security-Policy',
+			contentSecurityPolicy.replace(/frame-ancestors[^;]*/, "frame-ancestors 'self'"),
+		);
+	}
+	res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+	next();
+};

--- a/src/utils/middleware/allow-same-origin-framing/index.ts
+++ b/src/utils/middleware/allow-same-origin-framing/index.ts
@@ -1,6 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
 
-
 export const allowSameOriginFraming = (_req: Request, res: Response, next: NextFunction) => {
 	const contentSecurityPolicy = res.getHeader('Content-Security-Policy');
 	if (typeof contentSecurityPolicy === 'string') {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

 Bug fix  


## **Overview of Changes**
OpenAPI tab broken = Developers → OpenAPI tab.
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-592/openapi-documentation-fails-to-render-due-to-frame-protection
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
