### PR TITLE
fix(frontend): dedupe client-side search filters

### DIFF
--- a/frontend/src/lib/client-search/agent-search.ts
+++ b/frontend/src/lib/client-search/agent-search.ts
@@ -1,0 +1,39 @@
+import { RegistryEntry } from '@/lib/api/generated';
+import { parseAmountSearchRange, parseAmountToBigInt } from '@/lib/parseAmountSearchRange';
+import { getPrimaryCardanoPricing } from '@/lib/registry-pricing';
+
+/**
+ * Client-side agent search while server results are pending.
+ * Mirrors the Prisma OR filter in src/routes/api/registry/index.ts.
+ */
+export function filterAgentsClientSide<T extends RegistryEntry>(
+  agents: T[],
+  searchQuery: string,
+): T[] {
+  const query = searchQuery.toLowerCase().trim();
+  if (!query) return agents;
+
+  const amountRange = parseAmountSearchRange(query);
+
+  return agents.filter((agent) => {
+    const pricing = getPrimaryCardanoPricing(agent);
+    if (agent.name?.toLowerCase().includes(query)) return true;
+    if (agent.description?.toLowerCase().includes(query)) return true;
+    if (agent.Tags?.some((tag) => tag.toLowerCase() === query)) return true;
+    if (agent.SmartContractWallet?.walletAddress?.toLowerCase().includes(query)) return true;
+    if (agent.RecipientWallet?.walletAddress?.toLowerCase().includes(query)) return true;
+    if (agent.state?.toLowerCase().includes(query)) return true;
+    if (pricing?.pricingType === 'Free' && 'free'.startsWith(query)) return true;
+    if (pricing?.pricingType === 'Dynamic' && 'dynamic'.startsWith(query)) return true;
+    if (
+      amountRange &&
+      pricing?.pricingType === 'Fixed' &&
+      pricing.Pricing.some((p) => {
+        const amt = parseAmountToBigInt(p.amount);
+        return amt != null && amt >= amountRange.min && amt <= amountRange.max;
+      })
+    )
+      return true;
+    return false;
+  });
+}

