### PR TITLE
fix(frontend): preserve decimal input in swap amounts

### DIFF
--- a/frontend/src/components/wallets/SwapDialog.tsx
+++ b/frontend/src/components/wallets/SwapDialog.tsx
@@ -142,7 +142,8 @@ export function SwapDialog({
   const [otherTokenBalances, setOtherTokenBalances] = useState<Record<string, number>>({});
   const [error, setError] = useState<string | null>(null);
 
-  const [fromAmount, setFromAmount] = useState<number>(1);
+  const [fromAmountInput, setFromAmountInput] = useState('1');
+  const fromAmount = Number.parseFloat(fromAmountInput) || 0;
   const { rate: adaToUsdRate } = useRate();
   const [isFetchingDetails, setIsFetchingDetails] = useState<boolean>(true);
   const [isSwapping, setIsSwapping] = useState<boolean>(false);
@@ -287,7 +288,7 @@ export function SwapDialog({
       setShowConfirmation(false);
       setSelectedFromToken(swappableTokens[adaIndex]);
       setSelectedToToken(swappableTokens[usdmIndex]);
-      setFromAmount(1);
+      setFromAmountInput('1');
       fetchBalance();
 
       const balanceInterval = setInterval(() => {
@@ -389,7 +390,7 @@ export function SwapDialog({
       const prevToAmount = conversionRate > 0 ? fromAmount * conversionRate : fromAmount;
       setSelectedFromToken(selectedToToken);
       setSelectedToToken(selectedFromToken);
-      setFromAmount(prevToAmount);
+      setFromAmountInput(String(prevToAmount));
     }
   };
 
@@ -433,15 +434,14 @@ export function SwapDialog({
   };
 
   const handleMaxClick = () => {
-    setFromAmount(getMaxAmount(selectedFromToken.symbol));
+    setFromAmountInput(String(getMaxAmount(selectedFromToken.symbol)));
   };
 
   const handleFromAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    const filteredValue = value.replace(/[^0-9.]/g, '');
-    const parsedValue = parseFloat(filteredValue);
-    const normalizedValue = isNaN(parsedValue) ? 0 : Number(parsedValue);
-    setFromAmount(normalizedValue);
+    const value = e.target.value.replace(/[^0-9.]/g, '');
+    const dotCount = (value.match(/\./g) ?? []).length;
+    if (dotCount > 1) return;
+    setFromAmountInput(value);
   };
 
   const toAmount = fromAmount * conversionRate;
@@ -789,14 +789,14 @@ export function SwapDialog({
                       disabled={isSwapping}
                     />
                     <input
-                      type="number"
+                      type="text"
+                      inputMode="decimal"
                       className={`w-full text-right bg-transparent focus:outline-none text-2xl font-semibold tabular-nums tracking-tight ${
                         isOverMax ? 'text-destructive' : 'text-foreground'
                       }`}
                       placeholder="0"
-                      value={fromAmount || ''}
+                      value={fromAmountInput}
                       onChange={handleFromAmountChange}
-                      step="0.1"
                     />
                   </div>
                   <div className="text-right text-xs text-muted-foreground mt-1.5">


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

Keep swap amount input as string while typing so values like `1.` are not collapsed by `parseFloat`.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
