### PR TITLE
fix(frontend): dedupe x402 setup UI mounts

### DIFF
--- a/frontend/src/components/x402/X402AdminPageExtras.tsx
+++ b/frontend/src/components/x402/X402AdminPageExtras.tsx
@@ -1,0 +1,25 @@
+import { useAppContext } from '@/lib/contexts/AppContext';
+import { hasEvmChainLimit } from '@/lib/permissions';
+import { useX402NetworksForSession } from '@/lib/hooks/useX402';
+import { X402ChainLimitHint } from '@/components/x402/X402ChainLimitHint';
+import { X402SetupGuide } from '@/components/x402/X402SetupGuide';
+
+/** Shared setup guide (admins) and chain-limit hint (non-admin keys) for x402 pages. */
+export function X402AdminPageExtras() {
+  const { capabilities } = useAppContext();
+  const { networks: sessionChains, isLoading: chainsLoading } = useX402NetworksForSession({
+    silentErrors: true,
+  });
+  const showChainLimitHint =
+    !capabilities.canAdmin &&
+    !chainsLoading &&
+    sessionChains.length === 0 &&
+    !hasEvmChainLimit(capabilities.chainIdLimit);
+
+  return (
+    <>
+      {capabilities.canAdmin && <X402SetupGuide />}
+      {showChainLimitHint && <X402ChainLimitHint />}
+    </>
+  );
+}

--- a/frontend/src/components/x402/X402ChainLimitHint.tsx
+++ b/frontend/src/components/x402/X402ChainLimitHint.tsx
@@ -1,0 +1,9 @@
+/** Shown when a non-admin key has no EVM chains in its chain limit. */
+export function X402ChainLimitHint() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-100">
+      This API key has no EVM chains in its chain limit, so no x402 chains or payment activity can
+      be shown. An admin can add the chain ids to the key.
+    </div>
+  );
+}

--- a/frontend/src/pages/x402/payments.tsx
+++ b/frontend/src/pages/x402/payments.tsx
@@ -18,7 +18,7 @@ export default function X402PaymentsPage() {
             <p className="max-w-2xl text-sm text-muted-foreground">
               Transaction activity for the x402 (EVM) rail.{' '}
               <a
-                href={MASUMI_DEV_HUB_URL}
+                href="https://www.masumi.network/dev/masumi"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"

--- a/frontend/src/pages/x402/payments.tsx
+++ b/frontend/src/pages/x402/payments.tsx
@@ -3,22 +3,9 @@ import { ExternalLink } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { AnimatedPage } from '@/components/ui/animated-page';
 import { PaymentsTab } from '@/components/x402/PaymentsTab';
-import { X402SetupGuide } from '@/components/x402/X402SetupGuide';
-import { useAppContext } from '@/lib/contexts/AppContext';
-import { hasEvmChainLimit } from '@/lib/permissions';
-import { useX402NetworksForSession } from '@/lib/hooks/useX402';
+import { X402AdminPageExtras } from '@/components/x402/X402AdminPageExtras';
 
 export default function X402PaymentsPage() {
-  const { capabilities } = useAppContext();
-  const { networks: sessionChains, isLoading: chainsLoading } = useX402NetworksForSession({
-    silentErrors: true,
-  });
-  const showChainLimitHint =
-    !capabilities.canAdmin &&
-    !chainsLoading &&
-    sessionChains.length === 0 &&
-    !hasEvmChainLimit(capabilities.chainIdLimit);
-
   return (
     <MainLayout>
       <Head>
@@ -31,7 +18,7 @@ export default function X402PaymentsPage() {
             <p className="max-w-2xl text-sm text-muted-foreground">
               Transaction activity for the x402 (EVM) rail.{' '}
               <a
-                href="https://www.masumi.network/dev/masumi"
+                href={MASUMI_DEV_HUB_URL}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"
@@ -42,14 +29,7 @@ export default function X402PaymentsPage() {
             </p>
           </div>
 
-          {capabilities.canAdmin && <X402SetupGuide />}
-
-          {showChainLimitHint && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-100">
-              This API key has no EVM chains in its chain limit, so no x402 chains or payment
-              activity can be shown. An admin can add the chain ids to the key.
-            </div>
-          )}
+          <X402AdminPageExtras />
 
           <PaymentsTab />
         </div>

--- a/frontend/src/pages/x402/wallets.tsx
+++ b/frontend/src/pages/x402/wallets.tsx
@@ -3,24 +3,11 @@ import { ExternalLink } from 'lucide-react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { AnimatedPage } from '@/components/ui/animated-page';
 import { WalletsTab } from '@/components/x402/WalletsTab';
-import { X402SetupGuide } from '@/components/x402/X402SetupGuide';
+import { X402AdminPageExtras } from '@/components/x402/X402AdminPageExtras';
 import { useAppContext } from '@/lib/contexts/AppContext';
-import { hasEvmChainLimit } from '@/lib/permissions';
-import { useX402NetworksForSession } from '@/lib/hooks/useX402';
 
 export default function X402WalletsPage() {
   const { capabilities } = useAppContext();
-  // A non-admin key only sees chains listed in its own CAIP-2 limit, so an empty
-  // rail here usually means the key was provisioned without any EVM chain rather
-  // than the rail being unconfigured. Say which, instead of rendering nothing.
-  const { networks: sessionChains, isLoading: chainsLoading } = useX402NetworksForSession({
-    silentErrors: true,
-  });
-  const showChainLimitHint =
-    !capabilities.canAdmin &&
-    !chainsLoading &&
-    sessionChains.length === 0 &&
-    !hasEvmChainLimit(capabilities.chainIdLimit);
 
   return (
     <MainLayout>
@@ -36,7 +23,7 @@ export default function X402WalletsPage() {
                 ? 'Managed EVM wallets for the x402 payment rail. Keys are encrypted at rest.'
                 : 'EVM wallets for chains your key can access.'}{' '}
               <a
-                href="https://www.masumi.network/dev/masumi"
+                href={MASUMI_DEV_HUB_URL}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"
@@ -47,14 +34,7 @@ export default function X402WalletsPage() {
             </p>
           </div>
 
-          {capabilities.canAdmin && <X402SetupGuide />}
-
-          {showChainLimitHint && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-100">
-              This API key has no EVM chains in its chain limit, so no x402 chains or payment
-              activity can be shown. An admin can add the chain ids to the key.
-            </div>
-          )}
+          <X402AdminPageExtras />
 
           <WalletsTab />
         </div>

--- a/frontend/src/pages/x402/wallets.tsx
+++ b/frontend/src/pages/x402/wallets.tsx
@@ -23,7 +23,7 @@ export default function X402WalletsPage() {
                 ? 'Managed EVM wallets for the x402 payment rail. Keys are encrypted at rest.'
                 : 'EVM wallets for chains your key can access.'}{' '}
               <a
-                href={MASUMI_DEV_HUB_URL}
+                href="https://www.masumi.network/dev/masumi"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-0.5 font-medium text-foreground underline-offset-2 hover:underline"


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Extract shared x402 setup banner/guide mounting into `X402AdminPageExtras`.
- Use it on x402 payments and wallets so setup UI is not double-mounted.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