--- a/frontend/src/lib/client-search/transaction-search.ts
+++ b/frontend/src/lib/client-search/transaction-search.ts
@@ -1,0 +1,81 @@
+import { ON_CHAIN_STATES } from '@/lib/hooks/useTransactions';
+import { parseAmountSearchRange, parseAmountToBigInt } from '@/lib/parseAmountSearchRange';
+
+const formatStatus = (status: string | null) => {
+  if (!status) return '—';
+  return status.replace(/([A-Z])/g, ' $1').trim();
+};
+
+type TransactionSearchRow = {
+  id?: string | null;
+  blockchainIdentifier?: string | null;
+  onChainState?: string | null;
+  agentIdentifier?: string | null;
+  agentName?: string | null;
+  type?: string | null;
+  inputHash?: string | null;
+  resultHash?: string | null;
+  CurrentTransaction?: {
+    txHash?: string | null;
+    layer?: string | null;
+    hydraHeadId?: string | null;
+  } | null;
+  TransactionHistory?: Array<{ txHash?: string | null }> | null;
+  SmartContractWallet?: { walletAddress?: string | null } | null;
+  RequestedFunds?: Array<{ amount?: string | null; unit?: string | null }> | null;
+  PaidFunds?: Array<{ amount?: string | null; unit?: string | null }> | null;
+};
+
+/**
+ * Client-side transaction search while server results are pending.
+ * Mirrors buildTransactionSearchFilter in src/utils/shared/queries.ts.
+ */
+export function filterTransactionsClientSide<T extends TransactionSearchRow>(
+  transactions: T[],
+  searchQuery: string,
+): T[] {
+  const query = searchQuery.toLowerCase().trim();
+  if (!query) return transactions;
+
+  const amountRange = parseAmountSearchRange(query);
+  const isHashQuery = query.length >= 5 && /^[0-9a-f]+$/.test(query);
+  const matchingLayer =
+    query === 'hydra' ? 'L2' : query === 'l1' || query === 'l2' ? query.toUpperCase() : null;
+  const matchingStates = ON_CHAIN_STATES.filter(
+    (s) => s.toLowerCase().includes(query) || formatStatus(s).toLowerCase().includes(query),
+  );
+
+  return transactions.filter((tx) => {
+    if (tx.id?.toLowerCase().includes(query)) return true;
+    if (tx.blockchainIdentifier?.toLowerCase() === query) return true;
+    if (isHashQuery) {
+      if (tx.CurrentTransaction?.txHash?.toLowerCase().includes(query)) return true;
+      if (tx.TransactionHistory?.some((h) => h.txHash?.toLowerCase().includes(query))) return true;
+      if (tx.inputHash?.toLowerCase().includes(query)) return true;
+      if (tx.resultHash?.toLowerCase().includes(query)) return true;
+      if (tx.CurrentTransaction?.hydraHeadId?.toLowerCase().includes(query)) return true;
+    }
+    if (matchingLayer && tx.CurrentTransaction?.layer === matchingLayer) return true;
+    if (tx.SmartContractWallet?.walletAddress?.toLowerCase().includes(query)) return true;
+    if (
+      matchingStates.length > 0 &&
+      tx.onChainState &&
+      matchingStates.includes(tx.onChainState as (typeof ON_CHAIN_STATES)[number])
+    )
+      return true;
+    if (tx.agentIdentifier?.toLowerCase().includes(query)) return true;
+    if (tx.agentName?.toLowerCase().includes(query)) return true;
+    if (amountRange) {
+      const funds =
+        tx.type === 'payment' ? tx.RequestedFunds : tx.type === 'purchase' ? tx.PaidFunds : [];
+      if (
+        funds?.some((f) => {
+          const amt = parseAmountToBigInt(f.amount);
+          return amt != null && amt >= amountRange.min && amt <= amountRange.max;
+        })
+      )
+        return true;
+    }
+    return false;
+  });
+}

--- a/frontend/src/pages/ai-agents.tsx
+++ b/frontend/src/pages/ai-agents.tsx
@@ -37,7 +37,7 @@ import { AnimatedPage } from '@/components/ui/animated-page';
 import { EmptyState } from '@/components/ui/empty-state';
 import { SearchInput } from '@/components/ui/search-input';
 import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
-import { parseAmountSearchRange, parseAmountToBigInt } from '@/lib/parseAmountSearchRange';
+import { filterAgentsClientSide } from '@/lib/client-search/agent-search';
 import { useRegistryEntryByAgentIdentifier } from '@/lib/queries/useRegistryEntryByAgentIdentifier';
 import { useAgentDetailsDialog } from '@/lib/contexts/AgentDetailsDialogContext';
 import { lookupWalletByVkey } from '@/lib/wallet-lookup';
@@ -153,32 +153,7 @@ export default function AIAgentsPage() {
     if (!query || (query === debouncedSearchQuery.toLowerCase().trim() && !isPlaceholderData))
       return byType(agents);
 
-    const amountRange = parseAmountSearchRange(query);
-
-    return byType(
-      agents.filter((agent) => {
-        const pricing = getPrimaryCardanoPricing(agent);
-        if (agent.name?.toLowerCase().includes(query)) return true;
-        if (agent.description?.toLowerCase().includes(query)) return true;
-        // Backend uses hasSome (exact match against tag array), not partial
-        if (agent.Tags?.some((tag) => tag.toLowerCase() === query)) return true;
-        if (agent.SmartContractWallet?.walletAddress?.toLowerCase().includes(query)) return true;
-        if (agent.RecipientWallet?.walletAddress?.toLowerCase().includes(query)) return true;
-        if (agent.state?.toLowerCase().includes(query)) return true;
-        if (pricing?.pricingType === 'Free' && 'free'.startsWith(query)) return true;
-        if (pricing?.pricingType === 'Dynamic' && 'dynamic'.startsWith(query)) return true;
-        if (
-          amountRange &&
-          pricing?.pricingType === 'Fixed' &&
-          pricing.Pricing.some((p) => {
-            const amt = parseAmountToBigInt(p.amount);
-            return amt != null && amt >= amountRange.min && amt <= amountRange.max;
-          })
-        )
-          return true;
-        return false;
-      }),
-    );
+    return byType(filterAgentsClientSide(agents, searchQuery));
   }, [agents, searchQuery, debouncedSearchQuery, isPlaceholderData, typeFilter]);
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -26,7 +26,7 @@ import { SearchInput } from '@/components/ui/search-input';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
-import { parseAmountSearchRange, parseAmountToBigInt } from '@/lib/parseAmountSearchRange';
+import { filterTransactionsClientSide } from '@/lib/client-search/transaction-search';
 import Link from 'next/link';
 import { PaymentSourceTypeBadge } from '@/components/payment-sources/PaymentSourceTypeBadge';
 import { TransactionAgentIdentifierCell } from '@/components/transactions/TransactionAgentIdentifierCell';
