### PR TITLE
fix(frontend): align sticky table action cells with headers

### DIFF
--- a/frontend/src/components/ui/table-actions-column.ts
+++ b/frontend/src/components/ui/table-actions-column.ts
@@ -14,7 +14,9 @@ const tableActionsGradientHover =
 const tableActionsHeadTypography =
   'text-right text-sm font-medium text-muted-foreground whitespace-nowrap';
 
-const tableActionsCellShared = `${tableActionsSticky} ${tableActionsGradientDefault} ${tableActionsGradientHover} transition-[background] duration-150`;
+const tableActionsCellAlignment = 'flex items-center justify-end';
+
+const tableActionsCellShared = `${tableActionsSticky} ${tableActionsGradientDefault} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellAlignment}`;
 
 export const tableActionsHeadClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-48 min-w-48 p-4 pr-4 ${tableActionsHeadTypography}`;
 
@@ -29,6 +31,6 @@ export const tableActionsCellCompactLowBalanceHoverClass =
 
 export const tableActionsHeadWideClass = `${tableActionsSticky} ${tableActionsGradientDefault} w-64 min-w-64 p-4 pr-4 ${tableActionsHeadTypography}`;
 
-export const tableActionsCellWideClass = `${tableActionsCellShared} w-64 min-w-64 p-4 pr-4 text-right`;
+export const tableActionsCellWideClass = `${tableActionsCellShared} w-64 min-w-64 p-4 pr-4`;
 
-export const tableActionsCellWideDestructiveClass = `${tableActionsSticky} ${tableActionsGradientDestructive} ${tableActionsGradientHover} transition-[background] duration-150 w-64 min-w-64 p-4 pr-4`;
+export const tableActionsCellWideDestructiveClass = `${tableActionsSticky} ${tableActionsGradientDestructive} ${tableActionsGradientHover} transition-[background] duration-150 ${tableActionsCellAlignment} w-64 min-w-64 p-4 pr-4`;


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->

## **Overview of Changes**
Action headers use text-right but cells lost alignment in the sticky-column refactor. Right-align cell content across api-keys, agents, wallets, and other admin tables that share these helpers.
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
