### PR TITLE
fix(frontend): resync hydra data after connect and redeem

### DIFF
--- a/frontend/src/pages/hydra-heads.tsx
+++ b/frontend/src/pages/hydra-heads.tsx
@@ -545,12 +545,12 @@ export default function HydraHeadsPage() {
       <RedeemHydraInviteDialog
         open={isRedeemInviteOpen}
         onOpenChange={setIsRedeemInviteOpen}
-        onRedeemed={() => void refetch()}
+        onRedeemed={() => void resync('hydra')}
       />
       <ConnectHydraNodeDialog
         open={isConnectNodeOpen}
         onOpenChange={setIsConnectNodeOpen}
-        onConnected={() => void refetch()}
+        onConnected={() => void resync('hydra')}
       />
       {/* A second instance rather than one with a `host` that toggles: the form
           seeds its fields from the host it opens with, and reusing the add


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

Call host and invite refetch after Hydra connect and redeem instead of only refetching heads.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
