### PR TITLE
Mas 530 preserve webhook tokens when editing other fields mas 512 7

### DIFF
--- a/frontend/openapi-docs.json
+++ b/frontend/openapi-docs.json
@@ -26198,7 +26198,7 @@
                                         "nullable": true,
                                         "minLength": 10,
                                         "maxLength": 200,
-                                        "description": "Authentication token for extended webhook requests. Required when format is EXTENDED"
+                                        "description": "Authentication token for extended webhook requests. Omit to keep the stored token; required when changing a webhook to EXTENDED"
                                     },
                                     "format": {
                                         "type": "string",

--- a/frontend/src/components/webhooks/WebhookDialog.tsx
+++ b/frontend/src/components/webhooks/WebhookDialog.tsx
@@ -341,7 +341,6 @@ export function WebhookDialog({
               <Input
                 id="webhook-auth-token"
                 type="password"
-
                 autoComplete="new-password"
                 placeholder={
                   canKeepStoredToken ? 'Leave blank to keep the current token' : 'shared-secret'

--- a/frontend/src/components/webhooks/WebhookDialog.tsx
+++ b/frontend/src/components/webhooks/WebhookDialog.tsx
@@ -55,15 +55,21 @@ const webhookFormSchema = z
     url: z.string().trim().url('Enter a valid webhook URL'),
     authToken: z.string().max(200, 'Auth token must be 200 characters or fewer'),
     Events: z.array(z.enum(WEBHOOK_EVENTS)).min(1, 'Select at least one event'),
+    canKeepStoredToken: z.boolean(),
   })
   .superRefine((value, ctx) => {
-    if (value.format === 'EXTENDED' && !value.authToken.trim()) {
+    if (value.format !== 'EXTENDED') return;
+
+    const authToken = value.authToken.trim();
+    if (!authToken && value.canKeepStoredToken) return;
+
+    if (!authToken) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Auth token is required for extended webhooks',
         path: ['authToken'],
       });
-    } else if (value.format === 'EXTENDED' && value.authToken.trim().length < 10) {
+    } else if (authToken.length < 10) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Auth token must be at least 10 characters',
@@ -118,6 +124,7 @@ function getDefaultValues(
     url: webhook?.url ?? '',
     authToken: '',
     Events: webhook?.Events ?? [...availableEvents],
+    canKeepStoredToken: webhook?.format === 'EXTENDED',
   };
 }
 
@@ -178,6 +185,7 @@ export function WebhookDialog({
     name: 'Events',
     defaultValue: webhook?.Events ?? [...availableEvents],
   });
+  const canKeepStoredToken = useWatch({ control, name: 'canKeepStoredToken' });
 
   const allEventsSelected =
     availableEvents.every((event) => selectedEvents.includes(event)) && selectedEvents.length > 0;
@@ -217,11 +225,12 @@ export function WebhookDialog({
   };
 
   const submit = async (values: WebhookFormValues) => {
+    const authToken = values.authToken.trim();
     const payload = {
       name: values.name.trim() || undefined,
       format: values.format,
       url: values.url.trim(),
-      authToken: values.format === 'EXTENDED' ? values.authToken.trim() : undefined,
+      authToken: values.format === 'EXTENDED' && authToken ? authToken : undefined,
       Events: values.Events,
     };
 
@@ -332,13 +341,18 @@ export function WebhookDialog({
               <Input
                 id="webhook-auth-token"
                 type="password"
-                placeholder="shared-secret"
+
+                autoComplete="new-password"
+                placeholder={
+                  canKeepStoredToken ? 'Leave blank to keep the current token' : 'shared-secret'
+                }
                 {...register('authToken')}
                 disabled={isSubmitting}
               />
               <p className="text-xs text-muted-foreground">
-                Masumi will send this value as a Bearer token so your endpoint can verify the
-                request.
+                {canKeepStoredToken
+                  ? 'Leave blank to keep the current token. Enter a new value to replace it.'
+                  : 'Masumi will send this value as a Bearer token so your endpoint can verify the request.'}
               </p>
               {errors.authToken && (
                 <p className="text-xs text-destructive">{errors.authToken.message}</p>

--- a/frontend/src/lib/api/generated/types.gen.ts
+++ b/frontend/src/lib/api/generated/types.gen.ts
@@ -11292,7 +11292,7 @@ export type PatchWebhooksData = {
          */
         url: string;
         /**
-         * Authentication token for extended webhook requests. Required when format is EXTENDED
+         * Authentication token for extended webhook requests. Omit to keep the stored token; required when changing a webhook to EXTENDED
          */
         authToken?: string | null;
         /**

--- a/src/routes/api/webhooks/index.spec.ts
+++ b/src/routes/api/webhooks/index.spec.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import type { Mock } from 'jest-mock';
 import { testEndpoint } from 'express-zod-api';
-import { ApiKeyStatus, Network, WebhookFormat } from '@/generated/prisma/client';
+import { ApiKeyStatus, Network, Prisma, WebhookFormat } from '@/generated/prisma/client';
 
 type AnyMock = Mock<(...args: any[]) => any>;
 
@@ -96,6 +96,40 @@ describe('webhook endpoints', () => {
 		walletScopeEnabled: false,
 		WalletScopes: [],
 	});
+
+	const asStoredWebhook = (overrides: { format: WebhookFormat; authToken: string | null }) => ({
+		id: 'webhook-6',
+		url: 'enc:https://example.com/old',
+		events: ['PAYMENT_ON_ERROR'],
+		name: 'Webhook',
+		isActive: true,
+		createdAt: new Date('2026-04-08T12:00:00.000Z'),
+		updatedAt: new Date('2026-04-08T12:05:00.000Z'),
+		paymentSourceId: 'payment-source-1',
+		createdByApiKeyId: 'api-key-1',
+		PaymentSource: {
+			id: 'payment-source-1',
+			network: Network.Preprod,
+			deletedAt: null,
+		},
+		...overrides,
+	});
+
+	const patchExtendedWithoutToken = () =>
+		testEndpoint({
+			endpoint: patchWebhookPatch,
+			requestProps: {
+				method: 'PATCH',
+				headers: { token: 'valid' },
+				body: {
+					webhookId: 'webhook-6',
+					url: 'https://example.com/new',
+					format: WebhookFormat.EXTENDED,
+					Events: ['PAYMENT_ON_ERROR'],
+					name: 'Webhook renamed',
+				},
+			},
+		});
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -396,23 +430,100 @@ describe('webhook endpoints', () => {
 		});
 	});
 
-	it('rejects patching without authToken when format is EXTENDED', async () => {
+	it('keeps the stored authToken when an EXTENDED patch omits it', async () => {
+		mockFindWebhookById.mockResolvedValue(
+			asStoredWebhook({ format: WebhookFormat.EXTENDED, authToken: 'enc:old-secret' }),
+		);
+		mockUpdateWebhook.mockResolvedValue({
+			...asStoredWebhook({ format: WebhookFormat.EXTENDED, authToken: 'enc:old-secret' }),
+			name: 'Webhook renamed',
+		});
+
+		const { responseMock } = await patchExtendedWithoutToken();
+
+		expect(responseMock.statusCode).toBe(200);
+		expect(mockUpdateWebhook).toHaveBeenCalledWith({
+			where: { id: 'webhook-6', format: WebhookFormat.EXTENDED, authToken: { not: null } },
+			data: {
+				url: 'enc:https://example.com/new',
+				urlHash: 'hash:https://example.com/new',
+				format: WebhookFormat.EXTENDED,
+				events: ['PAYMENT_ON_ERROR'],
+				name: 'Webhook renamed',
+			},
+		});
+	});
+
+	it('rejects an EXTENDED patch without authToken when switching from a provider format', async () => {
+		mockFindWebhookById.mockResolvedValue(asStoredWebhook({ format: WebhookFormat.SLACK, authToken: null }));
+
+		const { responseMock } = await patchExtendedWithoutToken();
+
+		expect(responseMock.statusCode).toBe(400);
+		expect(mockUpdateWebhook).not.toHaveBeenCalled();
+	});
+
+	it('rejects an EXTENDED patch without authToken when no token is stored', async () => {
+		mockFindWebhookById.mockResolvedValue(asStoredWebhook({ format: WebhookFormat.EXTENDED, authToken: null }));
+
+		const { responseMock } = await patchExtendedWithoutToken();
+
+		expect(responseMock.statusCode).toBe(400);
+		expect(mockUpdateWebhook).not.toHaveBeenCalled();
+	});
+
+	it('rejects a provided authToken shorter than 10 characters on patch', async () => {
+		mockFindWebhookById.mockResolvedValue(
+			asStoredWebhook({ format: WebhookFormat.EXTENDED, authToken: 'enc:old-secret' }),
+		);
+
 		const { responseMock } = await testEndpoint({
 			endpoint: patchWebhookPatch,
 			requestProps: {
 				method: 'PATCH',
 				headers: { token: 'valid' },
 				body: {
-					webhookId: 'webhook-3',
+					webhookId: 'webhook-6',
 					url: 'https://example.com/new',
+					authToken: 'short',
 					format: WebhookFormat.EXTENDED,
 					Events: ['PAYMENT_ON_ERROR'],
-					name: 'Webhook updated',
+					name: 'Webhook renamed',
 				},
 			},
 		});
 
 		expect(responseMock.statusCode).toBe(400);
+		expect(mockUpdateWebhook).not.toHaveBeenCalled();
+	});
+
+	it('returns 409 when the stored token disappears before the token-preserving update', async () => {
+		mockFindWebhookById.mockResolvedValue(
+			asStoredWebhook({ format: WebhookFormat.EXTENDED, authToken: 'enc:old-secret' }),
+		);
+		mockUpdateWebhook.mockRejectedValue(
+			new Prisma.PrismaClientKnownRequestError('No record was found for an update.', {
+				code: 'P2025',
+				clientVersion: 'test',
+			}),
+		);
+
+		const { responseMock } = await patchExtendedWithoutToken();
+
+		expect(responseMock.statusCode).toBe(409);
+	});
+
+	it('checks edit permission before revealing whether a token is stored', async () => {
+		mockFindApiKey.mockResolvedValue({
+			...asApiKey(),
+			id: 'api-key-2',
+			canAdmin: false,
+		});
+		mockFindWebhookById.mockResolvedValue(asStoredWebhook({ format: WebhookFormat.SLACK, authToken: null }));
+
+		const { responseMock } = await patchExtendedWithoutToken();
+
+		expect(responseMock.statusCode).toBe(403);
 		expect(mockUpdateWebhook).not.toHaveBeenCalled();
 	});
 

--- a/src/routes/api/webhooks/index.ts
+++ b/src/routes/api/webhooks/index.ts
@@ -2,7 +2,7 @@ import { payAuthenticatedEndpointFactory } from '@masumi/payment-core/auth';
 import { cursorPaginationArgs } from '@/utils/shared/queries';
 import { prisma } from '@masumi/payment-core/db';
 import createHttpError from 'http-errors';
-import { Network, WebhookFormat } from '@/generated/prisma/client';
+import { Network, Prisma, WebhookFormat } from '@/generated/prisma/client';
 import { checkIsAllowedNetworkOrThrowUnauthorized } from '@masumi/payment-core/auth';
 import {
 	decryptWebhookUrlSafe,
@@ -189,6 +189,12 @@ export const patchWebhookPatch = webhookMutationEndpointFactory.build({
 			}
 		}
 
+
+		const keepStoredAuthToken = input.format === WebhookFormat.EXTENDED && input.authToken == null;
+		if (keepStoredAuthToken && (webhook.format !== WebhookFormat.EXTENDED || webhook.authToken == null)) {
+			throw createHttpError(400, 'authToken is required when format is EXTENDED');
+		}
+
 		const existingWebhook = await prisma.webhookEndpoint.findFirst({
 			where: {
 				id: { not: input.webhookId },
@@ -202,17 +208,33 @@ export const patchWebhookPatch = webhookMutationEndpointFactory.build({
 			throw createHttpError(409, 'Webhook URL already registered for this payment source');
 		}
 
-		const updatedWebhook = await prisma.webhookEndpoint.update({
-			where: { id: input.webhookId },
-			data: {
-				url: encryptWebhookUrl(input.url),
-				urlHash,
-				authToken: input.format === WebhookFormat.EXTENDED ? encryptWebhookAuthToken(input.authToken) : null,
-				format: input.format,
-				events: input.Events,
-				name: input.name ?? null,
-			},
-		});
+		let updatedWebhook;
+		try {
+			updatedWebhook = await prisma.webhookEndpoint.update({
+
+				where: keepStoredAuthToken
+					? { id: input.webhookId, format: WebhookFormat.EXTENDED, authToken: { not: null } }
+					: { id: input.webhookId },
+				data: {
+					url: encryptWebhookUrl(input.url),
+					urlHash,
+					// undefined leaves the stored token untouched
+					authToken: keepStoredAuthToken
+						? undefined
+						: input.format === WebhookFormat.EXTENDED
+							? encryptWebhookAuthToken(input.authToken)
+							: null,
+					format: input.format,
+					events: input.Events,
+					name: input.name ?? null,
+				},
+			});
+		} catch (err) {
+			if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+				throw createHttpError(409, 'Webhook changed concurrently; reload and retry');
+			}
+			throw err;
+		}
 
 		return {
 			id: updatedWebhook.id,

--- a/src/routes/api/webhooks/index.ts
+++ b/src/routes/api/webhooks/index.ts
@@ -189,7 +189,6 @@ export const patchWebhookPatch = webhookMutationEndpointFactory.build({
 			}
 		}
 
-
 		const keepStoredAuthToken = input.format === WebhookFormat.EXTENDED && input.authToken == null;
 		if (keepStoredAuthToken && (webhook.format !== WebhookFormat.EXTENDED || webhook.authToken == null)) {
 			throw createHttpError(400, 'authToken is required when format is EXTENDED');
@@ -211,7 +210,6 @@ export const patchWebhookPatch = webhookMutationEndpointFactory.build({
 		let updatedWebhook;
 		try {
 			updatedWebhook = await prisma.webhookEndpoint.update({
-
 				where: keepStoredAuthToken
 					? { id: input.webhookId, format: WebhookFormat.EXTENDED, authToken: { not: null } }
 					: { id: input.webhookId },

--- a/src/routes/api/webhooks/schemas.ts
+++ b/src/routes/api/webhooks/schemas.ts
@@ -33,34 +33,26 @@ export const registerWebhookSchemaInput = z
 		}
 	});
 
-export const patchWebhookSchemaInput = z
-	.object({
-		webhookId: z.string().describe('The ID of the webhook to update'),
-		url: z
-			.string()
-			.url()
-			.max(500)
-			.describe('The webhook URL to receive notifications. Only public http and https destinations are allowed.'),
-		authToken: z
-			.string()
-			.min(10)
-			.max(200)
-			.optional()
-			.nullable()
-			.describe('Authentication token for extended webhook requests. Required when format is EXTENDED'),
-		format: z.nativeEnum(WebhookFormat).describe('Webhook delivery format'),
-		Events: z.array(z.nativeEnum(WebhookEventType)).min(1).max(10).describe('Array of event types to subscribe to'),
-		name: z.string().max(100).optional().nullable().describe('Human-readable name for the webhook'),
-	})
-	.superRefine((value, ctx) => {
-		if (value.format === WebhookFormat.EXTENDED && value.authToken == null) {
-			ctx.addIssue({
-				code: 'custom',
-				path: ['authToken'],
-				message: 'authToken is required when format is EXTENDED',
-			});
-		}
-	});
+export const patchWebhookSchemaInput = z.object({
+	webhookId: z.string().describe('The ID of the webhook to update'),
+	url: z
+		.string()
+		.url()
+		.max(500)
+		.describe('The webhook URL to receive notifications. Only public http and https destinations are allowed.'),
+	authToken: z
+		.string()
+		.min(10)
+		.max(200)
+		.optional()
+		.nullable()
+		.describe(
+			'Authentication token for extended webhook requests. Omit to keep the stored token; required when changing a webhook to EXTENDED',
+		),
+	format: z.nativeEnum(WebhookFormat).describe('Webhook delivery format'),
+	Events: z.array(z.nativeEnum(WebhookEventType)).min(1).max(10).describe('Array of event types to subscribe to'),
+	name: z.string().max(100).optional().nullable().describe('Human-readable name for the webhook'),
+});
 
 export const registerWebhookSchemaOutput = z.object({
 	id: z.string(),

--- a/src/utils/generator/swagger-generator/openapi-docs.json
+++ b/src/utils/generator/swagger-generator/openapi-docs.json
@@ -26198,7 +26198,7 @@
                                         "nullable": true,
                                         "minLength": 10,
                                         "maxLength": 200,
-                                        "description": "Authentication token for extended webhook requests. Required when format is EXTENDED"
+                                        "description": "Authentication token for extended webhook requests. Omit to keep the stored token; required when changing a webhook to EXTENDED"
                                     },
                                     "format": {
                                         "type": "string",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

 Bug fix  

## **Overview of Changes**
Preserve webhook tokens when editing other fields 
<!-- (Provide a detailed description of what changes were made in this PR and why they are necessary.) -->

## **Issue Addressed**
https://linear.app/masumi/issue/MAS-530/preserve-webhook-tokens-when-editing-other-fields-mas-512-7
<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
