### PR TITLE
fix(frontend): show fund transfer fetch errors without hiding section

### DIFF
--- a/frontend/src/components/wallets/sections/FundTransfersSection.tsx
+++ b/frontend/src/components/wallets/sections/FundTransfersSection.tsx
@@ -33,12 +33,13 @@ export function FundTransfersSection({
 }) {
   const { apiClient } = useAppContext();
 
-  const { data, isFetching, refetch } = useQuery({
+  const { data, isFetching, isError, error, refetch } = useQuery({
     queryKey: ['fundTransfers', walletAddress],
     enabled: walletAddress !== '',
     // Keep polling while anything is still Pending so Pending → Confirmed shows
-    // up without a manual refresh; stop once every row is terminal.
+    // up without a manual refresh; stop once every row is terminal or the fetch fails.
     refetchInterval: (query) => {
+      if (query.state.status === 'error') return false;
       const rows = query.state.data ?? [];
       return rows.some((t) => !TERMINAL_STATUSES.includes(t.status)) ? 6000 : false;
     },
@@ -52,7 +53,7 @@ export function FundTransfersSection({
   });
 
   const transfers = data ?? [];
-  if (transfers.length === 0) return null;
+  if (transfers.length === 0 && !isError) return null;
 
   return (
     <div className="bg-muted rounded-lg p-4 space-y-3">
@@ -69,6 +70,20 @@ export function FundTransfersSection({
           <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
         </Button>
       </div>
+      {isError && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          <p>{error instanceof Error ? error.message : 'Failed to load fund transfers'}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
       <div className="space-y-2">
         {transfers.map((transfer) => (
           <div


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Render a visible error state when fund transfer history fails to load.
- Keep the section on screen instead of returning null on fetch error.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
