### PR TITLE
fix(frontend): keep transfer asset rows stable after removal

### DIFF
--- a/frontend/src/components/wallets/TransferFundsDialog.tsx
+++ b/frontend/src/components/wallets/TransferFundsDialog.tsx
@@ -47,7 +47,15 @@ interface TransferFundsDialogProps {
 // mainnet) by name, or a custom token by hex unit. This mirrors the low-balance
 // rule asset model exactly, so the same units and decimals are used everywhere.
 type AssetPreset = 'stablecoin' | 'custom';
-type AssetFormRow = { preset: AssetPreset; customUnit: string; amount: string };
+type AssetFormRow = { id: string; preset: AssetPreset; customUnit: string; amount: string };
+
+let nextAssetRowId = 0;
+const createAssetRow = (): AssetFormRow => ({
+  id: `asset-row-${++nextAssetRowId}`,
+  preset: 'stablecoin',
+  customUnit: '',
+  amount: '',
+});
 type AssetPayload = { unit: string; quantity: string };
 
 // Client-side mirror of the API's postWalletFundSchemaInput, so a bad input is
@@ -163,8 +171,7 @@ export function TransferFundsDialog({
     errorMessage: 'Failed to queue fund transfer',
   });
 
-  const addAssetRow = () =>
-    setAssets((rows) => [...rows, { preset: 'stablecoin', customUnit: '', amount: '' }]);
+  const addAssetRow = () => setAssets((rows) => [...rows, createAssetRow()]);
   const updateAssetRow = (index: number, patch: Partial<AssetFormRow>) =>
     setAssets((rows) => rows.map((row, i) => (i === index ? { ...row, ...patch } : row)));
   const removeAssetRow = (index: number) => setAssets((rows) => rows.filter((_, i) => i !== index));
@@ -294,7 +301,7 @@ export function TransferFundsDialog({
                 const isCustom = row.preset === 'custom';
                 const meta = getRuleAssetMetaFromPreset(row.preset, network, row.customUnit);
                 return (
-                  <div key={index} className="space-y-2 rounded-lg border p-2">
+                  <div key={row.id} className="space-y-2 rounded-lg border p-2">
                     <div className="flex items-center gap-2">
                       <Select
                         value={row.preset}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

Use stable row ids for transfer asset rows so removing a middle row does not shift the other inputs.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