@@ -208,49 +208,7 @@ export default function Transactions() {
     if (!query || (query === debouncedSearchQuery.toLowerCase().trim() && !isPlaceholderData))
       return filteredTransactions;
 
-    const amountRange = parseAmountSearchRange(query);
-    // Mirror backend looksLikeHash (HASH_QUERY_MIN_LENGTH): the hash columns and
-    // the head ID are only searched for a hex query of 5+ characters.
-    const isHashQuery = query.length >= 5 && /^[0-9a-f]+$/.test(query);
-    // Mirror backend buildMatchingLayers: exact match plus the 'hydra' alias.
-    const matchingLayer =
-      query === 'hydra' ? 'L2' : query === 'l1' || query === 'l2' ? query.toUpperCase() : null;
-
-    // Mirror backend buildMatchingStates
-    const matchingStates = ON_CHAIN_STATES.filter(
-      (s) => s.toLowerCase().includes(query) || formatStatus(s).toLowerCase().includes(query),
-    );
-
-    return filteredTransactions.filter((tx) => {
-      if (tx.id?.toLowerCase().includes(query)) return true;
-      if (tx.blockchainIdentifier?.toLowerCase() === query) return true;
-      if (isHashQuery) {
-        if (tx.CurrentTransaction?.txHash?.toLowerCase().includes(query)) return true;
-        if (tx.TransactionHistory?.some((h) => h.txHash?.toLowerCase().includes(query)))
-          return true;
-        if (tx.inputHash?.toLowerCase().includes(query)) return true;
-        if (tx.resultHash?.toLowerCase().includes(query)) return true;
-        if (tx.CurrentTransaction?.hydraHeadId?.toLowerCase().includes(query)) return true;
-      }
-      if (matchingLayer && tx.CurrentTransaction?.layer === matchingLayer) return true;
-      if (tx.SmartContractWallet?.walletAddress?.toLowerCase().includes(query)) return true;
-      if (matchingStates.length > 0 && tx.onChainState && matchingStates.includes(tx.onChainState))
-        return true;
-      if (tx.agentIdentifier?.toLowerCase().includes(query)) return true;
-      if (tx.agentName?.toLowerCase().includes(query)) return true;
-      if (amountRange) {
-        const funds =
-          tx.type === 'payment' ? tx.RequestedFunds : tx.type === 'purchase' ? tx.PaidFunds : [];
-        if (
-          funds?.some((f) => {
-            const amt = parseAmountToBigInt(f.amount);
-            return amt != null && amt >= amountRange.min && amt <= amountRange.max;
-          })
-        )
-          return true;
-      }
-      return false;
-    });
+    return filterTransactionsClientSide(filteredTransactions, searchQuery);
   }, [filteredTransactions, searchQuery, debouncedSearchQuery, isPlaceholderData]);
 
   const refreshTransactions = useCallback(() => {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Extract shared client search helpers for transactions and AI agents.
- Replace duplicated filter logic in both pages with the shared modules.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
