### PR TITLE
fix(frontend): dedupe dialog reset on open logic

### DIFF
--- a/frontend/src/components/ai-agents/MigrateAgentsDialog.tsx
+++ b/frontend/src/components/ai-agents/MigrateAgentsDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDialogResetOnOpen } from '@/lib/hooks/useDialogResetOnOpen';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { invalidateAgentQueries } from '@/lib/queries/agent-cache';
 import { toast } from 'react-toastify';
@@ -382,13 +383,11 @@ export function MigrateAgentsDialog({ open, onClose, onSuccess }: MigrateAgentsD
   // re-render when toggled.
   const hasPendingV1ListInvalidationRef = useRef(false);
 
-  useEffect(() => {
-    if (open) {
-      setResults({});
-      setIsDone(false);
-      setIsMigrating(false);
-    }
-  }, [open]);
+  useDialogResetOnOpen(open, () => {
+    setResults({});
+    setIsDone(false);
+    setIsMigrating(false);
+  });
 
   const handleClose = useCallback(() => {
     if (hasPendingV1ListInvalidationRef.current) {

--- a/frontend/src/components/testing/FullCycleDialog.tsx
+++ b/frontend/src/components/testing/FullCycleDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { useDialogResetOnOpen } from '@/lib/hooks/useDialogResetOnOpen';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import {
   postPayment,
@@ -94,8 +95,9 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
     watch,
   );
 
-  useEffect(() => {
-    if (open) {
+  useDialogResetOnOpen(
+    open,
+    () => {
       resetInputData();
       setValue('paymentOptionId', '');
       setValue('identifierFromPurchaser', generateRandomHex(16));
@@ -106,8 +108,9 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
       setPurchaseError(null);
       setPaymentCurl('');
       setPurchaseCurl('');
-    }
-  }, [open, selectedPaymentSource?.id, setValue, resetInputData]);
+    },
+    [selectedPaymentSource?.id, setValue, resetInputData],
+  );
 
   const createPurchaseAutomatically = useCallback(
     async (payment: PostPaymentResponse['data'], originalFormData: PaymentFormValues) => {

--- a/frontend/src/components/testing/FullCycleDialog.tsx
+++ b/frontend/src/components/testing/FullCycleDialog.tsx
@@ -95,22 +95,18 @@ export function FullCycleDialog({ open, onClose }: FullCycleDialogProps) {
     watch,
   );
 
-  useDialogResetOnOpen(
-    open,
-    () => {
-      resetInputData();
-      setValue('paymentOptionId', '');
-      setValue('identifierFromPurchaser', generateRandomHex(16));
-      setStep(1);
-      setPaymentResponse(null);
-      setPurchaseResponse(null);
-      setPaymentError(null);
-      setPurchaseError(null);
-      setPaymentCurl('');
-      setPurchaseCurl('');
-    },
-    [selectedPaymentSource?.id, setValue, resetInputData],
-  );
+  useDialogResetOnOpen(open, () => {
+    resetInputData();
+    setValue('paymentOptionId', '');
+    setValue('identifierFromPurchaser', generateRandomHex(16));
+    setStep(1);
+    setPaymentResponse(null);
+    setPurchaseResponse(null);
+    setPaymentError(null);
+    setPurchaseError(null);
+    setPaymentCurl('');
+    setPurchaseCurl('');
+  }, [selectedPaymentSource?.id, setValue, resetInputData]);
 
   const createPurchaseAutomatically = useCallback(
     async (payment: PostPaymentResponse['data'], originalFormData: PaymentFormValues) => {

--- a/frontend/src/components/testing/MockPaymentDialog.tsx
+++ b/frontend/src/components/testing/MockPaymentDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { useDialogResetOnOpen } from '@/lib/hooks/useDialogResetOnOpen';
 import { useAppContext } from '@/lib/contexts/AppContext';
 import { postPayment, PostPaymentResponse } from '@/lib/api/generated';
 import { toast } from 'react-toastify';
@@ -75,16 +76,18 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
     watch,
   );
 
-  useEffect(() => {
-    if (open) {
+  useDialogResetOnOpen(
+    open,
+    () => {
       resetInputData();
       setValue('paymentOptionId', '');
       setValue('identifierFromPurchaser', generateRandomHex(16));
       setResponse(null);
       setError(null);
       setCurlCommand('');
-    }
-  }, [open, selectedPaymentSource?.id, setValue, resetInputData]);
+    },
+    [selectedPaymentSource?.id, setValue, resetInputData],
+  );
 
   const onSubmit = useCallback(
     async (data: PaymentFormValues) => {

--- a/frontend/src/components/testing/MockPaymentDialog.tsx
+++ b/frontend/src/components/testing/MockPaymentDialog.tsx
@@ -76,18 +76,14 @@ export function MockPaymentDialog({ open, onClose }: MockPaymentDialogProps) {
     watch,
   );
 
-  useDialogResetOnOpen(
-    open,
-    () => {
-      resetInputData();
-      setValue('paymentOptionId', '');
-      setValue('identifierFromPurchaser', generateRandomHex(16));
-      setResponse(null);
-      setError(null);
-      setCurlCommand('');
-    },
-    [selectedPaymentSource?.id, setValue, resetInputData],
-  );
+  useDialogResetOnOpen(open, () => {
+    resetInputData();
+    setValue('paymentOptionId', '');
+    setValue('identifierFromPurchaser', generateRandomHex(16));
+    setResponse(null);
+    setError(null);
+    setCurlCommand('');
+  }, [selectedPaymentSource?.id, setValue, resetInputData]);
 
   const onSubmit = useCallback(
     async (data: PaymentFormValues) => {

--- a/frontend/src/lib/hooks/useDialogResetOnOpen.ts
+++ b/frontend/src/lib/hooks/useDialogResetOnOpen.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+/** Run a reset callback whenever a dialog opens (and when optional deps change). */
+export function useDialogResetOnOpen(
+  open: boolean,
+  reset: () => void,
+  deps: readonly unknown[] = [],
+) {
+  useEffect(() => {
+    if (open) {
+      reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset runs on open + caller deps only
+  }, [open, ...deps]);
+}


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

# Pull Request Template

## **Purpose of this Pull Request**

<!-- (Select the applicable option by placing an "X" in the box.)  -->

[] Documentation update  
[X] Bug fix  
[] New feature  
[] Other: <!-- (please explain) -->
## **Overview of Changes**

- Add `useDialogResetOnOpen` for consistent form reset when dialogs open.
- Adopt it in migrate agents and mock/full-cycle test dialogs.

## **Issue Addressed**

<!-- (If applicable, link to the issue this PR resolves, e.g., `Closes #123` or `Fixes #123`.) -->

## **Checklist**

<!-- (Ensure all tasks are completed before submitting your PR.) Only submit a PR to the `dev` branch. -->

- I have used `lint` and `format` to follow the code formatting
- I have tested my changes locally and all of them pass
- I have updated documentation (if applicable).

## **Focus for Reviewers**

<!-- (Is there anything specific you want reviewers to focus on, such as edge cases, possible regressions, or performance concerns?) -->
