### PR TITLE
fix(frontend): format internal status and type labels

### DIFF
--- a/frontend/src/components/hydra/HydraHeadConnection.tsx
+++ b/frontend/src/components/hydra/HydraHeadConnection.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState } from 'react';
+import { formatHydraNodeState } from '@/lib/display-labels';
 import { CheckCircle2, Loader2, RefreshCw, XCircle } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { Badge } from '@/components/ui/badge';
@@ -85,7 +86,7 @@ export function HydraHeadConnectionPanel({ headId }: { headId: string }) {
               absent usually re-establishes on its own. */}
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Node</span>
-            <span>{state.nodeState}</span>
+            <span>{formatHydraNodeState(state.nodeState)}</span>
           </div>
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Live session</span>

--- a/frontend/src/components/hydra/HydraHeadErrors.tsx
+++ b/frontend/src/components/hydra/HydraHeadErrors.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState } from 'react';
+import { formatHydraErrorType } from '@/lib/display-labels';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { useResync } from '@/lib/hooks/useResync';
@@ -116,7 +117,7 @@ export function HydraHeadErrors({
             <li key={error.id} className="space-y-1 px-3 py-2.5">
               <div className="flex flex-wrap items-center gap-2">
                 <Badge variant="outline" className="text-red-600 dark:text-red-400">
-                  {error.errorType}
+                  {formatHydraErrorType(error.errorType)}
                 </Badge>
                 {error.clientInput && <Badge variant="outline">{error.clientInput}</Badge>}
                 <span className="text-xs text-muted-foreground">

--- a/frontend/src/components/inbox-agents/InboxAgentDetailsDialog.tsx
+++ b/frontend/src/components/inbox-agents/InboxAgentDetailsDialog.tsx
@@ -11,6 +11,7 @@ import {
   RegistryInboxEntry,
 } from '@/lib/api/generated';
 import { getAgentStatusBadgeVariant } from '@/lib/agent-status';
+import { formatMetadataVersion, formatTxStatus } from '@/lib/display-labels';
 import { formatDateTime } from '@/lib/format-date';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { usePaymentSourceExtendedAll } from '@/lib/hooks/usePaymentSourceExtendedAll';
@@ -237,7 +238,9 @@ export function InboxAgentDetailsDialog({
                     <div className="grid gap-3 sm:grid-cols-2">
                       <div>
                         <div className="font-medium mb-1">Metadata version</div>
-                        <div className="text-muted-foreground">{agent.metadataVersion}</div>
+                        <div className="text-muted-foreground">
+                          {formatMetadataVersion(agent.metadataVersion)}
+                        </div>
                       </div>
                       <div>
                         <div className="font-medium mb-1">Holding wallet funding</div>
@@ -345,7 +348,7 @@ export function InboxAgentDetailsDialog({
                         <div>
                           <div className="font-medium mb-1">Status</div>
                           <div className="text-muted-foreground">
-                            {agent.CurrentTransaction.status}
+                            {formatTxStatus(agent.CurrentTransaction.status)}
                           </div>
                         </div>
                         <div>

--- a/frontend/src/components/transactions/TransactionErrorSection.tsx
+++ b/frontend/src/components/transactions/TransactionErrorSection.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { formatTransactionErrorType } from '@/lib/display-labels';
 import type { Transaction } from './transaction-format.helpers';
 
 interface TransactionErrorSectionProps {
@@ -33,7 +34,8 @@ export function TransactionErrorSection({
       <div className="space-y-2 rounded-md bg-destructive/20 p-4">
         <div className="space-y-1">
           <p className="text-sm">
-            <span className="font-medium">Error Type:</span> {transaction.NextAction.errorType}
+            <span className="font-medium">Error Type:</span>{' '}
+            {formatTransactionErrorType(transaction.NextAction.errorType)}
           </p>
           {transaction.NextAction.errorNote && (
             <p className="text-sm">

--- a/frontend/src/components/transactions/TransactionHistorySection.tsx
+++ b/frontend/src/components/transactions/TransactionHistorySection.tsx
@@ -4,6 +4,7 @@ import { cn, getExplorerUrl } from '@/lib/utils';
 import { formatDateTime } from '@/lib/format-date';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { formatTransactionErrorType } from '@/lib/display-labels';
 import {
   formatOnChainState,
   formatRequestedAction,
@@ -137,7 +138,8 @@ export function TransactionHistorySection({
                   )}
                   {action.errorType && (
                     <p className="text-xs text-destructive break-all">
-                      <span className="font-medium">Error:</span> {action.errorType}
+                      <span className="font-medium">Error:</span>{' '}
+                      {formatTransactionErrorType(action.errorType)}
                       {action.errorNote ? `: ${action.errorNote}` : ''}
                     </p>
                   )}

--- a/frontend/src/components/x402/AlertsTab.tsx
+++ b/frontend/src/components/x402/AlertsTab.tsx
@@ -36,6 +36,7 @@ import { RefreshButton } from '@/components/RefreshButton';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useX402LowBalanceRules, useX402Networks, useX402Wallets } from '@/lib/hooks/useX402';
+import { formatX402WalletType } from '@/lib/display-labels';
 import { cn, formatX402Amount, groupDigits, shortenAddress } from '@/lib/utils';
 import { walletsForNetworks } from '@/lib/x402-rail';
 import { useApiMutation } from '@/lib/hooks/useApiMutation';
@@ -449,7 +450,7 @@ function AlertDialog({
                           <span className="ml-2 text-muted-foreground">
                             {networks.find((network) => network.id === wallet.networkId)
                               ?.displayName ?? wallet.caip2Network}{' '}
-                            · {wallet.type}
+                            · {formatX402WalletType(wallet.type)}
                           </span>
                         </SelectItem>
                       ))}

--- a/frontend/src/components/x402/PaymentsTab.tsx
+++ b/frontend/src/components/x402/PaymentsTab.tsx
@@ -30,6 +30,7 @@ import {
   useX402PaymentAttempts,
   type X402PaymentFilters,
 } from '@/lib/hooks/useX402';
+import { formatX402PaymentStatus } from '@/lib/display-labels';
 import { cn, groupDigits, shortenAddress } from '@/lib/utils';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { useApiMutation } from '@/lib/hooks/useApiMutation';
@@ -239,7 +240,9 @@ export function PaymentsTab() {
                 >
                   <td className="p-4 text-sm">{DIRECTION_LABEL[attempt.direction]}</td>
                   <td className="p-4">
-                    <Badge variant={STATUS_VARIANT[attempt.status]}>{attempt.status}</Badge>
+                    <Badge variant={STATUS_VARIANT[attempt.status]}>
+                      {formatX402PaymentStatus(attempt.status)}
+                    </Badge>
                   </td>
                   <td className="p-4 text-sm">{chainLabel(attempt.caip2Network)}</td>
                   <td className="p-4 text-right font-mono text-sm">
@@ -336,7 +339,11 @@ function PaymentDetailsDialog({
               <DetailRow label="Direction" value={DIRECTION_LABEL[attempt.direction]} />
               <DetailRow
                 label="Status"
-                value={<Badge variant={STATUS_VARIANT[attempt.status]}>{attempt.status}</Badge>}
+                value={
+                  <Badge variant={STATUS_VARIANT[attempt.status]}>
+                    {formatX402PaymentStatus(attempt.status)}
+                  </Badge>
+                }
               />
               <DetailRow label="Chain" value={chainLabel} />
               <DetailRow label="Created" value={formatDateTime(attempt.createdAt)} />

--- a/frontend/src/components/x402/WalletDetailsDialog.tsx
+++ b/frontend/src/components/x402/WalletDetailsDialog.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from '@/lib/contexts/AppContext';
 import { formatDateTime } from '@/lib/format-date';
 import { useX402LowBalanceRules } from '@/lib/hooks/useX402';
 import { X402Wallet } from '@/lib/api/generated';
+import { formatX402WalletType } from '@/lib/display-labels';
 import { AlertsTab } from './AlertsTab';
 import { WalletBalances } from './WalletExtras';
 
@@ -34,7 +35,7 @@ export function WalletDetailsDialog({
       <DialogContent size="xl">
         <DialogHeader>
           <DialogTitle>Wallet details</DialogTitle>
-          <DialogDescription>{wallet.type} wallet</DialogDescription>
+          <DialogDescription>{formatX402WalletType(wallet.type)} wallet</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-6">
@@ -49,7 +50,7 @@ export function WalletDetailsDialog({
                 <CopyButton value={wallet.address} />
               </OverviewField>
               <OverviewField label="Chain">{chainLabel(wallet.caip2Network)}</OverviewField>
-              <OverviewField label="Direction">{wallet.type}</OverviewField>
+              <OverviewField label="Direction">{formatX402WalletType(wallet.type)}</OverviewField>
               <OverviewField label="Created">{formatDateTime(wallet.createdAt)}</OverviewField>
               {wallet.note && <OverviewField label="Note">{wallet.note}</OverviewField>}
             </div>

--- a/frontend/src/components/x402/WalletsTab.tsx
+++ b/frontend/src/components/x402/WalletsTab.tsx
@@ -66,15 +66,13 @@ import {
 } from '@/lib/api/generated';
 import { EditWalletNoteDialog } from '@/components/x402/WalletExtras';
 import { WalletDetailsDialog, WalletLowBalanceBadge } from '@/components/x402/WalletDetailsDialog';
+import { formatX402WalletType } from '@/lib/display-labels';
 
 const PRIVATE_KEY_REGEX = /^0x[a-fA-F0-9]{64}$/;
 
 type WalletType = X402Wallet['type'];
 
-const WALLET_TYPE_LABEL: Record<WalletType, string> = {
-  Purchasing: 'Purchasing · outbound',
-  Selling: 'Selling · facilitator',
-};
+const walletTypeLabel = (type: WalletType) => formatX402WalletType(type);
 
 const WALLET_TYPE_OPTIONS: Array<{
   value: WalletType;
@@ -210,7 +208,7 @@ export function WalletsTab() {
                       <CopyButton value={wallet.address} />
                     </div>
                   </td>
-                  <td className="p-4 text-sm">{WALLET_TYPE_LABEL[wallet.type]}</td>
+                  <td className="p-4 text-sm">{walletTypeLabel(wallet.type)}</td>
                   <td className="p-4 text-sm">{chainLabel(wallet.caip2Network)}</td>
                   <td className="p-4 text-sm text-muted-foreground">
                     {wallet.note || <span className="italic opacity-60">—</span>}
@@ -636,7 +634,7 @@ function BackupKeyStep({
             <CheckCircle2 className="h-3 w-3 text-green-600 dark:text-green-500" />
             Wallet created
           </Badge>
-          <span className="text-xs text-muted-foreground">{WALLET_TYPE_LABEL[type]}</span>
+          <span className="text-xs text-muted-foreground">{walletTypeLabel(type)}</span>
         </div>
 
         <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2">

--- a/frontend/src/lib/display-labels.ts
+++ b/frontend/src/lib/display-labels.ts
@@ -1,0 +1,69 @@
+import type { X402PaymentAttempt, X402Wallet } from '@/lib/api/generated';
+
+/** Split CamelCase enums into spaced words, with a safe fallback. */
+export function formatEnumLabel(value: string | null | undefined, fallback = '—'): string {
+  if (!value) return fallback;
+  return value.replace(/([A-Z])/g, ' $1').trim();
+}
+
+const X402_PAYMENT_STATUS_LABELS: Record<X402PaymentAttempt['status'], string> = {
+  PaymentRequired: 'Payment required',
+  Verified: 'Verified',
+  Settled: 'Settled',
+  Failed: 'Failed',
+  Replayed: 'Replayed',
+};
+
+export function formatX402PaymentStatus(status: X402PaymentAttempt['status']): string {
+  return X402_PAYMENT_STATUS_LABELS[status] ?? formatEnumLabel(status);
+}
+
+const X402_WALLET_TYPE_LABELS: Record<X402Wallet['type'], string> = {
+  Purchasing: 'Purchasing (outbound)',
+  Selling: 'Selling (facilitator)',
+};
+
+export function formatX402WalletType(type: X402Wallet['type']): string {
+  return X402_WALLET_TYPE_LABELS[type] ?? formatEnumLabel(type);
+}
+
+const HYDRA_NODE_STATE_LABELS: Record<string, string> = {
+  Running: 'Running',
+  Idle: 'Idle',
+  Starting: 'Starting',
+  Stopping: 'Stopping',
+  Stopped: 'Stopped',
+};
+
+export function formatHydraNodeState(state: string): string {
+  return HYDRA_NODE_STATE_LABELS[state] ?? formatEnumLabel(state);
+}
+
+const TRANSACTION_ERROR_TYPE_LABELS: Record<string, string> = {
+  NetworkError: 'Network error',
+  InsufficientFunds: 'Insufficient funds',
+  Unknown: 'Unknown error',
+};
+
+export function formatTransactionErrorType(errorType: string | null | undefined): string {
+  if (!errorType) return '—';
+  return TRANSACTION_ERROR_TYPE_LABELS[errorType] ?? formatEnumLabel(errorType);
+}
+
+const HYDRA_ERROR_TYPE_LABELS: Record<string, string> = {
+  CommandFailed: 'Command failed',
+  PostTxOnChainFailed: 'On-chain submission failed',
+  TxInvalid: 'Invalid transaction',
+  InvalidInput: 'Invalid input',
+};
+
+export function formatHydraErrorType(errorType: string): string {
+  return HYDRA_ERROR_TYPE_LABELS[errorType] ?? formatEnumLabel(errorType);
+}
+
+export function formatMetadataVersion(version: number | null | undefined): string {
+  if (version == null) return '—';
+  return `Version ${version}`;
+}
+
+export { formatTxStatus } from '@/components/transactions/transaction-format.helpers';

--- a/frontend/src/pages/x402/dashboard.tsx
+++ b/frontend/src/pages/x402/dashboard.tsx
@@ -28,6 +28,7 @@ import {
   useX402DashboardRecentPayments,
   useX402Wallets,
 } from '@/lib/hooks/useX402';
+import { formatX402PaymentStatus } from '@/lib/display-labels';
 import { formatX402Amount, groupDigits, shortenAddress } from '@/lib/utils';
 
 const STATUS_VARIANT: Record<X402PaymentAttempt['status'], BadgeProps['variant']> = {
@@ -354,7 +355,7 @@ export default function X402DashboardPage() {
                                 {DIRECTION_LABEL[attempt.direction]}
                               </span>
                               <Badge variant={STATUS_VARIANT[attempt.status]}>
-                                {attempt.status}
+                                {formatX402PaymentStatus(attempt.status)}
                               </Badge>
                             </div>
                             <p className="mt-1 truncate text-xs text-muted-foreground">


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Add shared `display-labels.ts` formatters for internal status and type enums.
- Apply readable labels on x402 dashboard, Hydra/inbox dialogs, and transaction views with safe fallbacks for unknown values.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
