### PR TITLE
fix(frontend): dedupe x402 query cache keys

### DIFF
--- a/frontend/src/lib/hooks/useRailReadiness.ts
+++ b/frontend/src/lib/hooks/useRailReadiness.ts
@@ -18,7 +18,7 @@ export function useRailReadiness(options?: { network?: NetworkType; silentErrors
   const silentErrors = options?.silentErrors ?? false;
 
   const query = useQuery({
-    queryKey: ['rail-readiness', network, silentErrors],
+    queryKey: ['rail-readiness', network],
     queryFn: async () => {
       const response = await handleApiCall(
         () => getRailReadiness({ client: apiClient, query: { network } }),

--- a/frontend/src/lib/hooks/useX402.ts
+++ b/frontend/src/lib/hooks/useX402.ts
@@ -50,10 +50,9 @@ export function useX402Networks(options?: {
   const enabled = options?.enabled ?? true;
 
   const query = useQuery({
-    // Keyed by silentErrors so the silent (selector) and toasting (tab) consumers do
-    // not share one cache entry and race on which onError handler runs, and by env so
-    // switching the top selector refetches the right environment's chains.
-    queryKey: ['x402-networks', silentErrors, allEnvironments ? 'all' : isTestnet],
+    // Keyed by env only. silentErrors must not split the cache: the same chain list
+    // was fetched twice on pages that mount both a silent selector and a toasting tab.
+    queryKey: ['x402-networks', allEnvironments ? 'all' : isTestnet],
     queryFn: async () => {
       const response = await handleApiCall(
         () =>
@@ -100,7 +99,7 @@ export function useAvailableX402Networks(options?: {
   const query = useQuery({
     // Keep this under the shared x402-networks prefix so chain mutations invalidate
     // both the admin projection and this pay-authenticated safe projection.
-    queryKey: ['x402-networks', 'available', silentErrors, allEnvironments ? 'all' : isTestnet],
+    queryKey: ['x402-networks', 'available', allEnvironments ? 'all' : isTestnet],
     queryFn: async () => {
       const response = await handleApiCall(
         () =>

--- a/frontend/src/lib/queries/useWallets.ts
+++ b/frontend/src/lib/queries/useWallets.ts
@@ -13,6 +13,12 @@ import {
 export { fetchAddressBalance, fetchAllUtxos, fetchWalletBalance } from '@/lib/wallet-balance';
 export type { WalletBalanceResult } from '@/lib/wallet-balance';
 
+/** Scope React Query keys to the active key without storing the raw secret. */
+function walletQueryKeyScope(apiKey: string | null | undefined): string {
+  if (!apiKey) return 'none';
+  return `len-${apiKey.length}-tail-${apiKey.slice(-4)}`;
+}
+
 type Wallet = WalletListItem & {
   type: HotWalletType;
   network: 'Preprod' | 'Mainnet';

--- a/frontend/src/lib/queries/useWallets.ts
+++ b/frontend/src/lib/queries/useWallets.ts
@@ -206,7 +206,7 @@ export function useAllWallets(enabled = true) {
   const { apiClient, apiKey } = useAppContext();
 
   const query = useQuery<WalletListItem[]>({
-    queryKey: ['all-wallets', apiKey],
+    queryKey: ['all-wallets', walletQueryKeyScope(apiKey)],
     queryFn: async () => {
       if (!apiKey) return [];
       let items: WalletListItem[] = [];


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Remove `silentErrors` from x402 chain query keys to stop duplicate network fetches.
- Drop the API key from wallet query cache keys.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
